### PR TITLE
chore: remove google auth fallback

### DIFF
--- a/frontend/assets/css/main.css
+++ b/frontend/assets/css/main.css
@@ -2077,46 +2077,6 @@ body::before {
     max-width: 100% !important;
 }
 
-/* Boutons de fallback (backup) */
-.google-auth-btn-fallback {
-    width: 100%;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 10px 14px;
-    border: 2px solid #e2e8f0;
-    border-radius: 10px;
-    background: white;
-    color: #2d3748;
-    cursor: pointer;
-    transition: all 0.3s ease;
-    text-align: center;
-    font-size: 1rem;
-    font-weight: 500;
-    font-family: inherit;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12);
-    min-width: 0;
-    max-width: 100%;
-    min-height: 50px;
-}
-
-.google-auth-btn-fallback:hover {
-    border-color: #4285f4;
-    box-shadow: 0 2px 8px rgba(66, 133, 244, 0.15);
-    background: #f8f9ff;
-}
-
-.google-auth-btn-fallback:active {
-    transform: translateY(1px);
-}
-
-/* Icône Google dans les boutons fallback */
-.google-icon {
-    width: 20px;
-    height: 20px;
-    flex-shrink: 0;
-}
-
 /* Animation de chargement pour Google Auth */
 .google-loading {
     display: flex;
@@ -2149,24 +2109,14 @@ body::before {
     #googleSignInButton,
     #googleSignInButton *,
     #googleSignInButtonRegister,
-    #googleSignInButtonRegister *,
-    .google-auth-btn-fallback {
+    #googleSignInButtonRegister * {
         min-width: 0;
         width: 100%;
-    }
-    .google-auth-btn-fallback {
-        font-size: 0.9rem;
-        padding: 10px 14px;
-    }
-
-    .google-icon {
-        width: 18px;
-        height: 18px;
     }
 }
 
 /* Fix pour éviter les conflits avec les autres boutons */
-.google-auth-container button:not(.google-auth-btn-fallback) {
+.google-auth-container button {
     font-family: 'Roboto', sans-serif !important;
 }
 
@@ -2175,10 +2125,7 @@ body::before {
     width: 100%;
 }
 
-/* Masquer les boutons pendant le chargement */
-.google-auth-container.loading .google-auth-btn-fallback {
-    display: none;
-}
+/* Message pendant le chargement */
 
 .google-auth-container.loading::after {
     content: 'Chargement Google...';

--- a/frontend/assets/js/auth.js
+++ b/frontend/assets/js/auth.js
@@ -208,20 +208,6 @@ function setupAuthListeners() {
         });
     });
 
-    // ⭐ NOUVEAU : Bouton Google pour inscription
-    const googleRegisterBtn = document.getElementById('googleRegisterBtn');
-    if (googleRegisterBtn) {
-        googleRegisterBtn.addEventListener('click', function() {
-            console.log('Déclenchement connexion Google manuelle...');
-            
-            if (typeof google !== 'undefined' && google.accounts && google.accounts.id) {
-                google.accounts.id.prompt();
-            } else {
-                showNotification('Service Google non disponible', 'error');
-            }
-        });
-    }
-
     // Connexion email (existant)
     const loginBtn = document.getElementById('loginBtn');
     if (loginBtn) {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -31,15 +31,6 @@
                     <!-- Bouton Google officiel -->
                     <div class="google-auth-container">
                         <div id="googleSignInButton"></div>
-                        <button type="button" class="google-auth-btn-fallback" id="googleLoginBtn" style="display: none;">
-                            <svg class="google-icon" viewBox="0 0 24 24">
-                                <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"/>
-                                <path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"/>
-                                <path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"/>
-                                <path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"/>
-                            </svg>
-                            Se connecter avec Google
-                        </button>
                     </div>
 
                     <div class="auth-separator">
@@ -69,15 +60,6 @@
                     <!-- Bouton Google pour inscription -->
                     <div class="google-auth-container">
                         <div id="googleSignInButtonRegister"></div>
-                        <button type="button" class="google-auth-btn-fallback" id="googleRegisterBtn" style="display: none;">
-                            <svg class="google-icon" viewBox="0 0 24 24">
-                                <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"/>
-                                <path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"/>
-                                <path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"/>
-                                <path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"/>
-                            </svg>
-                            S'inscrire avec Google
-                        </button>
                     </div>
 
                     <div class="auth-separator">


### PR DESCRIPTION
## Summary
- remove deprecated Google auth fallback buttons from login and register screens
- drop associated fallback styles
- clean up unused Google auth fallback event handler

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689ca2c5d7708325ae3594f8b4cc3794