### PR TITLE
Ensure responsive Google auth buttons

### DIFF
--- a/frontend/assets/css/main.css
+++ b/frontend/assets/css/main.css
@@ -2048,6 +2048,7 @@ body::before {
     width: 100%;
     display: block;
     min-height: 50px; /* Réserver l'espace pour éviter les jumps */
+    min-width: 300px;
 }
 
 /* Conteneur pour le bouton Google officiel */
@@ -2055,6 +2056,7 @@ body::before {
 #googleSignInButtonRegister {
     width: 100%;
     display: block;
+    min-width: 300px;
 }
 
 /* Styles pour les boutons Google officiels */
@@ -2062,18 +2064,22 @@ body::before {
 #googleSignInButtonRegister > div {
     width: 100% !important;
     max-width: none !important;
+    min-width: 300px !important;
 }
 
 #googleSignInButton iframe,
 #googleSignInButtonRegister iframe {
     width: 100% !important;
     height: 50px !important;
+    min-width: 300px !important;
 }
 
 /* Boutons de fallback (backup) */
 .google-auth-btn-fallback {
     width: 100%;
-    display: block;
+    display: flex;
+    align-items: center;
+    justify-content: center;
     padding: 14px 18px;
     border: 2px solid #dadce0;
     border-radius: 12px;
@@ -2086,6 +2092,8 @@ body::before {
     font-weight: 500;
     font-family: inherit;
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12);
+    min-width: 300px;
+    min-height: 50px;
 }
 
 .google-auth-btn-fallback:hover {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -333,7 +333,8 @@
             googleInitialized = true
             // Créer les boutons manuellement avec une approche différente
             createGoogleButtons();
-            
+            setupGoogleButtonObservers();
+
             googleReady = true;
             console.log('✅ Google Auth prêt !');
             
@@ -387,6 +388,39 @@
             console.error('❌ Erreur création boutons:', error);
             createFallbackButtons();
         }
+    }
+
+    // Forcer la dimension et observer les changements sur les boutons Google
+    function enforceGoogleButtonDimensions(container) {
+        if (!container) return;
+        container.style.width = '100%';
+        container.style.minWidth = '300px';
+        container.style.minHeight = '50px';
+        const inner = container.querySelector('div');
+        if (inner) {
+            inner.style.width = '100%';
+            inner.style.minWidth = '300px';
+        }
+        const iframe = container.querySelector('iframe');
+        if (iframe) {
+            iframe.style.width = '100%';
+            iframe.style.minWidth = '300px';
+            iframe.style.height = '50px';
+        }
+    }
+
+    function setupGoogleButtonObservers() {
+        const ids = ['googleSignInButton', 'googleSignInButtonRegister'];
+        ids.forEach(id => {
+            const container = document.getElementById(id);
+            if (!container) return;
+            const apply = () => enforceGoogleButtonDimensions(container);
+            apply();
+            const resizeObs = new ResizeObserver(apply);
+            resizeObs.observe(container);
+            const mutationObs = new MutationObserver(apply);
+            mutationObs.observe(container, { childList: true, subtree: true });
+        });
     }
 
     // Créer des boutons de fallback qui utilisent prompt()


### PR DESCRIPTION
## Summary
- Force Google auth button containers and inner elements to use full width with minimum 300px and 50px height
- Add Resize and Mutation observers to keep Google auth buttons sized correctly on changes

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689b94faa29883258da764cf0775ccdc