### PR TITLE
Guard GoogleAuth reset by state

### DIFF
--- a/frontend/assets/js/auth.js
+++ b/frontend/assets/js/auth.js
@@ -124,7 +124,9 @@ class AuthManager {
 
         // ⭐ Déconnexion Google et nettoyage des boutons
         if (window.GoogleAuth) {
-            GoogleAuth.reset();
+            if (GoogleAuth.state !== GoogleAuth.STATES.LOADING) {
+                GoogleAuth.reset();
+            }
             GoogleAuth.disableAutoSelect();
         }
 
@@ -209,7 +211,9 @@ function setupAuthListeners() {
 
             // Réinitialiser et recharger GoogleAuth lors du changement de vue
             if (window.GoogleAuth) {
-                GoogleAuth.reset();
+                if (GoogleAuth.state !== GoogleAuth.STATES.LOADING) {
+                    GoogleAuth.reset();
+                }
                 if (GoogleAuth.state === GoogleAuth.STATES.LOADING) {
                     GoogleAuth.init(response => authManager.handleGoogleLogin(response))
                         .then(() => {
@@ -354,7 +358,9 @@ document.addEventListener('DOMContentLoaded', function() {
     separators.forEach(el => el.style.display = 'none');
 
     if (window.GoogleAuth) {
-        GoogleAuth.reset();
+        if (GoogleAuth.state !== GoogleAuth.STATES.LOADING) {
+            GoogleAuth.reset();
+        }
         if (GoogleAuth.state === GoogleAuth.STATES.LOADING) {
             GoogleAuth.init(response => authManager.handleGoogleLogin(response))
                 .then(() => {

--- a/frontend/assets/js/googleAuth.js
+++ b/frontend/assets/js/googleAuth.js
@@ -15,6 +15,12 @@ const GoogleAuth = (() => {
     let googleButtonsRendered = false;
     let cachedClientId = null;
 
+    function setState(newState) {
+        if (state !== newState) {
+            state = newState;
+        }
+    }
+
     function loadSdk() {
         return new Promise((resolve, reject) => {
             if (typeof google !== 'undefined') {
@@ -65,7 +71,7 @@ const GoogleAuth = (() => {
                     cachedClientId = fallback;
                     return cachedClientId;
                 }
-                state = STATES.FAILED;
+                setState(STATES.FAILED);
                 showEmailFallback();
                 throw err;
             });
@@ -190,7 +196,7 @@ const GoogleAuth = (() => {
                 renderButtons();
                 observeButtons();
                 googleInitialized = true;
-                state = STATES.READY;
+                setState(STATES.READY);
             });
 
         const timeoutPromise = new Promise((_, reject) =>
@@ -200,7 +206,7 @@ const GoogleAuth = (() => {
         initPromise = Promise.race([initSequence, timeoutPromise]).catch(err => {
             console.error('GoogleAuth init error:', err);
             if (state !== STATES.FAILED) {
-                state = STATES.FAILED;
+                setState(STATES.FAILED);
                 showEmailFallback();
             }
             throw err;
@@ -232,7 +238,7 @@ const GoogleAuth = (() => {
         googleInitialized = false;
         googleButtonsRendered = false;
         initPromise = null;
-        state = STATES.LOADING;
+        setState(STATES.LOADING);
         document.querySelectorAll('.google-auth-container').forEach(container => {
             container.classList.remove('loading');
             container.style.display = '';
@@ -274,6 +280,8 @@ const GoogleAuth = (() => {
 window.GoogleAuth = GoogleAuth;
 
 document.addEventListener('DOMContentLoaded', () => {
-    GoogleAuth.reset();
+    if (GoogleAuth.state !== GoogleAuth.STATES.LOADING) {
+        GoogleAuth.reset();
+    }
 });
 


### PR DESCRIPTION
## Summary
- Ignore redundant GoogleAuth state transitions with new `setState`
- Only call `GoogleAuth.reset()` when not already loading
- Avoid auto reset on DOMContentLoaded if SDK is still loading

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689ce6356bf08325b68f6c148eb0bb55