### PR TITLE
Limit Anthropic answers to brief responses

### DIFF
--- a/backend/src/services/anthropicService.js
+++ b/backend/src/services/anthropicService.js
@@ -264,7 +264,7 @@ Instructions :
 - Si la question porte sur le contenu du cours ci-dessus, réponds en te basant sur ce contenu
 - Si la question sort du contexte du cours, réponds avec tes connaissances générales
 - Adapte ta réponse au niveau de vulgarisation demandé
-- Garde une réponse concise (maximum 300 mots)
+- Limite ta réponse à 2–3 phrases ou à moins de 100 mots
 - Sois utile et informatif dans tous les cas
 
 Réponse :`;
@@ -278,7 +278,7 @@ Niveau de vulgarisation : ${levelInstructions[level]}
 Question : ${question}
 
 Instructions :
-- Donne une réponse claire et concise (maximum 300 mots)
+- Donne une réponse claire et conversationnelle en 2–3 phrases ou moins de 100 mots
 - Adapte ton vocabulaire et tes explications au niveau demandé
 - Utilise des exemples concrets si nécessaire
 - Reste informatif tout en étant accessible
@@ -289,7 +289,7 @@ Réponse :`;
 
       const response = await this.client.messages.create({
         model: 'claude-3-5-sonnet-20241022',
-        max_tokens: 800,
+        max_tokens: 180,
         temperature: 0.7,
         messages: [{
           role: 'user',


### PR DESCRIPTION
## Summary
- Refine Anthropic question prompts to keep answers within 2–3 sentences or under 100 words
- Cap Anthropic message generation at 180 tokens for shorter replies

## Testing
- `node --test`
- `JWT_SECRET=devsecret ANTHROPIC_API_KEY=dummy DATABASE_URL=postgresql://user:pass@localhost:5432/db node server.js` *(fails: Can't reach database server)*
- `node -e "process.env.ANTHROPIC_API_KEY='dummy'; const s=require('./src/services/anthropicService'); s.answerQuestion('Quelle est la capitale de la France?', null, 'beginner').then(console.log).catch(console.error);"` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_689a0cb9ae148325b914f7fe7dab4909