### PR TITLE
feat: support unicode in sanitizeInput

### DIFF
--- a/backend/src/utils/helpers.js
+++ b/backend/src/utils/helpers.js
@@ -75,7 +75,7 @@ const sanitizeInput = (input, maxLength = 10000) => {
 
   return input
     .trim()
-    .replace(/[^a-zA-Z0-9 _\n\r.,!?;:'"()\[\]{}-]/g, '')
+    .replace(/[^\p{L}0-9 _\n\r.,!?;:'"()\[\]{}-]/gu, '')
     .substring(0, maxLength);
 };
 

--- a/backend/tests/utils/helpers.test.js
+++ b/backend/tests/utils/helpers.test.js
@@ -1,0 +1,21 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const { sanitizeInput } = require('../../src/utils/helpers');
+
+test('sanitizeInput preserves accented letters', () => {
+  const input = 'Café élève déjà naïve';
+  const result = sanitizeInput(input);
+  assert.strictEqual(result, input);
+});
+
+test('sanitizeInput removes disallowed characters', () => {
+  const input = 'Bonjour! 😊';
+  const result = sanitizeInput(input);
+  assert.strictEqual(result, 'Bonjour! ');
+});
+
+test('sanitizeInput respects maxLength with unicode', () => {
+  const input = 'É'.repeat(10);
+  const result = sanitizeInput(input, 5);
+  assert.strictEqual(result, 'É'.repeat(5));
+});

--- a/frontend/assets/js/utils.js
+++ b/frontend/assets/js/utils.js
@@ -37,7 +37,7 @@ const utils = {
     if (typeof input !== 'string') return input;
     return input
       .trim()
-      .replace(/[^a-zA-Z0-9 _\n\r.,!?;:'"()\[\]{}-]/g, '')
+      .replace(/[^\p{L}0-9 _\n\r.,!?;:'"()\[\]{}-]/gu, '')
       .substring(0, maxLength);
   },
 


### PR DESCRIPTION
## Summary
- allow accented characters in sanitizeInput regex
- add unit tests covering accent handling and unicode truncation

## Testing
- `cd backend && node --test`


------
https://chatgpt.com/codex/tasks/task_e_689e007de22c8325a4fe6e49d63ab0fc