### PR TITLE
feat: export course constants

### DIFF
--- a/frontend/assets/js/course.js
+++ b/frontend/assets/js/course.js
@@ -4,19 +4,19 @@ import { utils, API_BASE_URL } from './utils.js';
 import { authManager } from './auth.js';
 
 // Mapping for human-readable labels and icons
-const STYLE_LABELS = {
+export const STYLE_LABELS = {
   neutral: 'Neutre',
   pedagogical: 'Pédagogique',
   storytelling: 'Narratif'
 };
 
-const DURATION_LABELS = {
+export const DURATION_LABELS = {
   short: 'Courte',
   medium: 'Moyenne',
   long: 'Longue'
 };
 
-const INTENT_LABELS = {
+export const INTENT_LABELS = {
   discover: 'Découvrir',
   learn: 'Apprendre',
   master: 'Maîtriser',

--- a/frontend/assets/js/main.js
+++ b/frontend/assets/js/main.js
@@ -2,7 +2,7 @@
 
 import { utils, API_BASE_URL } from './utils.js';
 import { authManager } from './auth.js';
-import { courseManager } from './course.js';
+import { courseManager, STYLE_LABELS, DURATION_LABELS, INTENT_LABELS } from './course.js';
 
 // État global de l'application
 let currentCourse = null;


### PR DESCRIPTION
## Summary
- export style, duration, and intent label maps from course module
- import new label constants in main entry point

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm start` *(fails: Cannot find module 'dotenv')*


------
https://chatgpt.com/codex/tasks/task_e_689ee340942083258a04fd94e6547b2f