### PR TITLE
feat: toggle mobile nav

### DIFF
--- a/frontend/assets/css/main.css
+++ b/frontend/assets/css/main.css
@@ -95,6 +95,11 @@ body::before {
     font-size: 1.5rem;
 }
 
+.menu-toggle:focus {
+    outline: 2px solid #2b6cb0;
+    outline-offset: 2px;
+}
+
 /* --------------------------------------------------------------------------
    Navigation Menu - Couleurs & Interactions
    -------------------------------------------------------------------------- */
@@ -126,6 +131,13 @@ body::before {
 .header-nav a:hover {
     background-color: rgba(255, 255, 255, 0.2);
     color: #ffffff;
+}
+
+.header-nav a:focus {
+    background-color: rgba(255, 255, 255, 0.2);
+    color: #ffffff;
+    outline: 2px solid #2b6cb0;
+    outline-offset: 2px;
 }
 
 .header-nav a:active,

--- a/frontend/assets/js/main.js
+++ b/frontend/assets/js/main.js
@@ -54,10 +54,24 @@ function setupEventListeners() {
     if (generateQuiz) generateQuiz.addEventListener('click', handleGenerateQuiz);
     if (copyContent) copyContent.addEventListener('click', () => courseManager && courseManager.copyContent());
     if (randomSubjectBtn) randomSubjectBtn.addEventListener('click', generateRandomSubject);
-    if (menuToggle) menuToggle.addEventListener('click', () => {
-        if (configPanel) configPanel.classList.toggle('open');
-        if (headerNav) headerNav.classList.toggle('open');
-    });
+
+    if (menuToggle) {
+        menuToggle.setAttribute('aria-expanded', 'false');
+        const toggleNavigation = () => {
+            const expanded = menuToggle.getAttribute('aria-expanded') === 'true';
+            menuToggle.setAttribute('aria-expanded', String(!expanded));
+            if (headerNav) headerNav.classList.toggle('open');
+            if (configPanel) configPanel.classList.toggle('open');
+        };
+
+        menuToggle.addEventListener('click', toggleNavigation);
+        menuToggle.addEventListener('keydown', (e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                toggleNavigation();
+            }
+        });
+    }
 
     // Chat
     setupChatEventListeners();


### PR DESCRIPTION
## Summary
- toggle header navigation via mobile menu button with keyboard support
- add focus outlines for toggle and navigation links

## Testing
- `npm test` (fails: Missing script: test)
- `node --test frontend/tests/sanitize.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689f2966a4cc8325a87a533233834826