### PR TITLE
Remove preload for Google auth client

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -6,7 +6,6 @@
     <title>Science+ - La science accessible à tous</title>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="preconnect" href="https://accounts.google.com">
-    <link rel="preload" href="https://accounts.google.com/gsi/client" as="script">
     <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.js"></script>
     <link rel="stylesheet" href="assets/css/main.css">
 </head>


### PR DESCRIPTION
## Summary
- avoid preloading Google Identity script in index.html
- rely on existing `googleAuth.js` to load the SDK when needed

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689e4567a14083259f251f4a0c143408