### PR TITLE
feat: add automatic database migrations and improved logging

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -4,7 +4,7 @@
   "description": "Backend pour l'application Noza",
   "main": "server.js",
   "scripts": {
-    "start": "node scripts/check-migrations.js && node server.js",
+    "start": "node server.js",
     "dev": "nodemon server.js",
     "postinstall": "prisma generate",
     "migrate": "node scripts/check-migrations.js",

--- a/backend/scripts/check-migrations.js
+++ b/backend/scripts/check-migrations.js
@@ -1,4 +1,5 @@
 const { exec } = require('child_process');
+const { logger } = require('../src/utils/helpers');
 
 function run(command) {
   return new Promise((resolve) => {
@@ -13,7 +14,7 @@ async function hasPendingMigrations() {
   const output = `${stdout}\n${stderr}`.toLowerCase();
 
   if (error) {
-    console.error('Could not determine migration status.');
+    logger.error('Could not determine migration status.');
     return { pending: true, unknown: true };
   }
 
@@ -49,25 +50,25 @@ async function hasPendingMigrations() {
 async function deployMigrations() {
   const { error, stdout, stderr } = await run('npx prisma migrate deploy');
   if (error) {
-    console.error('Migration deploy failed.');
-    console.error(stderr || stdout);
+    logger.error('Migration deploy failed.');
+    logger.error(stderr || stdout);
     return false;
   }
-  console.log('Migrations deployed successfully.');
+  logger.success('Migrations deployed successfully.');
   return true;
 }
 
 async function ensureMigrations() {
   const status = await hasPendingMigrations();
   if (!status.pending && !status.unknown) {
-    console.log('Database schema is up to date.');
+    logger.success('Database schema is up to date.');
     return true;
   }
 
   if (status.unknown) {
-    console.warn('Unable to determine migration status, attempting to deploy migrations...');
+    logger.warn('Unable to determine migration status, attempting to deploy migrations...');
   } else {
-    console.log('Pending migrations detected, deploying...');
+    logger.info('Pending migrations detected, deploying...');
   }
 
   const success = await deployMigrations();
@@ -79,7 +80,7 @@ async function ensureMigrations() {
 
 if (require.main === module) {
   ensureMigrations().catch((err) => {
-    console.error('Error ensuring migrations:', err);
+    logger.error('Error ensuring migrations:', err);
     process.exit(1);
   });
 }

--- a/backend/server.js
+++ b/backend/server.js
@@ -3,6 +3,7 @@ require('dotenv').config();
 const { app, initializeApp } = require('./src/app');
 const { logger } = require('./src/utils/helpers');
 const { disconnectDatabase } = require('./src/config/database');
+const { ensureMigrations } = require('./scripts/check-migrations');
 
 const PORT = process.env.PORT || 3000;
 let server;
@@ -51,6 +52,10 @@ process.on('SIGINT', () => gracefulShutdown('SIGINT'));
 const startServer = async () => {
   try {
     validateEnv();
+
+    // Vérifier et appliquer les migrations
+    logger.info('Vérification des migrations de base de données...');
+    await ensureMigrations();
 
     // Initialiser l'application (DB, etc.)
     await initializeApp();

--- a/backend/src/config/database.js
+++ b/backend/src/config/database.js
@@ -1,5 +1,6 @@
 // backend/src/config/database.js
 const { PrismaClient } = require('@prisma/client');
+const { logger } = require('../utils/helpers');
 
 const prisma = new PrismaClient({
   log: process.env.NODE_ENV === 'development' ? ['query', 'info', 'warn', 'error'] : ['error'],
@@ -12,27 +13,27 @@ const prisma = new PrismaClient({
 
 // Test de connexion au démarrage
 async function connectDatabase() {
-  console.log('🔄 Attempting to connect to the database...');
+  logger.info('🔄 Attempting to connect to the database...');
   try {
     await prisma.$connect();
-    console.log('✅ Base de données connectée');
+    logger.success('✅ Base de données connectée');
 
     // List tables in the public schema
     const tables = await prisma.$queryRaw`SELECT tablename FROM pg_tables WHERE schemaname = 'public'`;
     if (!tables || tables.length === 0) {
-      console.warn('⚠️ Aucune table trouvée dans la base de données');
+      logger.warn('⚠️ Aucune table trouvée dans la base de données');
     } else {
-      console.log(`📋 Tables détectées: ${tables.map(t => t.tablename).join(', ')}`);
+      logger.info(`📋 Tables détectées: ${tables.map(t => t.tablename).join(', ')}`);
     }
   } catch (error) {
     if (error.code === 'P1001') {
-      console.error('❌ P1001: Le serveur de base de données est injoignable. Vérifiez la connexion.', error);
+      logger.error('❌ P1001: Le serveur de base de données est injoignable. Vérifiez la connexion.', error);
     } else if (error.code === 'P1010') {
-      console.error('❌ P1010: Accès refusé. Vérifiez les droits et les identifiants de connexion.', error);
+      logger.error('❌ P1010: Accès refusé. Vérifiez les droits et les identifiants de connexion.', error);
     } else if (error.code === 'P1003') {
-      console.error('❌ P1003: La base de données spécifiée est introuvable.', error);
+      logger.error('❌ P1003: La base de données spécifiée est introuvable.', error);
     } else {
-      console.error('❌ Erreur connexion base de données:', error);
+      logger.error('❌ Erreur connexion base de données:', error);
     }
     process.exit(1);
   }
@@ -40,9 +41,9 @@ async function connectDatabase() {
 
 // Fermeture propre
 async function disconnectDatabase() {
-  console.log('🔄 Fermeture de la connexion à la base de données...');
+  logger.info('🔄 Fermeture de la connexion à la base de données...');
   await prisma.$disconnect();
-  console.log('🔌 Base de données déconnectée');
+  logger.success('🔌 Base de données déconnectée');
 }
 
 module.exports = {


### PR DESCRIPTION
## Summary
- ensure server runs database migrations before startup
- integrate application logger into database and migration scripts
- simplify start script now that migrations run automatically

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6899c1dbe3f48325a1646778ebeb3543