### PR TITLE
test: cover param mapping and prompt creation

### DIFF
--- a/backend/tests/controllers/courseController.test.js
+++ b/backend/tests/controllers/courseController.test.js
@@ -1,0 +1,35 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const { mapLegacyParams } = require('../../src/utils/helpers');
+const { DURATIONS, INTENTS } = require('../../src/utils/constants');
+
+test('detailLevel numeric values map to durations', () => {
+  const mapping = {
+    1: DURATIONS.SHORT,
+    2: DURATIONS.MEDIUM,
+    3: DURATIONS.LONG
+  };
+  for (const [level, expected] of Object.entries(mapping)) {
+    const result = mapLegacyParams({ detailLevel: Number(level) });
+    assert.strictEqual(result.duration, expected);
+  }
+});
+
+test('vulgarizationLevel numeric values map to intents', () => {
+  const mapping = {
+    1: INTENTS.DISCOVER,
+    2: INTENTS.LEARN,
+    3: INTENTS.MASTER,
+    4: INTENTS.EXPERT
+  };
+  for (const [level, expected] of Object.entries(mapping)) {
+    const result = mapLegacyParams({ vulgarizationLevel: Number(level) });
+    assert.strictEqual(result.intent, expected);
+  }
+});
+
+test('applies default duration and intent when none provided', () => {
+  const result = mapLegacyParams({});
+  assert.strictEqual(result.duration, DURATIONS.MEDIUM);
+  assert.strictEqual(result.intent, INTENTS.LEARN);
+});

--- a/backend/tests/services/anthropicService.test.js
+++ b/backend/tests/services/anthropicService.test.js
@@ -1,0 +1,27 @@
+process.env.ANTHROPIC_API_KEY = 'test-key';
+
+const test = require('node:test');
+const assert = require('node:assert');
+const anthropicService = require('../../src/services/anthropicService');
+const { STYLES, DURATIONS, INTENTS } = require('../../src/utils/constants');
+
+test('createPrompt includes duration word counts', () => {
+  const mapping = {
+    [DURATIONS.SHORT]: 750,
+    [DURATIONS.MEDIUM]: 2250,
+    [DURATIONS.LONG]: 4200
+  };
+  for (const [duration, count] of Object.entries(mapping)) {
+    const prompt = anthropicService.createPrompt('Sujet', STYLES.NEUTRAL, duration, INTENTS.LEARN);
+    assert.match(prompt, new RegExp(`${count} mots`));
+  }
+});
+
+test('createPrompt includes distinct style instructions', () => {
+  const promptPedago = anthropicService.createPrompt('Sujet', STYLES.PEDAGOGICAL, DURATIONS.MEDIUM, INTENTS.LEARN);
+  const promptStory = anthropicService.createPrompt('Sujet', STYLES.STORYTELLING, DURATIONS.MEDIUM, INTENTS.LEARN);
+
+  assert.match(promptPedago, /ton pédagogique, clair et structuré/);
+  assert.match(promptStory, /récit engageant/);
+  assert.notStrictEqual(promptPedago, promptStory);
+});


### PR DESCRIPTION
## Summary
- add tests ensuring legacy numeric levels translate to duration/intent mappings and default values
- add anthropic service tests validating duration word counts and style-specific instructions in prompts

## Testing
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_6898d0c508c88325aec6d1b08f9a28fe