### PR TITLE
feat: align frontend options with backend

### DIFF
--- a/frontend/assets/js/course.js
+++ b/frontend/assets/js/course.js
@@ -2,21 +2,22 @@
 
 // Mapping for human-readable labels and icons
 const STYLE_LABELS = {
-  academique: 'Académique',
-  conversationnel: 'Conversationnel',
-  creatif: 'Créatif'
+  neutral: 'Neutre',
+  pedagogical: 'Pédagogique',
+  storytelling: 'Narratif'
 };
 
 const DURATION_LABELS = {
-  courte: 'Courte',
-  moyenne: 'Moyenne',
-  longue: 'Longue'
+  short: 'Courte',
+  medium: 'Moyenne',
+  long: 'Longue'
 };
 
 const INTENT_LABELS = {
-  informer: 'Informer',
-  convaincre: 'Convaincre',
-  divertir: 'Divertir'
+  discover: 'Découvrir',
+  learn: 'Apprendre',
+  master: 'Maîtriser',
+  expert: 'Expert'
 };
 
 class CourseManager {
@@ -28,18 +29,26 @@ class CourseManager {
   // Générer un cours
   async generateCourse(subject, style, duration, intent) {
     try {
+      const payload = {
+        subject: utils.sanitizeInput(subject)
+      };
+      if (style && STYLE_LABELS[style]) {
+        payload.style = utils.sanitizeInput(style);
+      }
+      if (duration && DURATION_LABELS[duration]) {
+        payload.duration = utils.sanitizeInput(duration);
+      }
+      if (intent && INTENT_LABELS[intent]) {
+        payload.intent = utils.sanitizeInput(intent);
+      }
+
       const response = await fetch(`${API_BASE_URL}/courses`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
           ...authManager.getAuthHeaders()
         },
-        body: JSON.stringify({
-          subject: utils.sanitizeInput(subject),
-          style: utils.sanitizeInput(style),
-          duration: utils.sanitizeInput(duration),
-          intent: utils.sanitizeInput(intent)
-        })
+        body: JSON.stringify(payload)
       });
 
       const data = await response.json();

--- a/frontend/assets/js/main.js
+++ b/frontend/assets/js/main.js
@@ -7,9 +7,9 @@ let quizState = { answered: 0, correct: 0 };
 
 // Configuration par défaut pour les nouveaux sélecteurs
 let currentConfig = {
-    style: 'academique',
-    duration: 'courte',
-    intent: 'informer'
+    style: 'neutral',
+    duration: 'short',
+    intent: 'discover'
 };
 
 // Initialisation de l'application
@@ -77,7 +77,10 @@ async function handleGenerateCourse() {
             );
             if (course) {
                 currentCourse = course;
-                displayCourseMetadata(course.style, course.duration, course.intent);
+                const styleLabel = STYLE_LABELS[course.style] || course.style;
+                const durationLabel = DURATION_LABELS[course.duration] || course.duration;
+                const intentLabel = INTENT_LABELS[course.intent] || course.intent;
+                displayCourseMetadata(styleLabel, durationLabel, intentLabel);
 
                 if (typeof gtag === 'function') {
                     gtag('event', 'course_generation', {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -101,25 +101,26 @@
                         <div class="selector-group">
                             <div class="selector-title">🖋️ Style</div>
                             <div class="selector-buttons">
-                                <button data-type="style" data-value="academique" class="active">Académique</button>
-                                <button data-type="style" data-value="conversationnel">Conversationnel</button>
-                                <button data-type="style" data-value="creatif">Créatif</button>
+                                <button data-type="style" data-value="neutral" class="active">Neutre</button>
+                                <button data-type="style" data-value="pedagogical">Pédagogique</button>
+                                <button data-type="style" data-value="storytelling">Narratif</button>
                             </div>
                         </div>
                         <div class="selector-group">
                             <div class="selector-title">⏱️ Durée</div>
                             <div class="selector-buttons">
-                                <button data-type="duration" data-value="courte" class="active">Courte</button>
-                                <button data-type="duration" data-value="moyenne">Moyenne</button>
-                                <button data-type="duration" data-value="longue">Longue</button>
+                                <button data-type="duration" data-value="short" class="active">Courte</button>
+                                <button data-type="duration" data-value="medium">Moyenne</button>
+                                <button data-type="duration" data-value="long">Longue</button>
                             </div>
                         </div>
                         <div class="selector-group">
                             <div class="selector-title">🎯 Intention</div>
                             <div class="selector-buttons">
-                                <button data-type="intent" data-value="informer" class="active">Informer</button>
-                                <button data-type="intent" data-value="convaincre">Convaincre</button>
-                                <button data-type="intent" data-value="divertir">Divertir</button>
+                                <button data-type="intent" data-value="discover" class="active">Découvrir</button>
+                                <button data-type="intent" data-value="learn">Apprendre</button>
+                                <button data-type="intent" data-value="master">Maîtriser</button>
+                                <button data-type="intent" data-value="expert">Expert</button>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
## Summary
- use backend keys for style, duration and intent selectors
- initialize configuration with backend values and translate labels for display
- validate course generation payload and drop empty fields

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6898fa9c33208325afbf28a356767cc2