### PR TITLE
feat: handle anthropic overload errors

### DIFF
--- a/backend/src/controllers/courseController.js
+++ b/backend/src/controllers/courseController.js
@@ -170,6 +170,9 @@ class CourseController {
       } else if (error.code === ERROR_CODES.QUOTA_EXCEEDED) {
         message = 'Quota IA dépassé, réessayez plus tard';
         status = HTTP_STATUS.RATE_LIMIT;
+      } else if (error.code === ERROR_CODES.IA_OVERLOADED) {
+        message = 'Service IA surchargé, réessayez plus tard';
+        status = HTTP_STATUS.SERVICE_UNAVAILABLE;
       }
       const { response, statusCode } = createResponse(false, null, message, status, error.code);
       res.status(statusCode).json(response);

--- a/backend/src/utils/constants.js
+++ b/backend/src/utils/constants.js
@@ -58,14 +58,16 @@ const LIMITS = {
 const ERROR_CODES = {
   IA_TIMEOUT: 'IA_TIMEOUT',
   QUOTA_EXCEEDED: 'QUOTA_EXCEEDED',
-  IA_ERROR: 'IA_ERROR'
+  IA_ERROR: 'IA_ERROR',
+  IA_OVERLOADED: 'IA_OVERLOADED'
 };
 
 // Libellés conviviaux pour les erreurs IA
 const AI_ERROR_MESSAGES = {
   [ERROR_CODES.IA_TIMEOUT]: "Temps de réponse de l'IA dépassé",
   [ERROR_CODES.QUOTA_EXCEEDED]: 'Quota IA dépassé, réessayez plus tard',
-  [ERROR_CODES.IA_ERROR]: 'Erreur du service IA, réessayez plus tard'
+  [ERROR_CODES.IA_ERROR]: 'Erreur du service IA, réessayez plus tard',
+  [ERROR_CODES.IA_OVERLOADED]: 'Service IA surchargé, réessayez plus tard'
 };
 
 // Quotas de rate limiting par type de route


### PR DESCRIPTION
## Summary
- add IA_OVERLOADED error code and messages
- retry Anthropics requests on 529/overloaded responses with exponential backoff
- surface overloaded errors as 503 in course generation

## Testing
- `node --test tests/services/anthropicService.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689eeab5afe883258e3ab0814dc820e6