### PR TITLE
Handle Google config errors in Google auth flow

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -81,7 +81,20 @@ const limiter = rateLimit({
 
 // Exposer la config Google au front
 app.get('/api/config/google', (req, res) => {
-  res.json({ clientId: process.env.GOOGLE_CLIENT_ID || '' });
+  try {
+    const clientId = process.env.GOOGLE_CLIENT_ID;
+
+    if (!clientId) {
+      return res.status(500).json({
+        error: 'Google Client ID not configured'
+      });
+    }
+
+    res.json({ clientId });
+  } catch (err) {
+    logger.error('Erreur récupération config Google', err);
+    res.status(500).json({ error: 'Internal Server Error' });
+  }
 });
 
 


### PR DESCRIPTION
## Summary
- add error handling to `/api/config/google` endpoint
- wrap Google config fetch with try/catch and env fallback on frontend
- display user-facing message when Google sign-in is unavailable

## Testing
- `npm test` *(fails: Missing script "test")*
- `cd backend && npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689cc388d4a48325a6557c3b3e48dd79