### PR TITLE
Improve Google auth error handling with timeout

### DIFF
--- a/backend/src/controllers/authController.js
+++ b/backend/src/controllers/authController.js
@@ -192,8 +192,13 @@ class AuthController {
       logger.error('Erreur authentification Google', error);
       
       // Gestion des erreurs spécifiques
-      if (error.message.includes('Token Google invalide')) {
-        const { response, statusCode } = createResponse(false, null, 'Token Google invalide', HTTP_STATUS.UNAUTHORIZED);
+      if (error.code === 'INVALID') {
+        const { response, statusCode } = createResponse(false, null, 'Token expiré', HTTP_STATUS.UNAUTHORIZED);
+        return res.status(statusCode).json(response);
+      }
+
+      if (error.code === 'TIMEOUT' || error.code === 'NETWORK') {
+        const { response, statusCode } = createResponse(false, null, 'Google indisponible', 503);
         return res.status(statusCode).json(response);
       }
 


### PR DESCRIPTION
## Summary
- add explicit 5s timeout around Google ID token verification
- differentiate timeout, network, and invalid token errors
- return user-friendly messages in Google auth controller

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689cabd583108325852371eb108f0555