### PR TITLE
feat: add google auth wrapper

### DIFF
--- a/frontend/assets/js/auth.js
+++ b/frontend/assets/js/auth.js
@@ -123,8 +123,8 @@ class AuthManager {
         localStorage.removeItem('user');
         
         // ⭐ NOUVEAU : Déconnexion Google aussi
-        if (typeof google !== 'undefined' && google.accounts && google.accounts.id) {
-            google.accounts.id.disableAutoSelect();
+        if (window.GoogleAuth) {
+            GoogleAuth.disableAutoSelect();
         }
         
         this.updateUI();
@@ -348,6 +348,9 @@ function showNotification(message, type = 'success') {
 // Initialiser les event listeners quand le DOM est chargé
 document.addEventListener('DOMContentLoaded', function() {
     console.log('DOM chargé, configuration de l\'authentification...');
+    if (window.GoogleAuth) {
+        GoogleAuth.init((response) => authManager.handleGoogleLogin(response));
+    }
     setupAuthListeners();
 });
 

--- a/frontend/assets/js/googleAuth.js
+++ b/frontend/assets/js/googleAuth.js
@@ -1,0 +1,94 @@
+/**
+ * Gestionnaire du SDK Google Identity pour l'application.
+ * Garantit une initialisation unique et expose des méthodes utilitaires.
+ */
+const GoogleAuth = (() => {
+    const STATES = {
+        LOADING: 'LOADING',
+        READY: 'READY',
+        FAILED: 'FAILED'
+    };
+
+    let state = STATES.LOADING;
+    let initialized = false;
+    let initPromise = null;
+
+    function loadSdk() {
+        return new Promise((resolve, reject) => {
+            if (typeof google !== 'undefined') {
+                resolve();
+                return;
+            }
+            const script = document.createElement('script');
+            script.src = 'https://accounts.google.com/gsi/client';
+            script.async = true;
+            script.defer = true;
+            script.onload = resolve;
+            script.onerror = () => reject(new Error('Google SDK failed to load'));
+            document.head.appendChild(script);
+        });
+    }
+
+    async function init(callback = () => {}) {
+        if (initialized) return;
+        if (initPromise) return initPromise;
+
+        initPromise = (async () => {
+            try {
+                await loadSdk();
+
+                const res = await fetch('/api/config/google');
+                const data = await res.json();
+
+                if (!data.client_id) {
+                    throw new Error('Missing Google client_id');
+                }
+
+                google.accounts.id.initialize({
+                    client_id: data.client_id,
+                    callback,
+                });
+
+                initialized = true;
+                state = STATES.READY;
+            } catch (err) {
+                console.error('GoogleAuth init error:', err);
+                state = STATES.FAILED;
+                throw err;
+            }
+        })();
+
+        return initPromise;
+    }
+
+    function promptLogin(notificationCallback) {
+        if (state !== STATES.READY) return;
+        try {
+            google.accounts.id.prompt(notificationCallback);
+        } catch (err) {
+            console.error('GoogleAuth prompt error:', err);
+        }
+    }
+
+    function disableAutoSelect() {
+        if (google?.accounts?.id) {
+            try {
+                google.accounts.id.disableAutoSelect();
+            } catch (err) {
+                console.error('GoogleAuth disableAutoSelect error:', err);
+            }
+        }
+    }
+
+    return {
+        init,
+        promptLogin,
+        disableAutoSelect,
+        STATES,
+        get state() {
+            return state;
+        }
+    };
+})();
+
+window.GoogleAuth = GoogleAuth;

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -217,6 +217,7 @@
     <!-- Scripts - Dans l'ordre de dépendance -->
     <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.js"></script>
     <script src="assets/js/utils.js"></script>
+    <script src="assets/js/googleAuth.js"></script>
     <script src="assets/js/auth.js"></script>
     <script src="assets/js/course.js"></script>
     <script src="assets/js/main.js"></script>


### PR DESCRIPTION
## Summary
- add `GoogleAuth` module to manage Google SDK initialization and login prompts
- use new `GoogleAuth` in auth manager and include script in frontend

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689ca4db69fc8325892413cb493132a4