### PR TITLE
Add basic site pages

### DIFF
--- a/frontend/contact.html
+++ b/frontend/contact.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Skillence AI - Contact</title>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="assets/css/main.css">
+</head>
+<body>
+    <div class="container">
+        <header class="header">
+            <button class="menu-toggle" id="menuToggle">
+                <i data-lucide="menu"></i>
+            </button>
+            <div class="header-text">
+                <h1>Skillence AI</h1>
+                <p>Le savoir accessible à tous</p>
+            </div>
+            <nav class="header-nav">
+                <ul>
+                    <li><a href="index.html">Accueil</a></li>
+                    <li><a href="solutions.html">Solutions</a></li>
+                    <li><a href="tarifs.html">Tarifs</a></li>
+                    <li><a href="contact.html">Contact</a></li>
+                </ul>
+            </nav>
+        </header>
+
+        <main class="main-content">
+            <h2>Contact</h2>
+            <p>Une question ou une suggestion&nbsp;? Écrivez-nous à <a href="mailto:contact@skillence.ai">contact@skillence.ai</a>.</p>
+        </main>
+    </div>
+
+    <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.js"></script>
+    <script>
+        lucide.createIcons();
+    </script>
+</body>
+</html>
+

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -24,10 +24,10 @@
             </div>
             <nav class="header-nav">
                 <ul>
-                    <li><a href="#">Accueil</a></li>
-                    <li><a href="#">Solutions</a></li>
-                    <li><a href="#">Tarifs</a></li>
-                    <li><a href="#">Contact</a></li>
+                    <li><a href="index.html">Accueil</a></li>
+                    <li><a href="solutions.html">Solutions</a></li>
+                    <li><a href="tarifs.html">Tarifs</a></li>
+                    <li><a href="contact.html">Contact</a></li>
                 </ul>
             </nav>
         </header>

--- a/frontend/solutions.html
+++ b/frontend/solutions.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Skillence AI - Solutions</title>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="assets/css/main.css">
+</head>
+<body>
+    <div class="container">
+        <header class="header">
+            <button class="menu-toggle" id="menuToggle">
+                <i data-lucide="menu"></i>
+            </button>
+            <div class="header-text">
+                <h1>Skillence AI</h1>
+                <p>Le savoir accessible à tous</p>
+            </div>
+            <nav class="header-nav">
+                <ul>
+                    <li><a href="index.html">Accueil</a></li>
+                    <li><a href="solutions.html">Solutions</a></li>
+                    <li><a href="tarifs.html">Tarifs</a></li>
+                    <li><a href="contact.html">Contact</a></li>
+                </ul>
+            </nav>
+        </header>
+
+        <main class="main-content">
+            <h2>Nos solutions</h2>
+            <p>Découvrez comment Skillence AI peut vous aider à apprendre plus efficacement grâce à des cours personnalisés et des outils interactifs.</p>
+        </main>
+    </div>
+
+    <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.js"></script>
+    <script>
+        lucide.createIcons();
+    </script>
+</body>
+</html>
+

--- a/frontend/tarifs.html
+++ b/frontend/tarifs.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Skillence AI - Tarifs</title>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="assets/css/main.css">
+</head>
+<body>
+    <div class="container">
+        <header class="header">
+            <button class="menu-toggle" id="menuToggle">
+                <i data-lucide="menu"></i>
+            </button>
+            <div class="header-text">
+                <h1>Skillence AI</h1>
+                <p>Le savoir accessible à tous</p>
+            </div>
+            <nav class="header-nav">
+                <ul>
+                    <li><a href="index.html">Accueil</a></li>
+                    <li><a href="solutions.html">Solutions</a></li>
+                    <li><a href="tarifs.html">Tarifs</a></li>
+                    <li><a href="contact.html">Contact</a></li>
+                </ul>
+            </nav>
+        </header>
+
+        <main class="main-content">
+            <h2>Tarifs</h2>
+            <p>Choisissez le plan qui vous convient, de l'accès gratuit aux fonctionnalités avancées pour les apprenants passionnés.</p>
+        </main>
+    </div>
+
+    <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.js"></script>
+    <script>
+        lucide.createIcons();
+    </script>
+</body>
+</html>
+


### PR DESCRIPTION
## Summary
- add navigation links in index.html
- create Solutions, Tarifs and Contact static pages

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm test --prefix backend` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689f63a3933883259081a5bba40aa8eb