### PR TITLE
chore: safely disable google auto select on logout

### DIFF
--- a/frontend/assets/js/auth.js
+++ b/frontend/assets/js/auth.js
@@ -163,11 +163,8 @@ class AuthManager {
         localStorage.removeItem('user');
 
         // ⭐ Déconnexion Google et nettoyage des boutons
-        if (window.GoogleAuth) {
-            if (GoogleAuth.state === GoogleAuth.STATES.FAILED) {
-                GoogleAuth.reset();
-            }
-            GoogleAuth.disableAutoSelect();
+        if (window.google?.accounts?.id) {
+            google.accounts.id.disableAutoSelect?.();
         }
 
         this.updateUI();


### PR DESCRIPTION
## Summary
- ensure Google Identity logout uses safe check before disabling auto select

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689e3f15823883258e8bc75571afd521