### PR TITLE
feat: allow http mode

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,9 @@
+# Backend
+
+## Environment variables
+
+The backend uses `scripts/check-env.js` to ensure required configuration is present before the server starts.
+
+### TLS configuration
+
+In `production` mode the server expects `TLS_CERT_PATH` and `TLS_KEY_PATH` to start in HTTPS. Set `ALLOW_HTTP=true` to bypass this check and run the server over plain HTTP. This flag defaults to `false` and should only be used for development or testing.

--- a/backend/scripts/check-env.js
+++ b/backend/scripts/check-env.js
@@ -36,8 +36,11 @@ function checkEnv() {
   }
 
   const required = ['DATABASE_URL', 'JWT_SECRET'];
-  if (process.env.NODE_ENV === 'production') {
+  const allowHttp = process.env.ALLOW_HTTP === 'true';
+  if (process.env.NODE_ENV === 'production' && !allowHttp) {
     required.push('TLS_CERT_PATH', 'TLS_KEY_PATH');
+  } else if (process.env.NODE_ENV === 'production' && allowHttp) {
+    logger.warn('ALLOW_HTTP activé: démarrage sans TLS.');
   }
 
   const missing = required.filter((v) => !process.env[v]);

--- a/backend/server.js
+++ b/backend/server.js
@@ -13,6 +13,7 @@ const HTTP_PORT = process.env.PORT || 3000;
 const HTTPS_PORT = process.env.HTTPS_PORT || 3443;
 let server;
 let httpRedirectServer;
+const allowHttp = process.env.ALLOW_HTTP === 'true';
 
 // Gestion propre de l'arrêt
 const gracefulShutdown = async (signal) => {
@@ -52,7 +53,7 @@ const startServer = async () => {
     // Initialiser l'application (DB, etc.)
     await initializeApp();
 
-    if (process.env.NODE_ENV === 'production') {
+    if (process.env.NODE_ENV === 'production' && !allowHttp) {
       const certPath = process.env.TLS_CERT_PATH;
       const keyPath = process.env.TLS_KEY_PATH;
 
@@ -74,6 +75,9 @@ const startServer = async () => {
           logger.info(`Redirection HTTP active sur le port ${HTTP_PORT}`);
         });
     } else {
+      if (process.env.NODE_ENV === 'production' && allowHttp) {
+        logger.warn('ALLOW_HTTP activé: serveur démarré en HTTP sans TLS.');
+      }
       server = app.listen(HTTP_PORT, '0.0.0.0', () => {
         logger.success(`🚀 Serveur démarré sur 0.0.0.0:${HTTP_PORT}`);
       });

--- a/backend/tests/scripts/check-env.test.js
+++ b/backend/tests/scripts/check-env.test.js
@@ -1,0 +1,19 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const { spawnSync } = require('child_process');
+const path = require('path');
+
+test('allows startup without TLS when ALLOW_HTTP is set', () => {
+  const result = spawnSync('node', [path.join(__dirname, '../../scripts/check-env.js')], {
+    cwd: path.join(__dirname, '../../'),
+    env: {
+      ...process.env,
+      NODE_ENV: 'production',
+      DATABASE_URL: 'postgres://user:pass@localhost:5432/db',
+      JWT_SECRET: 'secret',
+      ALLOW_HTTP: 'true',
+      NODE_PATH: path.join(__dirname, '../../node_modules')
+    },
+  });
+  assert.strictEqual(result.status, 0, result.stderr.toString());
+});


### PR DESCRIPTION
## Summary
- allow bypassing TLS requirements in check-env.js via ALLOW_HTTP
- support HTTP server start in production when ALLOW_HTTP=true
- document ALLOW_HTTP flag and add integration test

## Testing
- `node --test` *(fails: Cannot find module '@prisma/client', dotenv)*

------
https://chatgpt.com/codex/tasks/task_e_689e0d692e408325b0de939be6948b57