### PR TITLE
chore: default backend to dev and document TLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,14 @@ The `POST /api/courses` endpoint now supports the following parameters:
 ```
 
 Legacy clients may continue to send `detailLevel` and `vulgarizationLevel`. These fields remain supported for backward compatibility but will be removed in a future release.
+
+## Running the Server
+
+`npm start` launches the backend with `NODE_ENV` defaulting to `development`, which runs the API over plain HTTP and does not require TLS certificates.
+
+For production deployments you must:
+
+- set `NODE_ENV=production`
+- provide paths to your TLS files via `TLS_CERT_PATH` and `TLS_KEY_PATH`
+
+With these variables defined the server starts in HTTPS mode. Without them the start script keeps the server in HTTP mode, suitable for local development or environments without TLS.

--- a/backend/package.json
+++ b/backend/package.json
@@ -4,7 +4,7 @@
   "description": "Backend pour l'application Noza",
   "main": "server.js",
   "scripts": {
-    "start": "node scripts/check-env.js && node server.js",
+    "start": "NODE_ENV=${NODE_ENV:-development} node scripts/check-env.js && node server.js",
     "dev": "node scripts/check-env.js && nodemon server.js",
     "postinstall": "prisma generate",
     "migrate": "node scripts/check-migrations.js",


### PR DESCRIPTION
## Summary
- default backend start script to NODE_ENV=development when unspecified
- document production TLS variables and default HTTP mode

## Testing
- `npm test`
- `GOOGLE_CLIENT_ID="fake" ANTHROPIC_API_KEY="fake" DATABASE_URL="postgresql://user:pass@localhost:5432/postgres" JWT_SECRET="secret" npm start`


------
https://chatgpt.com/codex/tasks/task_e_689e061ff2dc83258c317a04c6afe425