### PR TITLE
Handle course field defaults in migration

### DIFF
--- a/backend/prisma/migrations/20240711120000_add_course_fields/migration.sql
+++ b/backend/prisma/migrations/20240711120000_add_course_fields/migration.sql
@@ -1,6 +1,6 @@
 -- AlterTable
-ALTER TABLE "courses" ADD COLUMN "style" TEXT NOT NULL;
-ALTER TABLE "courses" ADD COLUMN "duration" INTEGER NOT NULL;
-ALTER TABLE "courses" ADD COLUMN "intent" TEXT NOT NULL;
+ALTER TABLE "courses" ADD COLUMN "style" TEXT NOT NULL DEFAULT 'unknown';
+ALTER TABLE "courses" ADD COLUMN "duration" INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE "courses" ADD COLUMN "intent" TEXT NOT NULL DEFAULT 'general';
 ALTER TABLE "courses" ALTER COLUMN "detailLevel" DROP NOT NULL;
 ALTER TABLE "courses" ALTER COLUMN "vulgarizationLevel" DROP NOT NULL;


### PR DESCRIPTION
## Summary
- Ensure new course fields have default values to avoid failure when applying migration

## Testing
- `echo 'SELECT migration_name, finished_at, rolled_back_at, applied_steps_count FROM "_prisma_migrations";' | npx prisma db execute --stdin --schema prisma/schema.prisma` *(fails: Can't reach database server at `localhost:5432`)*
- `npx prisma migrate resolve --rolled-back 20240711120000_add_course_fields` *(fails: Can't reach database server at `localhost:5432`)*
- `npx prisma migrate deploy` *(fails: Can't reach database server at `localhost:5432`)*

------
https://chatgpt.com/codex/tasks/task_e_6899c77b94948325976270bce8208a0a