### PR TITLE
Use sanitize-html for Unicode-aware sanitization

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -15,6 +15,7 @@
     "@anthropic-ai/sdk": "^0.24.3",
     "@prisma/client": "^6.13.0",
     "bcryptjs": "^3.0.2",
+    "cookie-parser": "^1.4.6",
     "cors": "^2.8.5",
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
@@ -24,7 +25,7 @@
     "helmet": "^7.0.0",
     "jsonwebtoken": "^9.0.2",
     "prisma": "^6.13.0",
-    "cookie-parser": "^1.4.6"
+    "sanitize-html": "^2.10.0"
   },
   "devDependencies": {
     "nodemon": "^3.0.1"

--- a/backend/src/utils/helpers.js
+++ b/backend/src/utils/helpers.js
@@ -1,5 +1,6 @@
 // backend/src/utils/helpers.js
 const { ERROR_MESSAGES, HTTP_STATUS, STYLES, DURATIONS, INTENTS } = require('./constants');
+const sanitizeHtml = require('sanitize-html');
 
 // Formatage de réponse standardisé
 const createResponse = (success, data = null, error = null, statusCode = HTTP_STATUS.OK, code = null) => {
@@ -69,16 +70,21 @@ const mapLegacyParams = ({ detailLevel, vulgarizationLevel, style, duration, int
   };
 };
 
-// Sanitisation des entrées avec whitelist.
-// This logic mirrors frontend/assets/js/shared/sanitize.js to ensure
-// consistent behavior between client and server. Update both places
-// if the allowed characters or processing steps change.
+// Sanitisation des entrées avec une bibliothèque dédiée.
+// This mirrors frontend/assets/js/shared/sanitize.js to maintain
+// consistent behavior across client and server. Update both places
+// if the allowed character set or processing steps change.
 const sanitizeInput = (input, maxLength = 10000) => {
   if (typeof input !== 'string') return input;
 
-  return input
+  const clean = sanitizeHtml(input, {
+    allowedTags: [],
+    allowedAttributes: {},
+  });
+
+  return clean
     .trim()
-    .replace(/[^\p{L}0-9 _\n\r.,!?;:'"()\[\]{}-]/gu, '')
+    .replace(/[^\p{L}\p{N}\p{P}\p{Zs}\n\r]/gu, '')
     .substring(0, maxLength);
 };
 

--- a/backend/tests/utils/helpers.test.js
+++ b/backend/tests/utils/helpers.test.js
@@ -8,7 +8,19 @@ test('sanitizeInput preserves accented letters', () => {
   assert.strictEqual(result, input);
 });
 
-test('sanitizeInput removes disallowed characters', () => {
+test('sanitizeInput preserves multilingual scripts and punctuation', () => {
+  const input = '你好，世界! — Привет! Café';
+  const result = sanitizeInput(input);
+  assert.strictEqual(result, input);
+});
+
+test('sanitizeInput strips HTML tags', () => {
+  const input = '<strong>Bold</strong> text';
+  const result = sanitizeInput(input);
+  assert.strictEqual(result, 'Bold text');
+});
+
+test('sanitizeInput removes emoji characters', () => {
   const input = 'Bonjour! 😊';
   const result = sanitizeInput(input);
   assert.strictEqual(result, 'Bonjour! ');

--- a/frontend/assets/js/shared/sanitize.js
+++ b/frontend/assets/js/shared/sanitize.js
@@ -1,5 +1,5 @@
 /**
- * Sanitize user-provided input while preserving accented and other Unicode letters.
+ * Sanitize user-provided input while preserving Unicode letters and punctuation.
  * This logic is mirrored in backend/src/utils/helpers.js; update both places when
  * changing the allowed character set or behavior.
  *
@@ -9,9 +9,11 @@
  */
 export function sanitizeInput(input, maxLength = 10000) {
   if (typeof input !== 'string') return input;
+
   return input
+    .replace(/<[^>]*>/g, '')
     .trim()
-    .replace(/[^\p{L}0-9 _\n\r.,!?;:'"()\[\]{}-]/gu, '')
+    .replace(/[^\p{L}\p{N}\p{P}\p{Zs}\n\r]/gu, '')
     .substring(0, maxLength);
 }
 

--- a/frontend/tests/sanitize.test.js
+++ b/frontend/tests/sanitize.test.js
@@ -1,0 +1,32 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const load = () => import('../assets/js/shared/sanitize.js');
+
+test('sanitizeInput preserves multilingual scripts and punctuation', async () => {
+  const { sanitizeInput } = await load();
+  const input = '你好，世界! — Привет! Café';
+  const result = sanitizeInput(input);
+  assert.strictEqual(result, input);
+});
+
+test('sanitizeInput strips HTML tags', async () => {
+  const { sanitizeInput } = await load();
+  const input = '<em>Italic</em> text';
+  const result = sanitizeInput(input);
+  assert.strictEqual(result, 'Italic text');
+});
+
+test('sanitizeInput removes emoji characters', async () => {
+  const { sanitizeInput } = await load();
+  const input = 'Bonjour! 😊';
+  const result = sanitizeInput(input);
+  assert.strictEqual(result, 'Bonjour! ');
+});
+
+test('sanitizeInput respects maxLength with unicode', async () => {
+  const { sanitizeInput } = await load();
+  const input = 'É'.repeat(10);
+  const result = sanitizeInput(input, 5);
+  assert.strictEqual(result, 'É'.repeat(5));
+});


### PR DESCRIPTION
## Summary
- Add `sanitize-html` dependency and use it in `sanitizeInput` with a punctuation-friendly Unicode whitelist.
- Mirror backend sanitization rules on the frontend and remove HTML tags.
- Extend backend and frontend tests to cover multilingual text, punctuation, and emoji handling.

## Testing
- `node --test backend/tests frontend/tests` *(fails: Cannot find module '@prisma/client', '@anthropic-ai/sdk', 'dotenv')*
- `node --test backend/tests/utils/helpers.test.js frontend/tests/sanitize.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689e102a75408325a050f8d192ceed02