### PR TITLE
feat: add reset for GoogleAuth

### DIFF
--- a/frontend/assets/js/auth.js
+++ b/frontend/assets/js/auth.js
@@ -121,12 +121,13 @@ class AuthManager {
         this.user = null;
         localStorage.removeItem('authToken');
         localStorage.removeItem('user');
-        
-        // ⭐ NOUVEAU : Déconnexion Google aussi
+
+        // ⭐ Déconnexion Google et nettoyage des boutons
         if (window.GoogleAuth) {
+            GoogleAuth.reset();
             GoogleAuth.disableAutoSelect();
         }
-        
+
         this.updateUI();
         window.location.reload();
     }
@@ -199,12 +200,24 @@ function setupAuthListeners() {
         tab.addEventListener('click', function() {
             const tabName = this.dataset.tab;
             console.log('Changement d\'onglet:', tabName);
-            
+
             document.querySelectorAll('.auth-tab').forEach(t => t.classList.remove('active'));
             this.classList.add('active');
-            
+
             document.getElementById('loginForm').style.display = tabName === 'login' ? 'block' : 'none';
             document.getElementById('registerForm').style.display = tabName === 'register' ? 'block' : 'none';
+
+            // Réinitialiser et recharger GoogleAuth lors du changement de vue
+            if (window.GoogleAuth) {
+                GoogleAuth.reset();
+                GoogleAuth.init(response => authManager.handleGoogleLogin(response))
+                    .then(() => {
+                        if (GoogleAuth.state === GoogleAuth.STATES.READY) {
+                            GoogleAuth.promptLogin();
+                        }
+                    })
+                    .catch(() => {});
+            }
         });
     });
 
@@ -339,6 +352,7 @@ document.addEventListener('DOMContentLoaded', function() {
     separators.forEach(el => el.style.display = 'none');
 
     if (window.GoogleAuth) {
+        GoogleAuth.reset();
         GoogleAuth.init(response => authManager.handleGoogleLogin(response))
             .then(() => {
                 if (GoogleAuth.state === GoogleAuth.STATES.READY) {

--- a/frontend/assets/js/googleAuth.js
+++ b/frontend/assets/js/googleAuth.js
@@ -10,9 +10,9 @@ const GoogleAuth = (() => {
     };
 
     let state = STATES.LOADING;
-    let initialized = false;
+    let googleInitialized = false;
     let initPromise = null;
-    let buttonsRendered = false;
+    let googleButtonsRendered = false;
 
     function loadSdk() {
         return new Promise((resolve, reject) => {
@@ -41,7 +41,7 @@ const GoogleAuth = (() => {
     }
 
     function renderButtons() {
-        if (buttonsRendered) return;
+        if (googleButtonsRendered) return;
         const configs = [
             { id: 'googleSignInButton', text: 'signin_with' },
             { id: 'googleSignInButtonRegister', text: 'signup_with' }
@@ -66,7 +66,7 @@ const GoogleAuth = (() => {
                 console.error('GoogleAuth renderButton error:', err);
             }
         });
-        buttonsRendered = true;
+        googleButtonsRendered = true;
     }
 
     function enforceButtonDimensions(container) {
@@ -107,7 +107,7 @@ const GoogleAuth = (() => {
     }
 
     async function init(callback = () => {}, timeout = 5000) {
-        if (initialized) return;
+        if (googleInitialized) return;
         if (initPromise) return initPromise;
 
         initPromise = (async () => {
@@ -129,7 +129,7 @@ const GoogleAuth = (() => {
 
                 renderButtons();
                 observeButtons();
-                initialized = true;
+                googleInitialized = true;
                 state = STATES.READY;
             })();
 
@@ -169,10 +169,24 @@ const GoogleAuth = (() => {
         }
     }
 
+    function reset() {
+        googleInitialized = false;
+        googleButtonsRendered = false;
+        initPromise = null;
+        state = STATES.LOADING;
+        document.querySelectorAll('.google-auth-container').forEach(container => {
+            container.classList.remove('loading');
+            container.innerHTML = '';
+            container.style.display = '';
+        });
+        document.querySelectorAll('.google-auth-fallback').forEach(el => el.remove());
+    }
+
     return {
         init,
         promptLogin,
         disableAutoSelect,
+        reset,
         STATES,
         get state() {
             return state;


### PR DESCRIPTION
## Summary
- encapsulate Google auth flags inside module
- add `GoogleAuth.reset()` to clear state and DOM
- reset GoogleAuth before init, view changes, and logout

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689cbfbabcd8832580ac88a6834b6ae7