### PR TITLE
fix: ensure Google auth loader removed in all cases

### DIFF
--- a/frontend/assets/js/googleAuth.js
+++ b/frontend/assets/js/googleAuth.js
@@ -49,7 +49,23 @@ const GoogleAuth = (() => {
 
         configs.forEach(({ id, text }) => {
             const container = document.getElementById(id);
-            if (!container || container.hasChildNodes()) return;
+            const parent = container?.parentElement || (
+                id === 'googleSignInButton'
+                    ? document.querySelector('#loginForm .google-auth-container')
+                    : document.querySelector('#registerForm .google-auth-container')
+            );
+
+            if (!container) {
+                console.warn(`GoogleAuth renderButtons: container #${id} not found`);
+                parent?.classList.remove('loading');
+                return;
+            }
+
+            if (container.hasChildNodes()) {
+                parent?.classList.remove('loading');
+                return;
+            }
+
             const width = Math.min(container.offsetWidth || window.innerWidth - 40, 300);
             try {
                 google.accounts.id.renderButton(container, {
@@ -67,7 +83,7 @@ const GoogleAuth = (() => {
                     showEmailFallback();
                 }
             } finally {
-                container.parentElement?.classList.remove('loading');
+                parent?.classList.remove('loading');
             }
         });
         googleButtonsRendered = true;


### PR DESCRIPTION
## Summary
- always remove loading class from Google auth containers even if buttons are missing or already rendered
- add warning log when Google auth button container is not found

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689cd8333d7c8325b0650ee3feaefcbd