### PR TITLE
Add close button to mobile configuration panel

### DIFF
--- a/frontend/assets/css/main.css
+++ b/frontend/assets/css/main.css
@@ -182,6 +182,10 @@ body::before {
     box-shadow: 0 4px 15px rgba(0, 0, 0, 0.1);
 }
 
+.config-close-btn {
+    display: none;
+}
+
 @media (max-width: 768px) {
     .main-content {
         grid-template-columns: 1fr;
@@ -201,6 +205,17 @@ body::before {
 
     .configuration-panel.open {
         transform: translateX(0);
+    }
+
+    .config-close-btn {
+        display: block;
+        position: absolute;
+        top: 10px;
+        right: 10px;
+        background: none;
+        border: none;
+        color: #2d3748;
+        cursor: pointer;
     }
 
     .header-nav {

--- a/frontend/assets/js/main.js
+++ b/frontend/assets/js/main.js
@@ -49,6 +49,7 @@ function setupEventListeners() {
     const menuToggle = document.getElementById('menuToggle');
     const configPanel = document.querySelector('.configuration-panel');
     const headerNav = document.querySelector('.header-nav');
+    const closeConfigBtn = document.getElementById('closeConfigBtn');
 
     if (generateBtn) generateBtn.addEventListener('click', handleGenerateCourse);
     if (generateQuiz) generateQuiz.addEventListener('click', handleGenerateQuiz);
@@ -71,6 +72,8 @@ function setupEventListeners() {
                 toggleNavigation();
             }
         });
+
+        if (closeConfigBtn) closeConfigBtn.addEventListener('click', toggleNavigation);
     }
 
     // Chat

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -119,6 +119,9 @@
 
         <div class="main-content">
             <div class="configuration-panel">
+                <button class="config-close-btn" id="closeConfigBtn">
+                    <i data-lucide="x"></i>
+                </button>
                 <button class="generate-btn" id="generateBtn">
                     <i data-lucide="sparkles"></i>
                     Décrypter le sujet


### PR DESCRIPTION
## Summary
- Add dedicated close button within configuration panel for mobile
- Style close button and hide on desktop
- Wire close button to existing navigation toggle logic

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689f2e818e6083259487820be53920bb