### PR TITLE
Ensure Google auth buttons span full width on mobile

### DIFF
--- a/frontend/assets/css/main.css
+++ b/frontend/assets/css/main.css
@@ -2145,11 +2145,20 @@ body::before {
 
 /* Responsive */
 @media (max-width: 768px) {
+    .google-auth-container,
+    #googleSignInButton,
+    #googleSignInButton *,
+    #googleSignInButtonRegister,
+    #googleSignInButtonRegister *,
+    .google-auth-btn-fallback {
+        min-width: 0;
+        width: 100%;
+    }
     .google-auth-btn-fallback {
         font-size: 0.9rem;
         padding: 12px 16px;
     }
-    
+
     .google-icon {
         width: 18px;
         height: 18px;


### PR DESCRIPTION
## Summary
- enforce full-width layout for Google authentication elements on screens 768px and smaller

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689c9dc1f7e883259d0e3d99c58a8894