### PR TITLE
feat: support cookie-based auth

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -20,7 +20,8 @@
         "google-auth-library": "^10.2.1",
         "helmet": "^7.0.0",
         "jsonwebtoken": "^9.0.2",
-        "prisma": "^6.13.0"
+        "prisma": "^6.13.0",
+        "cookie-parser": "^1.4.6"
       },
       "devDependencies": {
         "nodemon": "^3.0.1"

--- a/backend/package.json
+++ b/backend/package.json
@@ -23,7 +23,8 @@
     "google-auth-library": "^10.2.1",
     "helmet": "^7.0.0",
     "jsonwebtoken": "^9.0.2",
-    "prisma": "^6.13.0"
+    "prisma": "^6.13.0",
+    "cookie-parser": "^1.4.6"
   },
   "devDependencies": {
     "nodemon": "^3.0.1"

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -4,6 +4,7 @@ const cors = require('cors');
 const helmet = require('helmet');
 const rateLimit = require('express-rate-limit');
 const path = require('path');
+const cookieParser = require('cookie-parser');
 const { connectDatabase } = require('./config/database');
 const { logger } = require('./utils/helpers');
 const { LIMITS } = require('./utils/constants');
@@ -114,6 +115,7 @@ app.use('/api/', limiter);
 // Middleware pour parser JSON
 app.use(express.json({ limit: '10mb' }));
 app.use(express.urlencoded({ extended: true }));
+app.use(cookieParser());
 
 // Servir les fichiers statiques du frontend
 app.use(express.static(path.join(__dirname, '../../frontend')));

--- a/backend/src/middleware/auth.js
+++ b/backend/src/middleware/auth.js
@@ -7,9 +7,12 @@ const { ERROR_MESSAGES, HTTP_STATUS } = require('../utils/constants');
 // Middleware pour vérifier si l'utilisateur est connecté
 const authenticate = async (req, res, next) => {
   try {
-    // Récupérer le token depuis l'en-tête Authorization
-    const token = req.header('Authorization')?.replace('Bearer ', '');
-    
+    // Récupérer le token depuis l'en-tête Authorization ou les cookies
+    let token = req.header('Authorization')?.replace('Bearer ', '');
+    if (!token) {
+      token = req.cookies?.token;
+    }
+
     if (!token) {
       const { response, statusCode } = createResponse(false, null, ERROR_MESSAGES.UNAUTHORIZED, HTTP_STATUS.UNAUTHORIZED);
       return res.status(statusCode).json(response);

--- a/backend/tests/middleware/auth.test.js
+++ b/backend/tests/middleware/auth.test.js
@@ -1,0 +1,59 @@
+process.env.JWT_SECRET = 'test-secret';
+process.env.DATABASE_URL = 'postgresql://user:pass@localhost:5432/test';
+
+const test = require('node:test');
+const assert = require('node:assert');
+
+const { prisma } = require('../../src/config/database');
+const { generateToken } = require('../../src/utils/auth');
+const { authenticate } = require('../../src/middleware/auth');
+
+test('authenticate uses token from cookies when Authorization header missing', async () => {
+  const fakeUser = { id: 1, email: 'user@example.com', name: 'Test User' };
+  prisma.user.findUnique = async () => fakeUser;
+
+  const token = generateToken(fakeUser.id);
+
+  const req = {
+    header: () => undefined,
+    cookies: { token }
+  };
+
+  const res = {
+    statusCode: 0,
+    status(code) { this.statusCode = code; return this; },
+    json() { }
+  };
+
+  let called = false;
+  const next = () => { called = true; };
+
+  await authenticate(req, res, next);
+
+  assert.strictEqual(called, true);
+  assert.deepStrictEqual(req.user, fakeUser);
+});
+
+test('authenticate rejects when no token provided in header or cookies', async () => {
+  const req = {
+    header: () => undefined,
+    cookies: {}
+  };
+
+  let jsonBody;
+  const res = {
+    statusCode: 0,
+    status(code) { this.statusCode = code; return this; },
+    json(body) { jsonBody = body; }
+  };
+
+  let called = false;
+  const next = () => { called = true; };
+
+  await authenticate(req, res, next);
+
+  assert.strictEqual(called, false);
+  assert.strictEqual(res.statusCode, 401);
+  assert.ok(jsonBody.error);
+});
+


### PR DESCRIPTION
## Summary
- integrate cookie-parser middleware and enable cookie parsing
- fall back to JWT token from cookies when Authorization header is missing
- add tests for cookie-based authentication

## Testing
- `node --test backend/tests/**/*.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689e0bdecc6083258c96acd569eea3db