### PR TITLE
fix: remove requireTrustedTypesFor directive from CSP

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -62,8 +62,7 @@ app.use(
           "data:",
           "https://lh3.googleusercontent.com", // Pour les avatars Google
           "https://*.googleusercontent.com" // Autres images Google
-        ],
-        requireTrustedTypesFor: [] // Désactive 'require-trusted-types-for'
+        ]
       }
     },
     crossOriginEmbedderPolicy: false,


### PR DESCRIPTION
## Summary
- remove unused `requireTrustedTypesFor` directive from Helmet CSP configuration

## Testing
- `npm test --prefix backend` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689e429acad08325b2c9d427133a7ccb