### PR TITLE
Add Anthropic heartbeat recovery

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -7,3 +7,7 @@ The backend uses `scripts/check-env.js` to ensure required configuration is pres
 ### TLS configuration
 
 In `production` mode the server expects `TLS_CERT_PATH` and `TLS_KEY_PATH` to start in HTTPS. Set `ALLOW_HTTP=true` to bypass this check and run the server over plain HTTP. This flag defaults to `false` and should only be used for development or testing.
+
+## Anthropic recovery
+
+If the connection to Anthropic fails, the service enters an offline mode. A background task periodically sends a lightweight heartbeat to the Anthropic API. When a heartbeat succeeds the service resets its offline flag, allowing normal AI requests to resume automatically.

--- a/backend/src/controllers/aiController.js
+++ b/backend/src/controllers/aiController.js
@@ -187,5 +187,14 @@ class AiController {
     }
   }
 }
+const aiController = new AiController();
 
-module.exports = new AiController();
+// Vérifie périodiquement si le service Anthropic est de nouveau disponible
+const RECOVERY_INTERVAL = 60 * 1000; // 1 minute
+setInterval(() => {
+  if (anthropicService.isOffline()) {
+    anthropicService.recoverIfOffline();
+  }
+}, RECOVERY_INTERVAL);
+
+module.exports = aiController;

--- a/backend/src/services/anthropicService.js
+++ b/backend/src/services/anthropicService.js
@@ -54,6 +54,26 @@ class AnthropicService {
     return OFFLINE_MESSAGE;
   }
 
+  // Attempt a lightweight request to see if the service is reachable again
+  async recoverIfOffline() {
+    if (!this.offline || !this.client) {
+      return false;
+    }
+    try {
+      await this.sendWithTimeout({
+        model: 'claude-3-5-sonnet-20241022',
+        max_tokens: 1,
+        messages: [{ role: 'user', content: 'ping' }]
+      }, 5000);
+      this.offline = false;
+      logger.success('Service Anthropic rétabli');
+      return true;
+    } catch (error) {
+      logger.warn('Tentative de reconnexion Anthropic échouée');
+      return false;
+    }
+  }
+
   // Wrapper around Anthropic API with timeout support and retry on overload
   async sendWithTimeout(options, timeoutMs = REQUEST_TIMEOUT, retryDelays = [1000, 2000, 4000]) {
     for (let attempt = 0; ; attempt++) {


### PR DESCRIPTION
## Summary
- add `recoverIfOffline` method to retry lightweight Anthropic call and clear offline state
- schedule periodic recovery attempts from AI controller
- document automatic Anthropic service recovery

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node --test` *(fails: tests 6, fail 6)*

------
https://chatgpt.com/codex/tasks/task_e_689f0be0f9a883259cfd86ede876d718