### PR TITLE
Handle APIUserAbortError as IA_TIMEOUT

### DIFF
--- a/backend/src/services/anthropicService.js
+++ b/backend/src/services/anthropicService.js
@@ -659,7 +659,13 @@ Format JSON :
       return ERROR_CODES.QUOTA_EXCEEDED;
     }
     const message = error?.message?.toLowerCase() || '';
-    if (error?.name === 'AbortError' || error?.code === 'ETIMEDOUT' || message.includes('timeout')) {
+    if (
+      error?.name === 'AbortError' ||
+      error?.name === 'APIUserAbortError' ||
+      error?.code === 'ETIMEDOUT' ||
+      message.includes('timeout') ||
+      message.includes('abort')
+    ) {
       return ERROR_CODES.IA_TIMEOUT;
     }
     return ERROR_CODES.IA_ERROR;


### PR DESCRIPTION
## Summary
- Treat Anthropic SDK's APIUserAbortError as IA_TIMEOUT to avoid unnecessary offline mode
- Mock external dependencies and add tests ensuring APIUserAbortError doesn't flip service offline

## Testing
- `cd backend && node --test tests/services/anthropicService.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689f0aa109c08325a01bd119e5d2a2b0