### PR TITLE
Handle Google Auth init failures with timeout and fallback

### DIFF
--- a/frontend/assets/js/auth.js
+++ b/frontend/assets/js/auth.js
@@ -348,8 +348,20 @@ function showNotification(message, type = 'success') {
 // Initialiser les event listeners quand le DOM est chargé
 document.addEventListener('DOMContentLoaded', function() {
     console.log('DOM chargé, configuration de l\'authentification...');
+
+    const separators = document.querySelectorAll('.auth-separator');
+    separators.forEach(el => el.style.display = 'none');
+
     if (window.GoogleAuth) {
-        GoogleAuth.init((response) => authManager.handleGoogleLogin(response));
+        GoogleAuth.init((response) => authManager.handleGoogleLogin(response))
+            .then(() => {
+                if (GoogleAuth.state === GoogleAuth.STATES.READY) {
+                    separators.forEach(el => el.style.display = 'block');
+                }
+            })
+            .catch(() => {
+                // L'initialisation a échoué, le fallback est géré par GoogleAuth
+            });
     }
     setupAuthListeners();
 });


### PR DESCRIPTION
## Summary
- add timeout and fallback message to Google Auth initialization
- show email separator only when Google Auth is ready

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689ca69ca09883259753a38b14b0f6e1