### PR TITLE
Handle Google auth button load failures gracefully

### DIFF
--- a/frontend/assets/js/googleAuth.js
+++ b/frontend/assets/js/googleAuth.js
@@ -61,9 +61,13 @@ const GoogleAuth = (() => {
                     logo_alignment: 'left',
                     width
                 });
-                container.parentElement?.classList.remove('loading');
             } catch (err) {
                 console.error('GoogleAuth renderButton error:', err);
+                if (!document.querySelector('.google-auth-fallback')) {
+                    showEmailFallback();
+                }
+            } finally {
+                container.parentElement?.classList.remove('loading');
             }
         });
         googleButtonsRendered = true;


### PR DESCRIPTION
## Summary
- Ensure Google auth button container always removes its loading class
- Offer email auth fallback when Google button rendering fails

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689cd15c113c8325a6da285a57bb87c2