### PR TITLE
Add X-XSS-Protection response header

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -58,6 +58,11 @@ app.use(
   })
 );
 
+app.use((_, res, next) => {
+  res.setHeader('X-XSS-Protection', '1; mode=block');
+  next();
+});
+
 app.use(cors({
   origin: true,
   credentials: true


### PR DESCRIPTION
## Summary
- set `X-XSS-Protection` header after Helmet middleware

## Testing
- `npm test` (fails: Missing script: "test")
- `curl -I http://localhost:3000/`

------
https://chatgpt.com/codex/tasks/task_e_689b60858a388325b4b30b96771a564a