### PR TITLE
Ensure GoogleAuth reset before initialization

### DIFF
--- a/frontend/assets/js/auth.js
+++ b/frontend/assets/js/auth.js
@@ -210,13 +210,15 @@ function setupAuthListeners() {
             // Réinitialiser et recharger GoogleAuth lors du changement de vue
             if (window.GoogleAuth) {
                 GoogleAuth.reset();
-                GoogleAuth.init(response => authManager.handleGoogleLogin(response))
-                    .then(() => {
-                        if (GoogleAuth.state === GoogleAuth.STATES.READY) {
-                            GoogleAuth.promptLogin();
-                        }
-                    })
-                    .catch(() => {});
+                if (GoogleAuth.state === GoogleAuth.STATES.LOADING) {
+                    GoogleAuth.init(response => authManager.handleGoogleLogin(response))
+                        .then(() => {
+                            if (GoogleAuth.state === GoogleAuth.STATES.READY) {
+                                GoogleAuth.promptLogin();
+                            }
+                        })
+                        .catch(() => {});
+                }
             }
         });
     });
@@ -353,16 +355,18 @@ document.addEventListener('DOMContentLoaded', function() {
 
     if (window.GoogleAuth) {
         GoogleAuth.reset();
-        GoogleAuth.init(response => authManager.handleGoogleLogin(response))
-            .then(() => {
-                if (GoogleAuth.state === GoogleAuth.STATES.READY) {
-                    separators.forEach(el => el.style.display = 'block');
-                    GoogleAuth.promptLogin();
-                }
-            })
-            .catch(() => {
-                // L'initialisation a échoué, le fallback est géré par GoogleAuth
-            });
+        if (GoogleAuth.state === GoogleAuth.STATES.LOADING) {
+            GoogleAuth.init(response => authManager.handleGoogleLogin(response))
+                .then(() => {
+                    if (GoogleAuth.state === GoogleAuth.STATES.READY) {
+                        separators.forEach(el => el.style.display = 'block');
+                        GoogleAuth.promptLogin();
+                    }
+                })
+                .catch(() => {
+                    // L'initialisation a échoué, le fallback est géré par GoogleAuth
+                });
+        }
     }
     setupAuthListeners();
 });

--- a/frontend/assets/js/googleAuth.js
+++ b/frontend/assets/js/googleAuth.js
@@ -214,3 +214,7 @@ const GoogleAuth = (() => {
 
 window.GoogleAuth = GoogleAuth;
 
+document.addEventListener('DOMContentLoaded', () => {
+    GoogleAuth.reset();
+});
+


### PR DESCRIPTION
## Summary
- Reset GoogleAuth on DOMContentLoaded
- Guard GoogleAuth.init calls behind reset state checks

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689cc80595a88325ab9439289acbcad2