### PR TITLE
refactor: load frontend utilities as ES modules

### DIFF
--- a/frontend/assets/js/auth.js
+++ b/frontend/assets/js/auth.js
@@ -1,5 +1,7 @@
 // frontend/assets/js/auth.js
 
+import { utils, API_BASE_URL } from './utils.js';
+
 class AuthManager {
     constructor() {
         this.token = localStorage.getItem('authToken');
@@ -229,7 +231,7 @@ class AuthManager {
 }
 
 // Instance globale
-const authManager = new AuthManager();
+export const authManager = new AuthManager();
 
 // Fonctions pour gérer les événements d'authentification
 function setupAuthListeners() {

--- a/frontend/assets/js/course.js
+++ b/frontend/assets/js/course.js
@@ -1,5 +1,8 @@
 // frontend/assets/js/course.js
 
+import { utils, API_BASE_URL } from './utils.js';
+import { authManager } from './auth.js';
+
 // Mapping for human-readable labels and icons
 const STYLE_LABELS = {
   neutral: 'Neutre',
@@ -382,5 +385,6 @@ class CourseManager {
 }
 
 // Instance globale
-window.courseManager = new CourseManager();
+export const courseManager = new CourseManager();
+window.courseManager = courseManager;
 

--- a/frontend/assets/js/main.js
+++ b/frontend/assets/js/main.js
@@ -1,5 +1,9 @@
 // frontend/assets/js/main.js - Point d'entrée principal
 
+import { utils, API_BASE_URL } from './utils.js';
+import { authManager } from './auth.js';
+import { courseManager } from './course.js';
+
 // État global de l'application
 let currentCourse = null;
 let currentQuiz = null;

--- a/frontend/assets/js/utils.js
+++ b/frontend/assets/js/utils.js
@@ -80,3 +80,4 @@ const utils = {
 // Exporter pour utilisation globale
 window.utils = utils;
 window.API_BASE_URL = API_BASE_URL;
+export { utils, API_BASE_URL };

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -226,11 +226,11 @@
     <!-- Scripts - Dans l'ordre de dépendance -->
     <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/dompurify@2.4.0/dist/purify.min.js"></script>
-    <script src="assets/js/utils.js"></script>
+    <script type="module" src="assets/js/utils.js"></script>
     <script src="assets/js/googleAuth.js"></script>
-    <script src="assets/js/auth.js"></script>
-    <script src="assets/js/course.js"></script>
-    <script src="assets/js/main.js"></script>
+    <script type="module" src="assets/js/auth.js"></script>
+    <script type="module" src="assets/js/course.js"></script>
+    <script type="module" src="assets/js/main.js"></script>
 
     <!-- Suppression de l'ancienne initialisation Google; la logique est gérée par assets/js/googleAuth.js -->
 </body>


### PR DESCRIPTION
## Summary
- load utils.js and dependent scripts as ES modules
- export utils and API_BASE_URL for reuse
- import utilities in auth, course and main scripts and expose managers

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689e396342e08325b94510da06fc9746