### PR TITLE
feat: refine course prompt generation

### DIFF
--- a/backend/src/controllers/courseController.js
+++ b/backend/src/controllers/courseController.js
@@ -77,11 +77,12 @@ class CourseController {
       // Sanitisation
       const sanitizedSubject = sanitizeInput(subject);
 
-      // Génération du cours avec anciens paramètres
+      // Génération du cours
       const courseContent = await anthropicService.generateCourse(
         sanitizedSubject,
-        parseInt(params.detailLevel),
-        parseInt(params.vulgarizationLevel)
+        params.style,
+        params.duration,
+        params.intent
       );
 
       // Sauvegarde en base


### PR DESCRIPTION
## Summary
- map duration, style and intent options to richer prompt instructions
- enforce duration word counts via getDurationConstraint
- generate courses using new style, duration and intent params

## Testing
- `npm test --prefix backend` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6898c99b08148325b01c60747911cac5