### PR TITLE
feat: add route-level rate limiting and blacklist

### DIFF
--- a/backend/src/middleware/blacklist.js
+++ b/backend/src/middleware/blacklist.js
@@ -1,0 +1,27 @@
+// backend/src/middleware/blacklist.js
+const { createResponse } = require('../utils/helpers');
+const { ERROR_MESSAGES, HTTP_STATUS } = require('../utils/constants');
+
+// Ensembles pour stocker les IPs et utilisateurs blacklistés
+const blacklistedIPs = new Set();
+const blacklistedUserIds = new Set();
+
+// Middleware pour vérifier si la requête provient d'une source blacklistée
+const checkBlacklist = (req, res, next) => {
+  const ip = req.ip;
+  const userId = req.user?.id;
+
+  if (blacklistedIPs.has(ip) || (userId && blacklistedUserIds.has(userId))) {
+    const { response, statusCode } = createResponse(false, null, ERROR_MESSAGES.FORBIDDEN, HTTP_STATUS.FORBIDDEN);
+    return res.status(statusCode).json(response);
+  }
+
+  next();
+};
+
+module.exports = {
+  checkBlacklist,
+  blacklistedIPs,
+  blacklistedUserIds
+};
+

--- a/backend/src/routes/ai.js
+++ b/backend/src/routes/ai.js
@@ -3,17 +3,38 @@ const express = require('express');
 const aiController = require('../controllers/aiController');
 const { authenticate } = require('../middleware/auth');
 const { asyncHandler } = require('../utils/helpers');
+const rateLimit = require('express-rate-limit');
+const { RATE_LIMITS, ERROR_MESSAGES } = require('../utils/constants');
+const { checkBlacklist } = require('../middleware/blacklist');
 
 const router = express.Router();
 
+// Créateur de limiteur de requêtes
+const createRateLimiter = ({ WINDOW_MS, MAX }) => rateLimit({
+  windowMs: WINDOW_MS,
+  max: MAX,
+  message: ERROR_MESSAGES.RATE_LIMIT,
+  standardHeaders: true,
+  legacyHeaders: false
+});
+
+// Limiteurs pour chaque route
+const askQuestionLimiter = createRateLimiter(RATE_LIMITS.AI.ASK_QUESTION);
+const generateQuizLimiter = createRateLimiter(RATE_LIMITS.AI.GENERATE_QUIZ);
+const suggestQuestionsLimiter = createRateLimiter(RATE_LIMITS.AI.SUGGEST_QUESTIONS);
+const randomSubjectLimiter = createRateLimiter(RATE_LIMITS.AI.RANDOM_SUBJECT);
+const subjectCategoriesLimiter = createRateLimiter(RATE_LIMITS.AI.SUBJECT_CATEGORIES);
+
 // Toutes les routes nécessitent une authentification
 router.use(authenticate);
+// Contrôle de blacklist
+router.use(checkBlacklist);
 
 // Routes IA
-router.post('/ask-question', asyncHandler(aiController.askQuestion));
-router.post('/generate-quiz', asyncHandler(aiController.generateQuiz));
-router.post('/suggest-questions', asyncHandler(aiController.suggestQuestions));
-router.get('/random-subject', asyncHandler(aiController.getRandomSubject));
-router.get('/subject-categories', asyncHandler(aiController.getSubjectCategories));
+router.post('/ask-question', askQuestionLimiter, asyncHandler(aiController.askQuestion));
+router.post('/generate-quiz', generateQuizLimiter, asyncHandler(aiController.generateQuiz));
+router.post('/suggest-questions', suggestQuestionsLimiter, asyncHandler(aiController.suggestQuestions));
+router.get('/random-subject', randomSubjectLimiter, asyncHandler(aiController.getRandomSubject));
+router.get('/subject-categories', subjectCategoriesLimiter, asyncHandler(aiController.getSubjectCategories));
 
 module.exports = router;

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -4,15 +4,34 @@ const authController = require('../controllers/authController');
 const { authenticate } = require('../middleware/auth');
 const { registerValidation, loginValidation } = require('../middleware/validation');
 const { asyncHandler } = require('../utils/helpers');
+const rateLimit = require('express-rate-limit');
+const { RATE_LIMITS, ERROR_MESSAGES } = require('../utils/constants');
+const { checkBlacklist } = require('../middleware/blacklist');
 
 const router = express.Router();
 
+// Créateur de limiteur de requêtes
+const createRateLimiter = ({ WINDOW_MS, MAX }) => rateLimit({
+  windowMs: WINDOW_MS,
+  max: MAX,
+  message: ERROR_MESSAGES.RATE_LIMIT,
+  standardHeaders: true,
+  legacyHeaders: false
+});
+
+// Limiteurs spécifiques aux routes d'authentification
+const loginLimiter = createRateLimiter(RATE_LIMITS.AUTH.LOGIN);
+const googleLimiter = createRateLimiter(RATE_LIMITS.AUTH.GOOGLE);
+
+// Contrôle de blacklist pour toutes les routes d'authentification
+router.use(checkBlacklist);
+
 // Routes publiques existantes
 router.post('/register', registerValidation, asyncHandler(authController.register));
-router.post('/login', loginValidation, asyncHandler(authController.login));
+router.post('/login', loginLimiter, loginValidation, asyncHandler(authController.login));
 
 // NOUVELLE ROUTE : Authentification Google
-router.post('/google', asyncHandler(authController.googleAuth));
+router.post('/google', googleLimiter, asyncHandler(authController.googleAuth));
 
 // Routes protégées existantes
 router.get('/profile', authenticate, asyncHandler(authController.getProfile));

--- a/backend/src/utils/constants.js
+++ b/backend/src/utils/constants.js
@@ -54,6 +54,21 @@ const LIMITS = {
   MAX_HISTORY_ITEMS: 50
 };
 
+// Quotas de rate limiting par type de route
+const RATE_LIMITS = {
+  AI: {
+    ASK_QUESTION: { WINDOW_MS: 60 * 60 * 1000, MAX: 5 }, // 5 requêtes/heure
+    GENERATE_QUIZ: { WINDOW_MS: 60 * 60 * 1000, MAX: 5 },
+    SUGGEST_QUESTIONS: { WINDOW_MS: 60 * 60 * 1000, MAX: 5 },
+    RANDOM_SUBJECT: { WINDOW_MS: 60 * 60 * 1000, MAX: 5 },
+    SUBJECT_CATEGORIES: { WINDOW_MS: 60 * 60 * 1000, MAX: 5 }
+  },
+  AUTH: {
+    LOGIN: { WINDOW_MS: 60 * 60 * 1000, MAX: 15 },
+    GOOGLE: { WINDOW_MS: 60 * 60 * 1000, MAX: 5 }
+  }
+};
+
 // Messages d'erreur standardisés
 const ERROR_MESSAGES = {
   UNAUTHORIZED: 'Non autorisé',
@@ -83,6 +98,7 @@ module.exports = {
   VULGARIZATION_LEVELS,
   QUESTION_TYPES,
   LIMITS,
+  RATE_LIMITS,
   ERROR_MESSAGES,
   HTTP_STATUS,
   STYLES,


### PR DESCRIPTION
## Summary
- add per-route rate limit constants and use them for AI and auth endpoints
- introduce blacklist middleware to block requests from banned IPs or users

## Testing
- `npm test` (fails: Missing script "test")


------
https://chatgpt.com/codex/tasks/task_e_689de90f04448325b325854f64050edb