### PR TITLE
fix: disable trusted types requirement

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -50,7 +50,8 @@ app.use(
           "data:",
           "https://lh3.googleusercontent.com", // Pour les avatars Google
           "https://*.googleusercontent.com" // Autres images Google
-        ]
+        ],
+        requireTrustedTypesFor: [] // Désactive 'require-trusted-types-for'
       }
     },
     crossOriginEmbedderPolicy: false,


### PR DESCRIPTION
## Summary
- disable Helmet's default `require-trusted-types-for` to prevent script blocking

## Testing
- `npm test --prefix backend` *(fails: Missing script)*
- `node --test backend/tests/**/*.test.js`
- `curl -I https://accounts.google.com/gsi/client` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_689b619b00b48325b6e6c3c1d0e23442