### PR TITLE
refactor: centralize input sanitization

### DIFF
--- a/backend/src/utils/helpers.js
+++ b/backend/src/utils/helpers.js
@@ -69,7 +69,10 @@ const mapLegacyParams = ({ detailLevel, vulgarizationLevel, style, duration, int
   };
 };
 
-// Sanitisation des entrées avec whitelist
+// Sanitisation des entrées avec whitelist.
+// This logic mirrors frontend/assets/js/shared/sanitize.js to ensure
+// consistent behavior between client and server. Update both places
+// if the allowed characters or processing steps change.
 const sanitizeInput = (input, maxLength = 10000) => {
   if (typeof input !== 'string') return input;
 

--- a/frontend/assets/js/shared/sanitize.js
+++ b/frontend/assets/js/shared/sanitize.js
@@ -1,0 +1,18 @@
+/**
+ * Sanitize user-provided input while preserving accented and other Unicode letters.
+ * This logic is mirrored in backend/src/utils/helpers.js; update both places when
+ * changing the allowed character set or behavior.
+ *
+ * @param {string} input - The raw input string to clean.
+ * @param {number} [maxLength=10000] - Maximum length of the returned string.
+ * @returns {string} The sanitized string limited to the specified length.
+ */
+export function sanitizeInput(input, maxLength = 10000) {
+  if (typeof input !== 'string') return input;
+  return input
+    .trim()
+    .replace(/[^\p{L}0-9 _\n\r.,!?;:'"()\[\]{}-]/gu, '')
+    .substring(0, maxLength);
+}
+
+export default sanitizeInput;

--- a/frontend/assets/js/utils.js
+++ b/frontend/assets/js/utils.js
@@ -1,5 +1,7 @@
 // frontend/assets/js/utils.js
 
+import { sanitizeInput } from './shared/sanitize.js'; // Shared sanitization logic
+
 // Configuration API
 const API_BASE_URL = window.location.origin + '/api';
 
@@ -33,13 +35,7 @@ const utils = {
   },
 
   // Sanitisation avec whitelist
-  sanitizeInput(input, maxLength = 10000) {
-    if (typeof input !== 'string') return input;
-    return input
-      .trim()
-      .replace(/[^\p{L}0-9 _\n\r.,!?;:'"()\[\]{}-]/gu, '')
-      .substring(0, maxLength);
-  },
+  sanitizeInput,
 
   // Gestion du chargement global et des boutons
   showLoading(buttonIds = []) {


### PR DESCRIPTION
## Summary
- add shared sanitizeInput module to frontend and document its usage
- import shared sanitization in utils and remove inline version
- mirror sanitization logic in backend helpers for parity

## Testing
- `node --test tests/utils/helpers.test.js tests/controllers/courseController.test.js tests/services/anthropicService.test.js`

------
https://chatgpt.com/codex/tasks/task_e_689e08993b148325a06169179b74fa62