### PR TITLE
Handle Anthropic offline mode and surface 503 errors

### DIFF
--- a/backend/src/controllers/aiController.js
+++ b/backend/src/controllers/aiController.js
@@ -6,6 +6,10 @@ const anthropicService = require('../services/anthropicService');
 class AiController {
   // Répondre à une question
   async askQuestion(req, res) {
+    if (anthropicService.isOffline()) {
+      const { response, statusCode } = createResponse(false, null, 'Service IA indisponible, réessayez plus tard', HTTP_STATUS.SERVICE_UNAVAILABLE);
+      return res.status(statusCode).json(response);
+    }
     try {
       const { question, courseContent, level = 'intermediate', questionType = 'auto' } = req.body;
 
@@ -39,6 +43,10 @@ class AiController {
       res.json(response);
     } catch (error) {
       logger.error('Erreur réponse question', { error, code: error.code });
+      if (error.offline) {
+        const { response, statusCode } = createResponse(false, null, 'Service IA indisponible, réessayez plus tard', HTTP_STATUS.SERVICE_UNAVAILABLE);
+        return res.status(statusCode).json(response);
+      }
       let message = ERROR_MESSAGES.SERVER_ERROR;
       let status = HTTP_STATUS.SERVER_ERROR;
       if (error.code === ERROR_CODES.IA_TIMEOUT) {
@@ -55,6 +63,10 @@ class AiController {
 
   // Générer un quiz
   async generateQuiz(req, res) {
+    if (anthropicService.isOffline()) {
+      const { response, statusCode } = createResponse(false, null, 'Service IA indisponible, réessayez plus tard', HTTP_STATUS.SERVICE_UNAVAILABLE);
+      return res.status(statusCode).json(response);
+    }
     try {
       const { courseContent } = req.body;
 
@@ -75,6 +87,10 @@ class AiController {
       res.json(response);
     } catch (error) {
       logger.error('Erreur génération quiz', { error, code: error.code });
+      if (error.offline) {
+        const { response, statusCode } = createResponse(false, null, 'Service IA indisponible, réessayez plus tard', HTTP_STATUS.SERVICE_UNAVAILABLE);
+        return res.status(statusCode).json(response);
+      }
       let message = ERROR_MESSAGES.SERVER_ERROR;
       let status = HTTP_STATUS.SERVER_ERROR;
       if (error.code === ERROR_CODES.IA_TIMEOUT) {
@@ -91,6 +107,10 @@ class AiController {
 
   // Suggérer des questions
   async suggestQuestions(req, res) {
+    if (anthropicService.isOffline()) {
+      const { response, statusCode } = createResponse(false, null, 'Service IA indisponible, réessayez plus tard', HTTP_STATUS.SERVICE_UNAVAILABLE);
+      return res.status(statusCode).json(response);
+    }
     try {
       const { courseContent, level = 'intermediate' } = req.body;
 
@@ -111,6 +131,10 @@ class AiController {
       res.json(response);
     } catch (error) {
       logger.error('Erreur suggestions questions', { error, code: error.code });
+      if (error.offline) {
+        const { response, statusCode } = createResponse(false, null, 'Service IA indisponible, réessayez plus tard', HTTP_STATUS.SERVICE_UNAVAILABLE);
+        return res.status(statusCode).json(response);
+      }
       let message = ERROR_MESSAGES.SERVER_ERROR;
       let status = HTTP_STATUS.SERVER_ERROR;
       if (error.code === ERROR_CODES.IA_TIMEOUT) {

--- a/frontend/assets/js/course.js
+++ b/frontend/assets/js/course.js
@@ -106,6 +106,10 @@ class CourseManager {
         },
         body: JSON.stringify(payload)
       });
+      if (response.status === 503) {
+        this.showAction('Service IA indisponible, réessayez plus tard', 'OK', () => {});
+        return null;
+      }
 
       const data = await response.json();
 
@@ -154,6 +158,10 @@ class CourseManager {
         },
         body: JSON.stringify({ courseContent: this.currentCourse.content })
       });
+      if (response.status === 503) {
+        this.showAction('Service IA indisponible, réessayez plus tard', 'OK', () => {});
+        return null;
+      }
 
       const data = await response.json();
 


### PR DESCRIPTION
## Summary
- Add offline mode to Anthropic service with graceful fallback when API key or connection is missing
- Propagate service unavailability as HTTP 503 in AI controller
- Notify users in course UI when AI service is down

## Testing
- `npm test` *(fails: Missing script "test")*
- `(cd backend && npm test)` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689e495bb7688325a64a0f1789b295a8