### PR TITLE
feat: add timeout and cancellation for AI requests

### DIFF
--- a/backend/src/controllers/aiController.js
+++ b/backend/src/controllers/aiController.js
@@ -50,7 +50,7 @@ class AiController {
       let message = ERROR_MESSAGES.SERVER_ERROR;
       let status = HTTP_STATUS.SERVER_ERROR;
       if (error.code === ERROR_CODES.IA_TIMEOUT) {
-        message = 'Temps dépassé lors de la réponse de l\'IA';
+        message = 'Temps de réponse de l\'IA dépassé';
         status = HTTP_STATUS.SERVICE_UNAVAILABLE;
       } else if (error.code === ERROR_CODES.QUOTA_EXCEEDED) {
         message = 'Quota IA dépassé, réessayez plus tard';
@@ -94,7 +94,7 @@ class AiController {
       let message = ERROR_MESSAGES.SERVER_ERROR;
       let status = HTTP_STATUS.SERVER_ERROR;
       if (error.code === ERROR_CODES.IA_TIMEOUT) {
-        message = 'Temps dépassé lors de la génération du quiz';
+        message = 'Temps de réponse de l\'IA dépassé';
         status = HTTP_STATUS.SERVICE_UNAVAILABLE;
       } else if (error.code === ERROR_CODES.QUOTA_EXCEEDED) {
         message = 'Quota IA dépassé, réessayez plus tard';
@@ -138,7 +138,7 @@ class AiController {
       let message = ERROR_MESSAGES.SERVER_ERROR;
       let status = HTTP_STATUS.SERVER_ERROR;
       if (error.code === ERROR_CODES.IA_TIMEOUT) {
-        message = 'Temps dépassé lors de la génération des suggestions';
+        message = 'Temps de réponse de l\'IA dépassé';
         status = HTTP_STATUS.SERVICE_UNAVAILABLE;
       } else if (error.code === ERROR_CODES.QUOTA_EXCEEDED) {
         message = 'Quota IA dépassé, réessayez plus tard';


### PR DESCRIPTION
## Summary
- add 30s timeout wrapper for Anthropic messages with AbortController
- propagate IA_TIMEOUT and update controller messaging
- show cancellation option after 25s on course generation

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm test --prefix backend` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_689e4b0b3c388325ba8369de976233e7