### PR TITLE
feat: add configuration selectors

### DIFF
--- a/frontend/assets/css/main.css
+++ b/frontend/assets/css/main.css
@@ -209,6 +209,47 @@ body::before {
     animation: spin 0.8s ease-in-out;
 }
 
+/* --- Nouveaux sélecteurs de configuration --- */
+.new-selector-container {
+    display: flex;
+    flex-direction: column;
+    gap: 25px;
+}
+
+.selector-group {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.selector-buttons {
+    display: flex;
+    gap: 10px;
+    flex-wrap: wrap;
+}
+
+.selector-group button {
+    padding: 10px 14px;
+    border: 2px solid #e2e8f0;
+    background: white;
+    border-radius: 10px;
+    cursor: pointer;
+    color: #2d3748;
+    font-weight: 500;
+    transition: all 0.3s ease;
+    font-family: inherit;
+}
+
+.selector-group button:hover {
+    background: #edf2f7;
+}
+
+.selector-group button.active {
+    background: linear-gradient(135deg, #4299e1, #3182ce);
+    color: white;
+    border-color: #3182ce;
+}
+
 /* --- Gauge Slider System - Style Moderne --- */
 .gauge-group {
     margin-bottom: 30px;

--- a/frontend/assets/js/main.js
+++ b/frontend/assets/js/main.js
@@ -5,6 +5,13 @@ let currentCourse = null;
 let currentQuiz = null;
 let quizState = { answered: 0, correct: 0 };
 
+// Configuration par défaut pour les nouveaux sélecteurs
+let currentConfig = {
+    style: 'academique',
+    duration: 'courte',
+    intent: 'informer'
+};
+
 // Initialisation de l'application
 document.addEventListener('DOMContentLoaded', function() {
     console.log('🚀 Initialisation Hermès App');
@@ -25,7 +32,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
 function initializeApp() {
     // Configuration initiale de l'interface
-    initializeGauges();
+    setupNewSelectors();
     setupFormControls();
 }
 
@@ -48,8 +55,6 @@ function setupEventListeners() {
 // Gestionnaires d'événements principaux
 async function handleGenerateCourse() {
     const subject = document.getElementById('subject').value.trim();
-    const detailLevel = document.getElementById('detailSlider').value;
-    const vulgarizationLevel = document.getElementById('vulgarizationSlider').value;
 
     if (!subject) {
         utils.showNotification('Veuillez entrer un sujet pour le décryptage', 'error');
@@ -62,7 +67,12 @@ async function handleGenerateCourse() {
 
     try {
         if (courseManager) {
-            const course = await courseManager.generateCourse(subject, detailLevel, vulgarizationLevel);
+            const course = await courseManager.generateCourse(
+                subject,
+                currentConfig.style,
+                currentConfig.duration,
+                currentConfig.intent
+            );
             if (course) {
                 currentCourse = course;
             }
@@ -103,6 +113,27 @@ async function askQuestion() {
 
     // TODO: Implémenter la logique de chat
     utils.showNotification('Chat - En cours d\'implémentation', 'error');
+}
+
+// Gestion des nouveaux sélecteurs de configuration
+function setupNewSelectors() {
+    document.querySelectorAll('.selector-group button').forEach(btn => {
+        btn.addEventListener('click', () => {
+            const type = btn.dataset.type;
+            const value = btn.dataset.value;
+            updateSelection(type, value, btn);
+        });
+    });
+}
+
+function updateSelection(type, value, selectedBtn) {
+    currentConfig[type] = value;
+    document.querySelectorAll(`.selector-group button[data-type="${type}"]`).forEach(btn => {
+        btn.classList.remove('active');
+    });
+    if (selectedBtn) {
+        selectedBtn.classList.add('active');
+    }
 }
 
 // Jauges et contrôles (copiés de votre ancien script)

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -97,66 +97,30 @@
                     </div>
                 </div>
                 <div class="form-group">
-                    <!-- Jauge Niveau de Détail -->
-                    <div class="gauge-group detail-gauge">
-                        <div class="gauge-label">
-                            <div class="gauge-title">📊 Niveau de Détail</div>
-                            <div class="gauge-value" id="detailValue">Détaillé</div>
+                    <div class="new-selector-container">
+                        <div class="selector-group">
+                            <div class="selector-title">🖋️ Style</div>
+                            <div class="selector-buttons">
+                                <button data-type="style" data-value="academique" class="active">Académique</button>
+                                <button data-type="style" data-value="conversationnel">Conversationnel</button>
+                                <button data-type="style" data-value="creatif">Créatif</button>
+                            </div>
                         </div>
-                        <div class="gauge-container">
-                            <div class="gauge-track" id="detailTrack" style="width: 66%"></div>
-                            <input 
-                                type="range" 
-                                min="1" 
-                                max="3" 
-                                value="1" 
-                                class="gauge-slider" 
-                                id="detailSlider"
-                            >
+                        <div class="selector-group">
+                            <div class="selector-title">⏱️ Durée</div>
+                            <div class="selector-buttons">
+                                <button data-type="duration" data-value="courte" class="active">Courte</button>
+                                <button data-type="duration" data-value="moyenne">Moyenne</button>
+                                <button data-type="duration" data-value="longue">Longue</button>
+                            </div>
                         </div>
-                        <div class="gauge-labels">
-                            <span>Synthèse</span>
-                            <span>Détaillé</span>
-                            <span>Exhaustif</span>
-                        </div>
-                        <div class="gauge-description" id="detailDescription">
-                            <strong>Synthèse :</strong> Cours concis avec les points essentiels.
-                        </div>
-                    </div>
-                
-                    <!-- Jauge Niveau de Vulgarisation -->
-                    <div class="gauge-group vulgarization-gauge">
-                        <div class="gauge-label">
-                            <div class="gauge-title">🎓 Niveau de Vulgarisation</div>
-                            <div class="gauge-value" id="vulgarizationValue">Accessible</div>
-                        </div>
-                        <div class="gauge-container">
-                            <div class="gauge-track" id="vulgarizationTrack" style="width: 75%"></div>
-                            <input 
-                                type="range" 
-                                min="1" 
-                                max="4" 
-                                value="1" 
-                                class="gauge-slider" 
-                                id="vulgarizationSlider"
-                            >
-                        </div>
-                        <div class="gauge-labels">
-                            <span>Grand Public</span>
-                            <span>Éclairé</span>
-                            <span>Connaisseur</span>
-                            <span>Expert</span>
-                        </div>
-                        <div class="gauge-description" id="vulgarizationDescription">
-                            <strong>Grand Public :</strong> Comme expliquer à votre grand-mère.
-                        </div>
-                    </div>
-                
-                    <!-- Indicateur de Combinaison -->
-                    <div class="combination-indicator" id="combinationIndicator">
-                        <div class="combination-icon">🎯</div>
-                        <div class="combination-text" id="combinationText">
-                            Cours détaillé et accessible - Idéal pour approfondir un sujet
+                        <div class="selector-group">
+                            <div class="selector-title">🎯 Intention</div>
+                            <div class="selector-buttons">
+                                <button data-type="intent" data-value="informer" class="active">Informer</button>
+                                <button data-type="intent" data-value="convaincre">Convaincre</button>
+                                <button data-type="intent" data-value="divertir">Divertir</button>
+                            </div>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- replace gauge controls with style, duration, and intent selectors
- style new selector groups and buttons with active state
- track selector choices in `currentConfig` and manage button state updates

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_6898cbb29d58832587645f00a8d20831