### PR TITLE
feat: strengthen input sanitization

### DIFF
--- a/backend/src/controllers/aiController.js
+++ b/backend/src/controllers/aiController.js
@@ -15,7 +15,7 @@ class AiController {
       }
 
       // Sanitisation
-      const sanitizedQuestion = sanitizeInput(question);
+      const sanitizedQuestion = sanitizeInput(question, 2000);
 
       // Générer la réponse
       const result = await anthropicService.answerQuestion(

--- a/backend/src/controllers/courseController.js
+++ b/backend/src/controllers/courseController.js
@@ -86,7 +86,7 @@ class CourseController {
       }
 
       // Sanitisation
-      const sanitizedSubject = sanitizeInput(subject);
+      const sanitizedSubject = sanitizeInput(subject, 500);
 
       // Génération du cours
       const courseContent = await anthropicService.generateCourse(

--- a/backend/src/middleware/validation.js
+++ b/backend/src/middleware/validation.js
@@ -46,8 +46,8 @@ const loginValidation = [
 const courseValidation = [
   body('subject')
     .trim()
-    .isLength({ min: 1 })
-    .withMessage('Le sujet est requis'),
+    .isLength({ min: 1, max: 500 })
+    .withMessage('Le sujet doit faire entre 1 et 500 caractères'),
   body('style')
     .optional()
     .isIn(Object.values(STYLES))
@@ -71,9 +71,19 @@ const courseValidation = [
   handleValidationErrors
 ];
 
+// Règles de validation pour les questions
+const questionValidation = [
+  body('question')
+    .trim()
+    .isLength({ min: 1, max: 2000 })
+    .withMessage('La question doit faire entre 1 et 2000 caractères'),
+  handleValidationErrors
+];
+
 module.exports = {
   registerValidation,
   loginValidation,
   courseValidation,
+  questionValidation,
   handleValidationErrors
 };

--- a/backend/src/routes/ai.js
+++ b/backend/src/routes/ai.js
@@ -3,6 +3,7 @@ const express = require('express');
 const aiController = require('../controllers/aiController');
 const { authenticate } = require('../middleware/auth');
 const { asyncHandler } = require('../utils/helpers');
+const { questionValidation } = require('../middleware/validation');
 const rateLimit = require('express-rate-limit');
 const { RATE_LIMITS, ERROR_MESSAGES } = require('../utils/constants');
 const { checkBlacklist } = require('../middleware/blacklist');
@@ -31,7 +32,7 @@ router.use(authenticate);
 router.use(checkBlacklist);
 
 // Routes IA
-router.post('/ask-question', askQuestionLimiter, asyncHandler(aiController.askQuestion));
+router.post('/ask-question', askQuestionLimiter, questionValidation, asyncHandler(aiController.askQuestion));
 router.post('/generate-quiz', generateQuizLimiter, asyncHandler(aiController.generateQuiz));
 router.post('/suggest-questions', suggestQuestionsLimiter, asyncHandler(aiController.suggestQuestions));
 router.get('/random-subject', randomSubjectLimiter, asyncHandler(aiController.getRandomSubject));

--- a/backend/src/utils/helpers.js
+++ b/backend/src/utils/helpers.js
@@ -64,15 +64,14 @@ const mapLegacyParams = ({ detailLevel, vulgarizationLevel, style, duration, int
   };
 };
 
-// Sanitisation des entrées
-const sanitizeInput = (input) => {
+// Sanitisation des entrées avec whitelist
+const sanitizeInput = (input, maxLength = 10000) => {
   if (typeof input !== 'string') return input;
-  
+
   return input
     .trim()
-    .replace(/<script[^>]*>.*?<\/script>/gi, '') // Supprimer les scripts
-    .replace(/<[^>]*>/g, '') // Supprimer les balises HTML
-    .substring(0, 10000); // Limiter la taille
+    .replace(/[^a-zA-Z0-9 _\n\r.,!?;:'"()\[\]{}-]/g, '')
+    .substring(0, maxLength);
 };
 
 // Gestion des erreurs async

--- a/frontend/assets/js/course.js
+++ b/frontend/assets/js/course.js
@@ -30,7 +30,7 @@ class CourseManager {
   async generateCourse(subject, style, duration, intent) {
     try {
       const payload = {
-        subject: utils.sanitizeInput(subject)
+        subject: utils.sanitizeInput(subject, 500)
       };
       if (style && STYLE_LABELS[style]) {
         payload.style = utils.sanitizeInput(style);
@@ -78,7 +78,10 @@ class CourseManager {
   displayCourse(course) {
     document.getElementById('emptyState').style.display = 'none';
     document.getElementById('courseContent').style.display = 'block';
-    document.getElementById('generatedCourse').innerHTML = course.content;
+    const sanitizedContent = typeof DOMPurify !== 'undefined'
+      ? DOMPurify.sanitize(course.content)
+      : course.content;
+    document.getElementById('generatedCourse').innerHTML = sanitizedContent;
     
     // Réinitialiser le chat
     const chatMessages = document.getElementById('chatMessages');

--- a/frontend/assets/js/main.js
+++ b/frontend/assets/js/main.js
@@ -153,7 +153,7 @@ function addChatMessage(text, type) {
 
 async function askQuestion() {
     const chatInput = document.getElementById('chatInput');
-    const question = chatInput.value.trim();
+    const question = utils.sanitizeInput(chatInput.value, 2000);
 
     if (!question) {
         utils.handleAuthError('Veuillez saisir une question');

--- a/frontend/assets/js/utils.js
+++ b/frontend/assets/js/utils.js
@@ -32,10 +32,13 @@ const utils = {
     }, 4000);
   },
 
-  // Sanitisation simple
-  sanitizeInput(input) {
+  // Sanitisation avec whitelist
+  sanitizeInput(input, maxLength = 10000) {
     if (typeof input !== 'string') return input;
-    return input.trim().substring(0, 10000);
+    return input
+      .trim()
+      .replace(/[^a-zA-Z0-9 _\n\r.,!?;:'"()\[\]{}-]/g, '')
+      .substring(0, maxLength);
   },
 
   // Gestion unifiée des erreurs d'authentification

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -217,6 +217,7 @@
     
     <!-- Scripts - Dans l'ordre de dépendance -->
     <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/dompurify@2.4.0/dist/purify.min.js"></script>
     <script src="assets/js/utils.js"></script>
     <script src="assets/js/googleAuth.js"></script>
     <script src="assets/js/auth.js"></script>


### PR DESCRIPTION
## Summary
- limit course subject to 500 characters and questions to 2000
- sanitize inputs with a shared whitelist on frontend and backend
- sanitize course content with DOMPurify before rendering

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Missing script: "lint")*

------
https://chatgpt.com/codex/tasks/task_e_689dea36c8e48325aef8c6648baf3b69