### PR TITLE
Fix signal handling for Anthropic messages.create

### DIFF
--- a/backend/src/services/anthropicService.js
+++ b/backend/src/services/anthropicService.js
@@ -59,10 +59,10 @@ class AnthropicService {
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), timeoutMs);
     try {
-      return await this.client.messages.create({
-        ...options,
-        signal: controller.signal
-      });
+      return await this.client.messages.create(
+        options,
+        { signal: controller.signal }
+      );
     } finally {
       clearTimeout(timer);
     }


### PR DESCRIPTION
## Summary
- Pass `AbortController` signal in config instead of message options to avoid `Extra inputs are not permitted` errors

## Testing
- `node --test tests/services/anthropicService.test.js`
- `node - <<'NODE'
process.env.ANTHROPIC_API_KEY = 'test';
const service = require('./src/services/anthropicService');
service.client.messages.create = async (options, config) => {
  console.log('options', options);
  console.log('config has signal', !!(config && config.signal));
  return { ok: true };
};
(async () => {
  await service.sendWithTimeout({ test: 1 }, 1000);
  console.log('completed');
})();
NODE`

------
https://chatgpt.com/codex/tasks/task_e_689ee7344230832589b08740a598a887