### PR TITLE
Allow jsdelivr scripts for DOMPurify

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -36,7 +36,8 @@ app.use(
           "'unsafe-inline'", // Pour les scripts inline (temporaire)
           "https://unpkg.com", // Pour Lucide icons
           "https://accounts.google.com", // Pour Google Auth
-          "https://apis.google.com" // Pour Google APIs
+          "https://apis.google.com", // Pour Google APIs
+          "https://cdn.jsdelivr.net" // Pour DOMPurify
         ],
         styleSrc: [
           "'self'",


### PR DESCRIPTION
## Summary
- allow scripts from `cdn.jsdelivr.net` in Helmet CSP so DOMPurify works

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689e389f82cc8325af4dfbfb2076bee4