### PR TITLE
feat: centralize loading UI handling

### DIFF
--- a/frontend/assets/css/main.css
+++ b/frontend/assets/css/main.css
@@ -1567,6 +1567,23 @@ body::before {
     margin-right: 15px;
 }
 
+.loading-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.4);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+}
+
+.loading-overlay .loading-spinner {
+    margin-right: 0;
+}
+
 .empty-state {
     text-align: center;
     padding: 80px 20px;

--- a/frontend/assets/js/course.js
+++ b/frontend/assets/js/course.js
@@ -50,6 +50,7 @@ class CourseManager {
 
   // Générer un cours
   async generateCourse(subject, style, duration, intent) {
+    utils.showLoading(['generateBtn', 'generateQuiz', 'copyContent', 'exportPdf', 'exportDocx']);
     try {
       const payload = {
         subject: utils.sanitizeInput(subject, 500)
@@ -97,6 +98,42 @@ class CourseManager {
       console.error('Erreur:', error);
       utils.handleAuthError('Erreur lors de la génération du cours: ' + error.message, true);
       throw error;
+    } finally {
+      utils.hideLoading(['generateBtn', 'generateQuiz', 'copyContent', 'exportPdf', 'exportDocx']);
+    }
+  }
+
+  async generateQuiz() {
+    if (!this.currentCourse) {
+      utils.handleAuthError("Veuillez d'abord générer un cours");
+      return null;
+    }
+
+    utils.showLoading(['generateQuiz']);
+    try {
+      const response = await fetch(`${API_BASE_URL}/ai/generate-quiz`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          ...authManager.getAuthHeaders()
+        },
+        body: JSON.stringify({ courseContent: this.currentCourse.content })
+      });
+
+      const data = await response.json();
+
+      if (data.success && data.quiz) {
+        utils.showNotification('Quiz généré avec succès !', 'success');
+        return data.quiz;
+      } else {
+        throw new Error(data.error || 'Erreur lors de la génération du quiz');
+      }
+    } catch (error) {
+      console.error('Erreur génération quiz:', error);
+      utils.handleAuthError('Erreur lors de la génération du quiz: ' + error.message, true);
+      throw error;
+    } finally {
+      utils.hideLoading(['generateQuiz']);
     }
   }
 
@@ -234,3 +271,4 @@ class CourseManager {
 
 // Instance globale
 window.courseManager = new CourseManager();
+

--- a/frontend/assets/js/main.js
+++ b/frontend/assets/js/main.js
@@ -63,10 +63,6 @@ async function handleGenerateCourse() {
         return;
     }
 
-    const generateBtn = document.getElementById('generateBtn');
-    generateBtn.disabled = true;
-    generateBtn.innerHTML = '<div class="loading-spinner"></div>Génération en cours...';
-
     try {
         if (courseManager) {
             const course = await courseManager.generateCourse(
@@ -94,8 +90,6 @@ async function handleGenerateCourse() {
             }
         }
     } finally {
-        generateBtn.disabled = false;
-        generateBtn.innerHTML = '<i data-lucide="sparkles"></i>Décrypter le sujet';
         utils.initializeLucide();
     }
 }
@@ -341,35 +335,13 @@ async function handleGenerateQuiz() {
         return;
     }
 
-    const quizBtn = document.getElementById('generateQuiz');
-    quizBtn.disabled = true;
-    quizBtn.innerHTML = '<div class="loading-spinner"></div>Génération du quiz...';
-
     try {
-        const response = await fetch(`${API_BASE_URL}/ai/generate-quiz`, {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-                ...authManager.getAuthHeaders()
-            },
-            body: JSON.stringify({ courseContent: courseManager.currentCourse.content })
-        });
-
-        const data = await response.json();
-
-        if (data.success && data.quiz) {
-            currentQuiz = data.quiz;
-            displayQuiz(data.quiz);
-            utils.showNotification('Quiz généré avec succès !', 'success');
-        } else {
-            throw new Error(data.error || 'Erreur lors de la génération du quiz');
+        const quiz = await courseManager.generateQuiz();
+        if (quiz) {
+            currentQuiz = quiz;
+            displayQuiz(quiz);
         }
-    } catch (error) {
-        console.error('Erreur génération quiz:', error);
-        utils.handleAuthError('Erreur lors de la génération du quiz: ' + error.message, true);
     } finally {
-        quizBtn.disabled = false;
-        quizBtn.innerHTML = '<i data-lucide="help-circle"></i>Quiz';
         utils.initializeLucide();
     }
 }

--- a/frontend/assets/js/utils.js
+++ b/frontend/assets/js/utils.js
@@ -41,6 +41,27 @@ const utils = {
       .substring(0, maxLength);
   },
 
+  // Gestion du chargement global et des boutons
+  showLoading(buttonIds = []) {
+    const loader = document.getElementById('loadingOverlay');
+    if (loader) loader.style.display = 'flex';
+
+    buttonIds.forEach(id => {
+      const btn = document.getElementById(id);
+      if (btn) btn.disabled = true;
+    });
+  },
+
+  hideLoading(buttonIds = []) {
+    const loader = document.getElementById('loadingOverlay');
+    if (loader) loader.style.display = 'none';
+
+    buttonIds.forEach(id => {
+      const btn = document.getElementById(id);
+      if (btn) btn.disabled = false;
+    });
+  },
+
   // Gestion unifiée des erreurs d'authentification
   handleAuthError(message, critical = false) {
     console.error(message);

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -11,6 +11,9 @@
     <link rel="stylesheet" href="assets/css/main.css">
 </head>
 <body>
+    <div id="loadingOverlay" class="loading-overlay" style="display:none;">
+        <div class="loading-spinner"></div>
+    </div>
     <div class="container">
         <header class="header">
             <h1>Science+</h1>


### PR DESCRIPTION
## Summary
- add global loading overlay and utilities
- use loading utilities for course and quiz generation

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689df2152a4483259571613cfa78cced