### PR TITLE
feat: log course generation params

### DIFF
--- a/backend/src/controllers/courseController.js
+++ b/backend/src/controllers/courseController.js
@@ -63,6 +63,8 @@ class CourseController {
   async generateCourse(req, res) {
     try {
       const { subject, detailLevel, vulgarizationLevel, style, duration, intent } = req.body;
+      const isLegacyPayload = (style == null && duration == null && intent == null) &&
+        (detailLevel != null || vulgarizationLevel != null);
 
       // Conversion et valeurs par défaut
       const params = mapLegacyParams({ detailLevel, vulgarizationLevel, style, duration, intent });
@@ -99,7 +101,14 @@ class CourseController {
         }
       });
 
-      logger.success('Cours généré et sauvegardé', { courseId: savedCourse.id, userId: req.user.id });
+      logger.success('Cours généré et sauvegardé', {
+        courseId: savedCourse.id,
+        userId: req.user.id,
+        style: params.style,
+        duration: params.duration,
+        intent: params.intent,
+        isLegacyPayload
+      });
 
       const { response, statusCode } = createResponse(true, { course: savedCourse }, null, HTTP_STATUS.CREATED);
       res.status(statusCode).json(response);

--- a/frontend/assets/js/main.js
+++ b/frontend/assets/js/main.js
@@ -55,6 +55,8 @@ function setupEventListeners() {
 // Gestionnaires d'événements principaux
 async function handleGenerateCourse() {
     const subject = document.getElementById('subject').value.trim();
+    const subjectLength = subject.length;
+    const isLegacyPayload = !currentConfig.style && !currentConfig.duration && !currentConfig.intent;
 
     if (!subject) {
         utils.showNotification('Veuillez entrer un sujet pour le décryptage', 'error');
@@ -76,6 +78,16 @@ async function handleGenerateCourse() {
             if (course) {
                 currentCourse = course;
                 displayCourseMetadata(course.style, course.duration, course.intent);
+
+                if (typeof gtag === 'function') {
+                    gtag('event', 'course_generation', {
+                        style: currentConfig.style,
+                        duration: currentConfig.duration,
+                        intent: currentConfig.intent,
+                        isLegacyPayload,
+                        subject_length: subjectLength
+                    });
+                }
             }
         }
     } finally {


### PR DESCRIPTION
## Summary
- log style, duration, intent and legacy payload flag in course creation
- track course generation via gtag with style, duration, intent, legacy flag and subject length

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6898cf5f09548325a5a7f95c23937d9a