### PR TITLE
refactor: remove dompurify and use local sanitization

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -36,8 +36,7 @@ app.use(
           "'unsafe-inline'", // Pour les scripts inline (temporaire)
           "https://unpkg.com", // Pour Lucide icons
           "https://accounts.google.com", // Pour Google Auth
-          "https://apis.google.com", // Pour Google APIs
-          "https://cdn.jsdelivr.net" // Pour DOMPurify
+          "https://apis.google.com" // Pour Google APIs
         ],
         styleSrc: [
           "'self'",

--- a/frontend/assets/js/course.js
+++ b/frontend/assets/js/course.js
@@ -176,8 +176,8 @@ class CourseManager {
   displayCourse(course) {
     document.getElementById('emptyState').style.display = 'none';
     document.getElementById('courseContent').style.display = 'block';
-    const sanitizedContent = typeof DOMPurify !== 'undefined'
-      ? DOMPurify.sanitize(course.content)
+    const sanitizedContent = typeof utils.sanitizeHTML === 'function'
+      ? utils.sanitizeHTML(course.content)
       : course.content;
     document.getElementById('generatedCourse').innerHTML = sanitizedContent;
     

--- a/frontend/assets/js/shared/sanitize.js
+++ b/frontend/assets/js/shared/sanitize.js
@@ -17,4 +17,27 @@ export function sanitizeInput(input, maxLength = 10000) {
     .substring(0, maxLength);
 }
 
+/**
+ * Basic HTML sanitizer that strips out potentially dangerous tags and
+ * attributes. This is a lightweight alternative to DOMPurify and should be
+ * complemented by server-side sanitization.
+ *
+ * @param {string} html - Raw HTML string to clean.
+ * @param {number} [maxLength=100000] - Maximum length of returned HTML.
+ * @returns {string} Sanitized HTML string.
+ */
+export function sanitizeHTML(html, maxLength = 100000) {
+  if (typeof html !== 'string') return html;
+
+  return html
+    // Remove script-like elements entirely
+    .replace(/<script[^>]*>[\s\S]*?<\/script>/gi, '')
+    .replace(/<iframe[^>]*>[\s\S]*?<\/iframe>/gi, '')
+    .replace(/<object[^>]*>[\s\S]*?<\/object>/gi, '')
+    .replace(/<embed[^>]*>[\s\S]*?<\/embed>/gi, '')
+    // Strip event handler attributes (onclick, onload, ...)
+    .replace(/ on\w+\s*=\s*("[^"]*"|'[^']*'|[^\s>]+)/gi, '')
+    .substring(0, maxLength);
+}
+
 export default sanitizeInput;

--- a/frontend/assets/js/utils.js
+++ b/frontend/assets/js/utils.js
@@ -1,6 +1,6 @@
 // frontend/assets/js/utils.js
 
-import { sanitizeInput } from './shared/sanitize.js'; // Shared sanitization logic
+import { sanitizeInput, sanitizeHTML } from './shared/sanitize.js'; // Shared sanitization logic
 
 // Configuration API
 const API_BASE_URL = window.location.origin + '/api';
@@ -36,6 +36,7 @@ const utils = {
 
   // Sanitisation avec whitelist
   sanitizeInput,
+  sanitizeHTML,
 
   // Gestion du chargement global et des boutons
   showLoading(buttonIds = []) {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -225,7 +225,6 @@
     
     <!-- Scripts - Dans l'ordre de dépendance -->
     <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/dompurify@2.4.0/dist/purify.min.js"></script>
     <script type="module" src="assets/js/utils.js"></script>
     <script src="assets/js/googleAuth.js"></script>
     <script type="module" src="assets/js/auth.js"></script>

--- a/frontend/tests/sanitize.test.js
+++ b/frontend/tests/sanitize.test.js
@@ -30,3 +30,10 @@ test('sanitizeInput respects maxLength with unicode', async () => {
   const result = sanitizeInput(input, 5);
   assert.strictEqual(result, 'É'.repeat(5));
 });
+
+test('sanitizeHTML removes script tags but keeps markup', async () => {
+  const { sanitizeHTML } = await load();
+  const input = '<p>Hello</p><script>alert(1)</script>';
+  const result = sanitizeHTML(input);
+  assert.strictEqual(result, '<p>Hello</p>');
+});


### PR DESCRIPTION
## Summary
- drop DOMPurify CDN from index and CSP config
- implement lightweight sanitizeHTML helper and expose it via utils
- use local sanitization for course rendering and add tests

## Testing
- `node --test frontend/tests/sanitize.test.js`
- `node --test backend/tests/utils/helpers.test.js` *(fails: Cannot find module 'sanitize-html')*
- `npm install sanitize-html` *(fails: 403 Forbidden - GET https://registry.npmjs.org/cookie-parser)*

------
https://chatgpt.com/codex/tasks/task_e_689e3b245e548325b1f86df4b812a4fb