### PR TITLE
Fix unicode apostrophe in quiz notification

### DIFF
--- a/frontend/assets/js/main.js
+++ b/frontend/assets/js/main.js
@@ -229,7 +229,7 @@ function switchTab(tabName) {
 // Générer et afficher un quiz
 async function handleGenerateQuiz() {
     if (!courseManager || !courseManager.currentCourse) {
-        utils.showNotification('Veuillez d\u0027abord générer un cours', 'error');
+        utils.showNotification('Veuillez d\'abord générer un cours', 'error');
         return;
     }
 


### PR DESCRIPTION
## Summary
- replace `\u0027` escape with a proper apostrophe in quiz generation notice

## Testing
- `npm test` (fails: Missing script: "test")

------
https://chatgpt.com/codex/tasks/task_e_68977d98726c83258f8320e9d47a3f1b