### PR TITLE
Disable cross-origin policies in Helmet configuration

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -14,45 +14,49 @@ const apiRoutes = require('./routes');
 const app = express();
 
 // ⭐ MODIFIÉ : Configuration Helmet avec CSP personnalisé
-app.use(helmet({
-  contentSecurityPolicy: {
-    directives: {
-      defaultSrc: ["'self'"],
-      scriptSrc: [
-        "'self'",
-        "'unsafe-inline'", // Pour les scripts inline (temporaire)
-        "https://unpkg.com", // Pour Lucide icons
-        "https://accounts.google.com", // Pour Google Auth
-        "https://apis.google.com" // Pour Google APIs
-      ],
-      styleSrc: [
-        "'self'",
-        "'unsafe-inline'", // Pour les styles inline
-        "https://fonts.googleapis.com", // Pour Google Fonts
-        "https://accounts.google.com" // Pour les styles Google Auth
-      ],
-      fontSrc: [
-        "'self'",
-        "https://fonts.gstatic.com" // Pour Google Fonts
-      ],
-      connectSrc: [
-        "'self'",
-        "https://accounts.google.com", // Pour Google Auth
-        "https://apis.google.com" // Pour Google APIs
-      ],
-      frameSrc: [
-        "'self'",
-        "https://accounts.google.com" // Pour les popups Google
-      ],
-      imgSrc: [
-        "'self'",
-        "data:",
-        "https://lh3.googleusercontent.com", // Pour les avatars Google
-        "https://*.googleusercontent.com" // Autres images Google
-      ]
+app.use(
+  helmet({
+    contentSecurityPolicy: {
+      directives: {
+        defaultSrc: ["'self'"],
+        scriptSrc: [
+          "'self'",
+          "'unsafe-inline'", // Pour les scripts inline (temporaire)
+          "https://unpkg.com", // Pour Lucide icons
+          "https://accounts.google.com", // Pour Google Auth
+          "https://apis.google.com" // Pour Google APIs
+        ],
+        styleSrc: [
+          "'self'",
+          "'unsafe-inline'", // Pour les styles inline
+          "https://fonts.googleapis.com", // Pour Google Fonts
+          "https://accounts.google.com" // Pour les styles Google Auth
+        ],
+        fontSrc: [
+          "'self'",
+          "https://fonts.gstatic.com" // Pour Google Fonts
+        ],
+        connectSrc: [
+          "'self'",
+          "https://accounts.google.com", // Pour Google Auth
+          "https://apis.google.com" // Pour Google APIs
+        ],
+        frameSrc: [
+          "'self'",
+          "https://accounts.google.com" // Pour les popups Google
+        ],
+        imgSrc: [
+          "'self'",
+          "data:",
+          "https://lh3.googleusercontent.com", // Pour les avatars Google
+          "https://*.googleusercontent.com" // Autres images Google
+        ]
+      }
     },
-  },
-}));
+    crossOriginEmbedderPolicy: false,
+    crossOriginOpenerPolicy: false
+  })
+);
 
 app.use(cors({
   origin: true,


### PR DESCRIPTION
## Summary
- allow third-party resources by disabling cross-origin embedder and opener policies in Helmet

## Testing
- `npm test --prefix backend` *(fails: Missing script "test")*
- `JWT_SECRET=dummy DATABASE_URL=postgresql://user:password@localhost:5432/db GOOGLE_CLIENT_ID=dummy ANTHROPIC_API_KEY=dummy npm start --prefix backend` *(fails: PrismaClientInitializationError: Can't reach database server)*

------
https://chatgpt.com/codex/tasks/task_e_689b5f3d4a98832593ca70850851bba4