### PR TITLE
feat: add responsive header navigation

### DIFF
--- a/frontend/assets/css/main.css
+++ b/frontend/assets/css/main.css
@@ -51,6 +51,7 @@ body::before {
     display: flex;
     justify-content: space-between;
     align-items: center;
+    gap: 20px;
     margin-bottom: 15px;
     padding: 10px 20px;
     background: linear-gradient(135deg, #4299e1, #3182ce);
@@ -58,6 +59,7 @@ body::before {
     box-shadow: 0 8px 25px rgba(66, 153, 225, 0.3);
     color: white;
     flex-shrink: 0;
+    position: relative;
 }
 
 .header-text {
@@ -92,6 +94,32 @@ body::before {
     display: none;
     font-size: 1.5rem;
 }
+
+.header-nav {
+    margin-left: auto;
+}
+
+.header-nav ul {
+    list-style: none;
+    display: flex;
+    gap: 20px;
+}
+
+.header-nav li {
+    list-style: none;
+}
+
+.header-nav a {
+    color: white;
+    text-decoration: none;
+    font-weight: 500;
+    transition: color 0.3s ease;
+}
+
+.header-nav a:hover {
+    color: #e2e8f0;
+}
+
 
 .main-content {
     display: grid;
@@ -147,6 +175,30 @@ body::before {
 
     .configuration-panel.open {
         transform: translateX(0);
+    }
+
+    .header-nav {
+        display: none;
+        position: absolute;
+        top: 100%;
+        right: 20px;
+        background: white;
+        padding: 10px 20px;
+        border-radius: 10px;
+        box-shadow: 0 8px 16px rgba(0, 0, 0, 0.15);
+    }
+
+    .header-nav.open {
+        display: block;
+    }
+
+    .header-nav ul {
+        flex-direction: column;
+        gap: 10px;
+    }
+
+    .header-nav a {
+        color: #2d3748;
     }
 
     .menu-toggle {

--- a/frontend/assets/js/main.js
+++ b/frontend/assets/js/main.js
@@ -48,12 +48,16 @@ function setupEventListeners() {
     const randomSubjectBtn = document.getElementById('randomSubjectBtn');
     const menuToggle = document.getElementById('menuToggle');
     const configPanel = document.querySelector('.configuration-panel');
+    const headerNav = document.querySelector('.header-nav');
 
     if (generateBtn) generateBtn.addEventListener('click', handleGenerateCourse);
     if (generateQuiz) generateQuiz.addEventListener('click', handleGenerateQuiz);
     if (copyContent) copyContent.addEventListener('click', () => courseManager && courseManager.copyContent());
     if (randomSubjectBtn) randomSubjectBtn.addEventListener('click', generateRandomSubject);
-    if (menuToggle && configPanel) menuToggle.addEventListener('click', () => configPanel.classList.toggle('open'));
+    if (menuToggle) menuToggle.addEventListener('click', () => {
+        if (configPanel) configPanel.classList.toggle('open');
+        if (headerNav) headerNav.classList.toggle('open');
+    });
 
     // Chat
     setupChatEventListeners();

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -22,6 +22,14 @@
                 <h1>Skillence AI</h1>
                 <p>Le savoir accessible à tous</p>
             </div>
+            <nav class="header-nav">
+                <ul>
+                    <li><a href="#">Accueil</a></li>
+                    <li><a href="#">Solutions</a></li>
+                    <li><a href="#">Tarifs</a></li>
+                    <li><a href="#">Contact</a></li>
+                </ul>
+            </nav>
         </header>
 
         <!-- Section d'authentification -->


### PR DESCRIPTION
## Summary
- add horizontal navigation links to homepage header
- style header navigation and adapt layout for flex
- enable menu toggle to show navigation on small screens

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689f256df7948325ba7153e96e3ca858