### PR TITLE
feat: harden production server

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -4,8 +4,8 @@
   "description": "Backend pour l'application Noza",
   "main": "server.js",
   "scripts": {
-    "start": "node server.js",
-    "dev": "nodemon server.js",
+    "start": "node scripts/check-env.js && node server.js",
+    "dev": "node scripts/check-env.js && nodemon server.js",
     "postinstall": "prisma generate",
     "migrate": "node scripts/check-migrations.js",
     "db:reset": "npx prisma migrate reset --force",

--- a/backend/scripts/check-env.js
+++ b/backend/scripts/check-env.js
@@ -1,0 +1,66 @@
+// backend/scripts/check-env.js
+// Vérifie la présence des variables d'environnement sensibles et
+// s'assure qu'elles ne proviennent pas d'un fichier suivi par git.
+
+require('dotenv').config();
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+const { logger } = require('../src/utils/helpers');
+
+// Vérifie si un fichier est suivi par git
+function isTracked(file, cwd) {
+  try {
+    execSync(`git ls-files --error-unmatch ${file}`, { stdio: 'ignore', cwd });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function checkEnv() {
+  const repoRoot = path.resolve(__dirname, '..', '..');
+  const backendRoot = path.resolve(__dirname, '..');
+
+  // Refuser si un fichier .env suivi est présent dans le dépôt
+  const envFiles = [
+    path.join(repoRoot, '.env'),
+    path.join(backendRoot, '.env'),
+  ];
+
+  for (const file of envFiles) {
+    if (fs.existsSync(file) && isTracked(path.relative(repoRoot, file), repoRoot)) {
+      logger.error(`Le fichier ${file} est suivi par git. Retirez les secrets du dépôt.`);
+      process.exit(1);
+    }
+  }
+
+  const required = ['DATABASE_URL', 'JWT_SECRET'];
+  if (process.env.NODE_ENV === 'production') {
+    required.push('TLS_CERT_PATH', 'TLS_KEY_PATH');
+  }
+
+  const missing = required.filter((v) => !process.env[v]);
+  if (missing.length) {
+    logger.error(`Variables d'environnement manquantes: ${missing.join(', ')}`);
+    process.exit(1);
+  }
+
+  if (!process.env.ANTHROPIC_API_KEY) {
+    logger.warn('ANTHROPIC_API_KEY non défini. Fonctionnalités IA désactivées.');
+  }
+
+  logger.success('Variables d\'environnement vérifiées.');
+}
+
+if (require.main === module) {
+  try {
+    checkEnv();
+  } catch (err) {
+    logger.error('Erreur lors de la vérification des variables d\'environnement', err);
+    process.exit(1);
+  }
+}
+
+module.exports = { checkEnv };
+

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,48 +1,39 @@
 // backend/server.js
 require('dotenv').config();
+const fs = require('fs');
+const http = require('http');
+const https = require('https');
 const { app, initializeApp } = require('./src/app');
 const { logger } = require('./src/utils/helpers');
 const { disconnectDatabase } = require('./src/config/database');
+const { checkEnv } = require('./scripts/check-env');
 // const { ensureMigrations } = require('./scripts/check-migrations');
 
-const PORT = process.env.PORT || 3000;
+const HTTP_PORT = process.env.PORT || 3000;
+const HTTPS_PORT = process.env.HTTPS_PORT || 3443;
 let server;
-
-// Vérification des variables d'environnement requises
-const validateEnv = () => {
-  let hasError = false;
-
-  if (!process.env.DATABASE_URL) {
-    logger.error('DATABASE_URL non défini. Impossible de démarrer le serveur.');
-    hasError = true;
-  }
-  if (!process.env.JWT_SECRET) {
-    logger.error('JWT_SECRET non défini. Impossible de démarrer le serveur.');
-    hasError = true;
-  }
-  if (!process.env.ANTHROPIC_API_KEY) {
-    logger.warn('ANTHROPIC_API_KEY non défini. Fonctionnalités IA désactivées.');
-  }
-
-  if (hasError) {
-    process.exit(1);
-  }
-};
+let httpRedirectServer;
 
 // Gestion propre de l'arrêt
 const gracefulShutdown = async (signal) => {
   logger.info(`${signal} reçu. Arrêt en cours...`);
 
-  if (server) {
-    server.close(async () => {
-      logger.info('Serveur HTTP fermé');
-      await disconnectDatabase();
-      process.exit(0);
+  const closeServer = (srv, name) =>
+    new Promise((resolve) => {
+      if (!srv) return resolve();
+      srv.close(() => {
+        logger.info(`Serveur ${name} fermé`);
+        resolve();
+      });
     });
-  } else {
-    await disconnectDatabase();
-    process.exit(0);
-  }
+
+  await Promise.all([
+    closeServer(server, 'principal HTTPS'),
+    closeServer(httpRedirectServer, 'HTTP'),
+  ]);
+
+  await disconnectDatabase();
+  process.exit(0);
 };
 
 process.on('SIGTERM', () => gracefulShutdown('SIGTERM'));
@@ -51,7 +42,8 @@ process.on('SIGINT', () => gracefulShutdown('SIGINT'));
 // Démarrage du serveur
 const startServer = async () => {
   try {
-    validateEnv();
+    // Vérifier les variables d'environnement
+    checkEnv();
 
     // Vérifier et appliquer les migrations
     logger.info('Vérification des migrations de base de données...');
@@ -60,23 +52,32 @@ const startServer = async () => {
     // Initialiser l'application (DB, etc.)
     await initializeApp();
 
-    // Démarrer le serveur
-    server = app.listen(PORT, '0.0.0.0', () => {
-      logger.success(`🚀 Serveur démarré sur 0.0.0.0:${PORT}`);
-      logger.info(`🔧 API disponible sur le port ${PORT}`);
-      logger.info(`📚 Routes disponibles:`);
-      logger.info(`   - GET  /api/health`);
-      logger.info(`   - POST /api/auth/register`);
-      logger.info(`   - POST /api/auth/login`);
-      logger.info(`   - GET  /api/auth/profile`);
-      logger.info(`   - GET  /api/courses`);
-      logger.info(`   - POST /api/courses`);
-      logger.info(`   - GET  /api/courses/:id`);
-      logger.info(`   - DELETE /api/courses/:id`);
-      logger.info(`   - POST /api/ai/ask-question`);
-      logger.info(`   - POST /api/ai/generate-quiz`);
-      logger.info(`   - POST /api/ai/suggest-questions`);
-    });
+    if (process.env.NODE_ENV === 'production') {
+      const certPath = process.env.TLS_CERT_PATH;
+      const keyPath = process.env.TLS_KEY_PATH;
+
+      const credentials = {
+        cert: fs.readFileSync(certPath),
+        key: fs.readFileSync(keyPath),
+      };
+
+      server = https.createServer(credentials, app).listen(HTTPS_PORT, '0.0.0.0', () => {
+        logger.success(`🚀 Serveur HTTPS démarré sur 0.0.0.0:${HTTPS_PORT}`);
+      });
+
+      httpRedirectServer = http
+        .createServer((req, res) => {
+          res.writeHead(301, { Location: `https://${req.headers.host}${req.url}` });
+          res.end();
+        })
+        .listen(HTTP_PORT, '0.0.0.0', () => {
+          logger.info(`Redirection HTTP active sur le port ${HTTP_PORT}`);
+        });
+    } else {
+      server = app.listen(HTTP_PORT, '0.0.0.0', () => {
+        logger.success(`🚀 Serveur démarré sur 0.0.0.0:${HTTP_PORT}`);
+      });
+    }
   } catch (error) {
     logger.error('Erreur démarrage serveur', error);
     process.exit(1);

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -13,6 +13,17 @@ const apiRoutes = require('./routes');
 
 const app = express();
 
+// Permet de faire confiance aux en-têtes du proxy (utile pour HTTPS derrière un proxy)
+app.enable('trust proxy');
+
+// Redirection HTTP -> HTTPS en production
+app.use((req, res, next) => {
+  if (process.env.NODE_ENV === 'production' && !req.secure) {
+    return res.redirect(`https://${req.headers.host}${req.url}`);
+  }
+  next();
+});
+
 // ⭐ MODIFIÉ : Configuration Helmet avec CSP personnalisé
 app.use(
   helmet({

--- a/backend/src/controllers/authController.js
+++ b/backend/src/controllers/authController.js
@@ -43,12 +43,19 @@ class AuthController {
 
       const token = generateToken(user.id);
 
+      // Définir le cookie d'authentification avec les attributs sécurisés
+      res.cookie('token', token, {
+        httpOnly: true,
+        secure: process.env.NODE_ENV === 'production',
+        sameSite: 'strict',
+      });
+
       logger.success('Nouvel utilisateur créé', { userId: user.id, email: user.email });
 
       const { response, statusCode } = createResponse(true, {
         message: 'Compte créé avec succès',
         user,
-        token
+        token,
       }, null, HTTP_STATUS.CREATED);
 
       res.status(statusCode).json(response);
@@ -76,6 +83,13 @@ class AuthController {
       }
 
       const token = generateToken(user.id);
+
+      // Définir le cookie d'authentification avec les attributs sécurisés
+      res.cookie('token', token, {
+        httpOnly: true,
+        secure: process.env.NODE_ENV === 'production',
+        sameSite: 'strict',
+      });
 
       logger.info('Connexion utilisateur', { userId: user.id, email: user.email });
 
@@ -180,6 +194,13 @@ class AuthController {
 
       // Générer notre JWT
       const token = generateToken(user.id);
+
+      // Définir le cookie d'authentification avec les attributs sécurisés
+      res.cookie('token', token, {
+        httpOnly: true,
+        secure: process.env.NODE_ENV === 'production',
+        sameSite: 'strict',
+      });
 
       const { response } = createResponse(true, {
         message: 'Connexion Google réussie',


### PR DESCRIPTION
## Summary
- use Node https server in production and redirect HTTP to HTTPS
- mark auth cookies as secure and httpOnly
- verify required env vars before start and block committed secrets

## Testing
- `DATABASE_URL=foo JWT_SECRET=bar node backend/scripts/check-env.js`
- `node --test backend/tests/**/*.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689def8e6dec83258c7ed48908c81b91