### PR TITLE
Add tests for Google config route

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -28,7 +28,8 @@
     "sanitize-html": "^2.10.0"
   },
   "devDependencies": {
-    "nodemon": "^3.0.1"
+    "nodemon": "^3.0.1",
+    "supertest": "^6.3.3"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/backend/tests/routes/config.test.js
+++ b/backend/tests/routes/config.test.js
@@ -1,0 +1,35 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const request = require('supertest');
+const { app } = require('../../src/app');
+
+test('GET /api/config/google returns client ID when configured', async () => {
+  const originalClientId = process.env.GOOGLE_CLIENT_ID;
+  process.env.GOOGLE_CLIENT_ID = 'test-client-id';
+
+  const res = await request(app).get('/api/config/google');
+
+  assert.strictEqual(res.status, 200);
+  assert.deepStrictEqual(res.body, { clientId: 'test-client-id' });
+
+  if (originalClientId === undefined) {
+    delete process.env.GOOGLE_CLIENT_ID;
+  } else {
+    process.env.GOOGLE_CLIENT_ID = originalClientId;
+  }
+});
+
+test('GET /api/config/google returns error when client ID missing', async () => {
+  const originalClientId = process.env.GOOGLE_CLIENT_ID;
+  delete process.env.GOOGLE_CLIENT_ID;
+
+  const res = await request(app).get('/api/config/google');
+
+  assert.strictEqual(res.status, 500);
+  assert.deepStrictEqual(res.body, { error: 'Google Client ID not configured' });
+
+  if (originalClientId !== undefined) {
+    process.env.GOOGLE_CLIENT_ID = originalClientId;
+  }
+});
+


### PR DESCRIPTION
## Summary
- add supertest dependency for backend tests
- verify `/api/config/google` returns client ID when configured
- assert error response when Google client ID missing

## Testing
- `node --test tests/routes/config.test.js` *(fails: Cannot find module 'supertest')*

------
https://chatgpt.com/codex/tasks/task_e_689e192ca2b08325961b2161c88c1117