### PR TITLE
fix: preserve google auth containers on reset

### DIFF
--- a/frontend/assets/js/googleAuth.js
+++ b/frontend/assets/js/googleAuth.js
@@ -198,9 +198,27 @@ const GoogleAuth = (() => {
         state = STATES.LOADING;
         document.querySelectorAll('.google-auth-container').forEach(container => {
             container.classList.remove('loading');
-            container.innerHTML = '';
             container.style.display = '';
         });
+
+        ['googleSignInButton', 'googleSignInButtonRegister'].forEach(id => {
+            let buttonContainer = document.getElementById(id);
+            if (!buttonContainer) {
+                buttonContainer = document.createElement('div');
+                buttonContainer.id = id;
+                const parent = id === 'googleSignInButton'
+                    ? document.querySelector('#loginForm .google-auth-container')
+                    : document.querySelector('#registerForm .google-auth-container');
+                parent?.appendChild(buttonContainer);
+            } else {
+                buttonContainer.innerHTML = '';
+            }
+            buttonContainer?.parentElement?.classList.remove('loading');
+            if (buttonContainer?.parentElement) {
+                buttonContainer.parentElement.style.display = '';
+            }
+        });
+
         document.querySelectorAll('.google-auth-fallback').forEach(el => el.remove());
     }
 


### PR DESCRIPTION
## Summary
- keep Google sign-in button divs on reset and recreate if missing
- clear only button contents and remove loading classes for containers

## Testing
- `npm test` *(fails: Missing script: "test"?)*

------
https://chatgpt.com/codex/tasks/task_e_689cd72d279083258c23755d6a3b6917