### PR TITLE
feat: paginate courses and add db index

### DIFF
--- a/backend/docs/api.md
+++ b/backend/docs/api.md
@@ -1,5 +1,19 @@
 # Course API
 
+## GET /api/courses
+
+Returns the authenticated user's courses ordered from newest to oldest.
+
+### Query parameters
+- `page` (integer, optional): page number, default `1`.
+- `limit` (integer, optional): number of courses per page, default `10`, max `50`.
+
+### Example
+```
+GET /api/courses?page=2&limit=10
+Authorization: Bearer <token>
+```
+
 ## POST /api/courses
 
 Creates a new course for the authenticated user.

--- a/backend/prisma/migrations/20240722100000_add_user_createdAt_index/migration.sql
+++ b/backend/prisma/migrations/20240722100000_add_user_createdAt_index/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE INDEX "courses_userId_createdAt_idx" ON "courses"("userId","createdAt");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -41,8 +41,9 @@ model Course {
   user               User     @relation(fields: [userId], references: [id], onDelete: Cascade)
   
   chatHistories      ChatHistory[]
-  
+
   @@map("courses")
+  @@index([userId, createdAt])
 }
 
 model ChatHistory {

--- a/backend/src/routes/courses.js
+++ b/backend/src/routes/courses.js
@@ -2,8 +2,10 @@
 const express = require('express');
 const courseController = require('../controllers/courseController');
 const { authenticate } = require('../middleware/auth');
-const { courseValidation } = require('../middleware/validation');
+const { courseValidation, handleValidationErrors } = require('../middleware/validation');
 const { asyncHandler } = require('../utils/helpers');
+const { query } = require('express-validator');
+const { LIMITS } = require('../utils/constants');
 
 const router = express.Router();
 
@@ -11,7 +13,15 @@ const router = express.Router();
 router.use(authenticate);
 
 // CRUD des cours
-router.get('/', asyncHandler(courseController.getAllCourses));
+router.get(
+  '/',
+  [
+    query('page').optional().isInt({ min: 1 }).toInt(),
+    query('limit').optional().isInt({ min: 1, max: LIMITS.MAX_HISTORY_ITEMS }).toInt(),
+    handleValidationErrors
+  ],
+  asyncHandler(courseController.getAllCourses)
+);
 router.get('/:id', asyncHandler(courseController.getCourse));
 router.post('/', courseValidation, asyncHandler(courseController.generateCourse));
 router.delete('/:id', asyncHandler(courseController.deleteCourse));


### PR DESCRIPTION
## Summary
- support page and limit for course history with Prisma skip/take
- document and expose pagination parameters
- add user/course index and frontend pagination controls

## Testing
- `node --test`
- `npx prisma migrate dev --name add_user_createdAt_index --create-only` *(fails: Can't reach database server at `localhost:5432`)*

------
https://chatgpt.com/codex/tasks/task_e_689df554689083258568a3cacb63cdbb