### PR TITLE
Document course creation parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,25 @@
+# Noza App
+
+## Course Creation Parameters
+
+The `POST /api/courses` endpoint now supports the following parameters:
+
+- `subject` (string, required): topic to generate a course about.
+- `style` (string, required): presentation style. Accepted values: `neutral`, `pedagogical`, `storytelling`.
+- `duration` (string, required): estimated course length. Accepted values: `short`, `medium`, `long`.
+- `intent` (string, required): learning intention. Accepted values: `discover`, `learn`, `master`, `expert`.
+- `detailLevel` (number, deprecated): legacy field mapped to `duration`.
+- `vulgarizationLevel` (number, deprecated): legacy field mapped to `intent`.
+
+### Sample payload
+
+```json
+{
+  "subject": "Introduction to Algebra",
+  "style": "pedagogical",
+  "duration": "medium",
+  "intent": "learn"
+}
+```
+
+Legacy clients may continue to send `detailLevel` and `vulgarizationLevel`. These fields remain supported for backward compatibility but will be removed in a future release.

--- a/backend/docs/api.md
+++ b/backend/docs/api.md
@@ -1,0 +1,34 @@
+# Course API
+
+## POST /api/courses
+
+Creates a new course for the authenticated user.
+
+### New fields
+- `style` (string, required): presentation style. Values: `neutral`, `pedagogical`, `storytelling`.
+- `duration` (string, required): course length. Values: `short`, `medium`, `long`.
+- `intent` (string, required): learning intent. Values: `discover`, `learn`, `master`, `expert`.
+
+### Deprecated fields
+- `detailLevel` (number): 1 `synthesis`, 2 `detailed`, 3 `exhaustive`. Replaced by `duration`.
+- `vulgarizationLevel` (number): 1 `general_public`, 2 `enlightened`, 3 `knowledgeable`, 4 `expert`. Replaced by `intent`.
+
+### Example request
+
+```
+POST /api/courses
+Content-Type: application/json
+
+{
+  "subject": "Introduction to Algebra",
+  "style": "pedagogical",
+  "duration": "medium",
+  "intent": "learn"
+}
+```
+
+### Migration guidance
+- Map `detailLevel` to `duration`: 1→`short`, 2→`medium`, 3→`long`.
+- Map `vulgarizationLevel` to `intent`: 1→`discover`, 2→`learn`, 3→`master`, 4→`expert`.
+
+Legacy fields remain accepted for backward compatibility but will be removed in a future release.


### PR DESCRIPTION
## Summary
- document new course creation parameters and legacy support in README
- add API docs for POST /api/courses including deprecated fields and migration guidance

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm test --prefix backend` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6898e788acb4832581fb5d5ea348232b