### PR TITLE
Handle AI timeouts and quota errors across stack

### DIFF
--- a/backend/src/controllers/aiController.js
+++ b/backend/src/controllers/aiController.js
@@ -1,6 +1,6 @@
 // backend/src/controllers/aiController.js
 const { createResponse, sanitizeInput, logger } = require('../utils/helpers');
-const { HTTP_STATUS, ERROR_MESSAGES } = require('../utils/constants');
+const { HTTP_STATUS, ERROR_MESSAGES, ERROR_CODES } = require('../utils/constants');
 const anthropicService = require('../services/anthropicService');
 
 class AiController {
@@ -38,8 +38,17 @@ class AiController {
 
       res.json(response);
     } catch (error) {
-      logger.error('Erreur réponse question', error);
-      const { response, statusCode } = createResponse(false, null, ERROR_MESSAGES.SERVER_ERROR, HTTP_STATUS.SERVER_ERROR);
+      logger.error('Erreur réponse question', { error, code: error.code });
+      let message = ERROR_MESSAGES.SERVER_ERROR;
+      let status = HTTP_STATUS.SERVER_ERROR;
+      if (error.code === ERROR_CODES.IA_TIMEOUT) {
+        message = 'Temps dépassé lors de la réponse de l\'IA';
+        status = HTTP_STATUS.SERVICE_UNAVAILABLE;
+      } else if (error.code === ERROR_CODES.QUOTA_EXCEEDED) {
+        message = 'Quota IA dépassé, réessayez plus tard';
+        status = HTTP_STATUS.RATE_LIMIT;
+      }
+      const { response, statusCode } = createResponse(false, null, message, status, error.code);
       res.status(statusCode).json(response);
     }
   }
@@ -65,8 +74,17 @@ class AiController {
       const { response } = createResponse(true, { quiz });
       res.json(response);
     } catch (error) {
-      logger.error('Erreur génération quiz', error);
-      const { response, statusCode } = createResponse(false, null, ERROR_MESSAGES.SERVER_ERROR, HTTP_STATUS.SERVER_ERROR);
+      logger.error('Erreur génération quiz', { error, code: error.code });
+      let message = ERROR_MESSAGES.SERVER_ERROR;
+      let status = HTTP_STATUS.SERVER_ERROR;
+      if (error.code === ERROR_CODES.IA_TIMEOUT) {
+        message = 'Temps dépassé lors de la génération du quiz';
+        status = HTTP_STATUS.SERVICE_UNAVAILABLE;
+      } else if (error.code === ERROR_CODES.QUOTA_EXCEEDED) {
+        message = 'Quota IA dépassé, réessayez plus tard';
+        status = HTTP_STATUS.RATE_LIMIT;
+      }
+      const { response, statusCode } = createResponse(false, null, message, status, error.code);
       res.status(statusCode).json(response);
     }
   }
@@ -92,8 +110,17 @@ class AiController {
       const { response } = createResponse(true, { suggestions });
       res.json(response);
     } catch (error) {
-      logger.error('Erreur suggestions questions', error);
-      const { response, statusCode } = createResponse(false, null, ERROR_MESSAGES.SERVER_ERROR, HTTP_STATUS.SERVER_ERROR);
+      logger.error('Erreur suggestions questions', { error, code: error.code });
+      let message = ERROR_MESSAGES.SERVER_ERROR;
+      let status = HTTP_STATUS.SERVER_ERROR;
+      if (error.code === ERROR_CODES.IA_TIMEOUT) {
+        message = 'Temps dépassé lors de la génération des suggestions';
+        status = HTTP_STATUS.SERVICE_UNAVAILABLE;
+      } else if (error.code === ERROR_CODES.QUOTA_EXCEEDED) {
+        message = 'Quota IA dépassé, réessayez plus tard';
+        status = HTTP_STATUS.RATE_LIMIT;
+      }
+      const { response, statusCode } = createResponse(false, null, message, status, error.code);
       res.status(statusCode).json(response);
     }
   }

--- a/backend/src/utils/constants.js
+++ b/backend/src/utils/constants.js
@@ -54,6 +54,13 @@ const LIMITS = {
   MAX_HISTORY_ITEMS: 50
 };
 
+// Codes d'erreur spécifiques à l'IA
+const ERROR_CODES = {
+  IA_TIMEOUT: 'IA_TIMEOUT',
+  QUOTA_EXCEEDED: 'QUOTA_EXCEEDED',
+  IA_ERROR: 'IA_ERROR'
+};
+
 // Quotas de rate limiting par type de route
 const RATE_LIMITS = {
   AI: {
@@ -90,7 +97,8 @@ const HTTP_STATUS = {
   FORBIDDEN: 403,
   NOT_FOUND: 404,
   RATE_LIMIT: 429,
-  SERVER_ERROR: 500
+  SERVER_ERROR: 500,
+  SERVICE_UNAVAILABLE: 503
 };
 
 module.exports = {
@@ -101,6 +109,7 @@ module.exports = {
   RATE_LIMITS,
   ERROR_MESSAGES,
   HTTP_STATUS,
+  ERROR_CODES,
   STYLES,
   DURATIONS,
   INTENTS

--- a/backend/src/utils/helpers.js
+++ b/backend/src/utils/helpers.js
@@ -2,7 +2,7 @@
 const { ERROR_MESSAGES, HTTP_STATUS, STYLES, DURATIONS, INTENTS } = require('./constants');
 
 // Formatage de réponse standardisé
-const createResponse = (success, data = null, error = null, statusCode = HTTP_STATUS.OK) => {
+const createResponse = (success, data = null, error = null, statusCode = HTTP_STATUS.OK, code = null) => {
   const response = { success };
   
   if (success && data) {
@@ -13,10 +13,15 @@ const createResponse = (success, data = null, error = null, statusCode = HTTP_ST
     }
   }
   
-  if (!success && error) {
-    response.error = error;
+  if (!success) {
+    if (error) {
+      response.error = error;
+    }
+    if (code) {
+      response.code = code;
+    }
   }
-  
+
   return { response, statusCode };
 };
 


### PR DESCRIPTION
## Summary
- categorize Anthropics API errors and expose IA_TIMEOUT/QUOTA_EXCEEDED codes
- surface AI error codes in controllers and frontend with contextual messages
- add retry/save UI actions for quota and timeout responses

## Testing
- `npm test --prefix backend` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689dec602b808325a98dfcec1e5f22c8