### PR TITLE
Simplify Google auth initialization

### DIFF
--- a/frontend/assets/js/auth.js
+++ b/frontend/assets/js/auth.js
@@ -384,18 +384,10 @@ function showNotification(message, type = 'success') {
 // Initialiser GoogleAuth une seule fois
 let googleAuthInitialized = false;
 async function initializeGoogleAuth() {
-    if (!window.GoogleAuth) return;
-    if (googleAuthInitialized) {
-        GoogleAuth.promptLogin();
-        return;
-    }
+    if (!window.GoogleAuth || googleAuthInitialized) return;
     try {
-        if (GoogleAuth.state === GoogleAuth.STATES.FAILED && typeof GoogleAuth.reset === 'function') {
-            GoogleAuth.reset();
-        }
         await GoogleAuth.init(response => authManager.handleGoogleLogin(response));
         document.querySelectorAll('.auth-separator').forEach(el => el.style.display = 'block');
-        GoogleAuth.promptLogin();
         googleAuthInitialized = true;
     } catch (err) {
         console.error('Erreur initialisation GoogleAuth:', err);


### PR DESCRIPTION
## Summary
- Simplify Google auth setup by removing deprecated state checks and prompt/reset calls
- Show separators directly after Google auth initialization

## Testing
- `node --test frontend/tests/sanitize.test.js`
- `node --test` *(fails: Cannot find module dependencies)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689e43c58f248325a8ca68f49375ef28