### PR TITLE
feat: add course fields and migration

### DIFF
--- a/backend/prisma/migrations/20240711120000_add_course_fields/migration.sql
+++ b/backend/prisma/migrations/20240711120000_add_course_fields/migration.sql
@@ -1,0 +1,6 @@
+-- AlterTable
+ALTER TABLE "courses" ADD COLUMN "style" TEXT NOT NULL;
+ALTER TABLE "courses" ADD COLUMN "duration" INTEGER NOT NULL;
+ALTER TABLE "courses" ADD COLUMN "intent" TEXT NOT NULL;
+ALTER TABLE "courses" ALTER COLUMN "detailLevel" DROP NOT NULL;
+ALTER TABLE "courses" ALTER COLUMN "vulgarizationLevel" DROP NOT NULL;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -25,10 +25,12 @@ model Course {
   id                 String   @id @default(cuid())
   subject            String
   content            String   @db.Text
-  detailLevel        Int
-  vulgarizationLevel Int
+  /// @deprecated Use style, duration, and intent instead
+  detailLevel        Int?
+  /// @deprecated Use style, duration, and intent instead
+  vulgarizationLevel Int?
   style              String
-  duration           String
+  duration           Int
   intent             String
   createdAt          DateTime @default(now())
   


### PR DESCRIPTION
## Summary
- add style, duration, and intent fields to Course model
- mark legacy detail and vulgarization levels deprecated
- include migration altering courses table

## Testing
- `npx prisma generate`
- `npm test` *(fails: Missing script: "test")*
- `npx prisma migrate dev --name add-course-fields --create-only` *(fails: Can't reach database server at `localhost:5432`)*

------
https://chatgpt.com/codex/tasks/task_e_6898c78e22e48325bdd6b59caf95ba10