### PR TITLE
feat: add friendly AI error labels

### DIFF
--- a/backend/src/controllers/aiController.js
+++ b/backend/src/controllers/aiController.js
@@ -1,6 +1,6 @@
 // backend/src/controllers/aiController.js
 const { createResponse, sanitizeInput, logger } = require('../utils/helpers');
-const { HTTP_STATUS, ERROR_MESSAGES, ERROR_CODES } = require('../utils/constants');
+const { HTTP_STATUS, ERROR_MESSAGES, ERROR_CODES, AI_ERROR_MESSAGES } = require('../utils/constants');
 const anthropicService = require('../services/anthropicService');
 
 class AiController {
@@ -47,13 +47,11 @@ class AiController {
         const { response, statusCode } = createResponse(false, null, 'Service IA indisponible, réessayez plus tard', HTTP_STATUS.SERVICE_UNAVAILABLE);
         return res.status(statusCode).json(response);
       }
-      let message = ERROR_MESSAGES.SERVER_ERROR;
+      let message = AI_ERROR_MESSAGES[error.code] || ERROR_MESSAGES.SERVER_ERROR;
       let status = HTTP_STATUS.SERVER_ERROR;
       if (error.code === ERROR_CODES.IA_TIMEOUT) {
-        message = 'Temps de réponse de l\'IA dépassé';
         status = HTTP_STATUS.SERVICE_UNAVAILABLE;
       } else if (error.code === ERROR_CODES.QUOTA_EXCEEDED) {
-        message = 'Quota IA dépassé, réessayez plus tard';
         status = HTTP_STATUS.RATE_LIMIT;
       }
       const { response, statusCode } = createResponse(false, null, message, status, error.code);
@@ -91,13 +89,11 @@ class AiController {
         const { response, statusCode } = createResponse(false, null, 'Service IA indisponible, réessayez plus tard', HTTP_STATUS.SERVICE_UNAVAILABLE);
         return res.status(statusCode).json(response);
       }
-      let message = ERROR_MESSAGES.SERVER_ERROR;
+      let message = AI_ERROR_MESSAGES[error.code] || ERROR_MESSAGES.SERVER_ERROR;
       let status = HTTP_STATUS.SERVER_ERROR;
       if (error.code === ERROR_CODES.IA_TIMEOUT) {
-        message = 'Temps de réponse de l\'IA dépassé';
         status = HTTP_STATUS.SERVICE_UNAVAILABLE;
       } else if (error.code === ERROR_CODES.QUOTA_EXCEEDED) {
-        message = 'Quota IA dépassé, réessayez plus tard';
         status = HTTP_STATUS.RATE_LIMIT;
       }
       const { response, statusCode } = createResponse(false, null, message, status, error.code);
@@ -135,13 +131,11 @@ class AiController {
         const { response, statusCode } = createResponse(false, null, 'Service IA indisponible, réessayez plus tard', HTTP_STATUS.SERVICE_UNAVAILABLE);
         return res.status(statusCode).json(response);
       }
-      let message = ERROR_MESSAGES.SERVER_ERROR;
+      let message = AI_ERROR_MESSAGES[error.code] || ERROR_MESSAGES.SERVER_ERROR;
       let status = HTTP_STATUS.SERVER_ERROR;
       if (error.code === ERROR_CODES.IA_TIMEOUT) {
-        message = 'Temps de réponse de l\'IA dépassé';
         status = HTTP_STATUS.SERVICE_UNAVAILABLE;
       } else if (error.code === ERROR_CODES.QUOTA_EXCEEDED) {
-        message = 'Quota IA dépassé, réessayez plus tard';
         status = HTTP_STATUS.RATE_LIMIT;
       }
       const { response, statusCode } = createResponse(false, null, message, status, error.code);

--- a/backend/src/utils/constants.js
+++ b/backend/src/utils/constants.js
@@ -61,6 +61,13 @@ const ERROR_CODES = {
   IA_ERROR: 'IA_ERROR'
 };
 
+// Libellés conviviaux pour les erreurs IA
+const AI_ERROR_MESSAGES = {
+  [ERROR_CODES.IA_TIMEOUT]: "Temps de réponse de l'IA dépassé",
+  [ERROR_CODES.QUOTA_EXCEEDED]: 'Quota IA dépassé, réessayez plus tard',
+  [ERROR_CODES.IA_ERROR]: 'Erreur du service IA, réessayez plus tard'
+};
+
 // Quotas de rate limiting par type de route
 const RATE_LIMITS = {
   AI: {
@@ -110,6 +117,7 @@ module.exports = {
   ERROR_MESSAGES,
   HTTP_STATUS,
   ERROR_CODES,
+  AI_ERROR_MESSAGES,
   STYLES,
   DURATIONS,
   INTENTS

--- a/frontend/assets/js/auth.js
+++ b/frontend/assets/js/auth.js
@@ -105,12 +105,12 @@ class AuthManager {
                 return { success: true };
             } else if (data.code === 'IA_TIMEOUT') {
                 this.showAction(data.error || 'Service indisponible', 'Réessayer', () => this.login(email, password));
-                return { success: false, error: data.error };
+                return { success: false, error: data.error, code: data.code };
             } else if (data.code === 'QUOTA_EXCEEDED') {
                 this.showAction(data.error || 'Quota dépassé', 'Sauvegarder', () => this.savePendingAuth({ email, password }));
-                return { success: false, error: data.error };
+                return { success: false, error: data.error, code: data.code };
             } else {
-                return { success: false, error: data.error };
+                return { success: false, error: data.error, code: data.code };
             }
         } catch (error) {
             console.error('Erreur login:', error);
@@ -141,12 +141,12 @@ class AuthManager {
                 return { success: true };
             } else if (data.code === 'IA_TIMEOUT') {
                 this.showAction(data.error || 'Service indisponible', 'Réessayer', () => this.register(name, email, password));
-                return { success: false, errors: [{ msg: data.error }] };
+                return { success: false, errors: [{ msg: data.error }], code: data.code };
             } else if (data.code === 'QUOTA_EXCEEDED') {
                 this.showAction(data.error || 'Quota dépassé', 'Sauvegarder', () => this.savePendingAuth({ name, email, password }));
-                return { success: false, errors: [{ msg: data.error }] };
+                return { success: false, errors: [{ msg: data.error }], code: data.code };
             } else {
-                return { success: false, errors: data.errors || [{ msg: data.error }] };
+                return { success: false, errors: data.errors || [{ msg: data.error }], code: data.code };
             }
         } catch (error) {
             console.error('Erreur register:', error);
@@ -283,7 +283,7 @@ function setupAuthListeners() {
                     courseManager.loadUserCourses();
                 }
             } else {
-                utils.handleAuthError(result.error);
+                utils.handleAuthError(result);
             }
 
             this.disabled = false;
@@ -323,7 +323,7 @@ function setupAuthListeners() {
                 showNotification('Compte créé avec succès !', 'success');
             } else {
                 const errorMessage = result.errors?.map(err => err.msg).join(', ') || 'Erreur lors de l\'inscription';
-                utils.handleAuthError(errorMessage);
+                utils.handleAuthError({ code: result.code, message: errorMessage });
             }
 
             this.disabled = false;

--- a/frontend/assets/js/utils.js
+++ b/frontend/assets/js/utils.js
@@ -5,6 +5,13 @@ import { sanitizeInput, sanitizeHTML } from './shared/sanitize.js'; // Shared sa
 // Configuration API
 const API_BASE_URL = window.location.origin + '/api';
 
+// Libellés conviviaux pour les codes d'erreur
+const ERROR_LABELS = {
+  IA_TIMEOUT: 'Service IA indisponible, réessayez plus tard',
+  QUOTA_EXCEEDED: 'Quota IA dépassé, réessayez plus tard',
+  IA_ERROR: 'Erreur du service IA, réessayez plus tard'
+};
+
 // Fonctions utilitaires globales
 const utils = {
   // Initialiser Lucide
@@ -60,8 +67,21 @@ const utils = {
   },
 
   // Gestion unifiée des erreurs d'authentification
-  handleAuthError(message, critical = false) {
-    console.error(message);
+  handleAuthError(error, critical = false) {
+    let message = 'Une erreur est survenue';
+    if (typeof error === 'string') {
+      message = error;
+    } else if (error && typeof error === 'object') {
+      if (error.code && ERROR_LABELS[error.code]) {
+        message = ERROR_LABELS[error.code];
+      } else if (error.message) {
+        message = error.message;
+      } else if (error.error) {
+        message = error.error;
+      }
+    }
+
+    console.error(error);
     this.showNotification(message, 'error');
 
     if (critical) {


### PR DESCRIPTION
## Summary
- add user-friendly AI error labels in backend constants
- use shared labels in AI controller responses
- map error codes to friendly messages on frontend

## Testing
- `node --test backend/tests/utils/helpers.test.js` *(fails: Cannot find module 'sanitize-html')*
- `node --test frontend/tests/sanitize.test.js`

------
https://chatgpt.com/codex/tasks/task_e_689e4cb019908325ba328d0639569041