### PR TITLE
Expose authentication on all public pages

### DIFF
--- a/frontend/contact.html
+++ b/frontend/contact.html
@@ -8,6 +8,9 @@
     <link rel="stylesheet" href="assets/css/main.css">
 </head>
 <body>
+    <div id="loadingOverlay" class="loading-overlay" style="display:none;">
+        <div class="loading-spinner"></div>
+    </div>
     <div class="container">
         <header class="header">
             <button class="menu-toggle" id="menuToggle">
@@ -23,9 +26,95 @@
                     <li><a href="solutions.html">Solutions</a></li>
                     <li><a href="tarifs.html">Tarifs</a></li>
                     <li><a href="contact.html">Contact</a></li>
+                    <li><a href="#authSection">Login/Signup</a></li>
                 </ul>
             </nav>
         </header>
+        
+        <!-- Section d'authentification -->
+        <div id="authSection" class="auth-section">
+            <div class="auth-container">
+                <div class="auth-tabs">
+                    <button class="auth-tab active" data-tab="login">Connexion</button>
+                    <button class="auth-tab" data-tab="register">Inscription</button>
+                </div>
+
+                <!-- Formulaire de connexion -->
+                <div id="loginForm" class="auth-form">
+                    <h3>Se connecter</h3>
+
+                    <!-- Bouton Google officiel -->
+                    <div class="google-auth-container">
+                        <div id="googleSignInButton"></div>
+                    </div>
+
+                    <div class="auth-separator">
+                        <span>ou</span>
+                    </div>
+
+                    <!-- Formulaire email existant -->
+                    <div class="form-group">
+                        <label for="loginEmail">Email</label>
+                        <input type="email" id="loginEmail" required>
+                    </div>
+                    <div class="form-group">
+                        <label for="loginPassword">Mot de passe</label>
+                        <input type="password" id="loginPassword" required>
+                    </div>
+                    <button type="button" class="auth-btn" id="loginBtn">
+                        <i data-lucide="log-in"></i>
+                        Se connecter
+                    </button>
+                    <div class="auth-error" id="loginError"></div>
+                </div>
+
+                <!-- Formulaire d'inscription -->
+                <div id="registerForm" class="auth-form" style="display: none;">
+                    <h3>Créer un compte</h3>
+
+                    <!-- Bouton Google pour inscription -->
+                    <div class="google-auth-container">
+                        <div id="googleSignInButtonRegister"></div>
+                    </div>
+
+                    <div class="auth-separator">
+                        <span>ou</span>
+                    </div>
+
+                    <!-- Formulaire email existant -->
+                    <div class="form-group">
+                        <label for="registerName">Nom</label>
+                        <input type="text" id="registerName" required>
+                    </div>
+                    <div class="form-group">
+                        <label for="registerEmail">Email</label>
+                        <input type="email" id="registerEmail" required>
+                    </div>
+                    <div class="form-group">
+                        <label for="registerPassword">Mot de passe</label>
+                        <input type="password" id="registerPassword" required>
+                    </div>
+                    <button type="button" class="auth-btn" id="registerBtn">
+                        <i data-lucide="user-plus"></i>
+                        Créer mon compte
+                    </button>
+                    <div class="auth-error" id="registerError"></div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Section utilisateur connecté -->
+        <div id="userSection" class="user-section">
+            <div class="user-info">
+                <img id="userAvatar" class="user-avatar" src="" alt="" style="display: none;">
+                <i data-lucide="user-circle" id="userDefaultIcon"></i>
+                <span class="user-name"></span>
+            </div>
+            <button class="logout-btn" id="logoutBtn">
+                <i data-lucide="log-out"></i>
+                Déconnexion
+            </button>
+        </div>
 
         <main class="main-content">
             <h2>Contact</h2>
@@ -34,6 +123,8 @@
     </div>
 
     <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.js"></script>
+    <script src="assets/js/googleAuth.js"></script>
+    <script type="module" src="assets/js/auth.js"></script>
     <script>
         lucide.createIcons();
     </script>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -28,6 +28,7 @@
                     <li><a href="solutions.html">Solutions</a></li>
                     <li><a href="tarifs.html">Tarifs</a></li>
                     <li><a href="contact.html">Contact</a></li>
+                    <li><a href="#authSection">Login/Signup</a></li>
                 </ul>
             </nav>
         </header>

--- a/frontend/solutions.html
+++ b/frontend/solutions.html
@@ -8,6 +8,9 @@
     <link rel="stylesheet" href="assets/css/main.css">
 </head>
 <body>
+    <div id="loadingOverlay" class="loading-overlay" style="display:none;">
+        <div class="loading-spinner"></div>
+    </div>
     <div class="container">
         <header class="header">
             <button class="menu-toggle" id="menuToggle">
@@ -23,9 +26,95 @@
                     <li><a href="solutions.html">Solutions</a></li>
                     <li><a href="tarifs.html">Tarifs</a></li>
                     <li><a href="contact.html">Contact</a></li>
+                    <li><a href="#authSection">Login/Signup</a></li>
                 </ul>
             </nav>
         </header>
+        
+        <!-- Section d'authentification -->
+        <div id="authSection" class="auth-section">
+            <div class="auth-container">
+                <div class="auth-tabs">
+                    <button class="auth-tab active" data-tab="login">Connexion</button>
+                    <button class="auth-tab" data-tab="register">Inscription</button>
+                </div>
+
+                <!-- Formulaire de connexion -->
+                <div id="loginForm" class="auth-form">
+                    <h3>Se connecter</h3>
+
+                    <!-- Bouton Google officiel -->
+                    <div class="google-auth-container">
+                        <div id="googleSignInButton"></div>
+                    </div>
+
+                    <div class="auth-separator">
+                        <span>ou</span>
+                    </div>
+
+                    <!-- Formulaire email existant -->
+                    <div class="form-group">
+                        <label for="loginEmail">Email</label>
+                        <input type="email" id="loginEmail" required>
+                    </div>
+                    <div class="form-group">
+                        <label for="loginPassword">Mot de passe</label>
+                        <input type="password" id="loginPassword" required>
+                    </div>
+                    <button type="button" class="auth-btn" id="loginBtn">
+                        <i data-lucide="log-in"></i>
+                        Se connecter
+                    </button>
+                    <div class="auth-error" id="loginError"></div>
+                </div>
+
+                <!-- Formulaire d'inscription -->
+                <div id="registerForm" class="auth-form" style="display: none;">
+                    <h3>Créer un compte</h3>
+
+                    <!-- Bouton Google pour inscription -->
+                    <div class="google-auth-container">
+                        <div id="googleSignInButtonRegister"></div>
+                    </div>
+
+                    <div class="auth-separator">
+                        <span>ou</span>
+                    </div>
+
+                    <!-- Formulaire email existant -->
+                    <div class="form-group">
+                        <label for="registerName">Nom</label>
+                        <input type="text" id="registerName" required>
+                    </div>
+                    <div class="form-group">
+                        <label for="registerEmail">Email</label>
+                        <input type="email" id="registerEmail" required>
+                    </div>
+                    <div class="form-group">
+                        <label for="registerPassword">Mot de passe</label>
+                        <input type="password" id="registerPassword" required>
+                    </div>
+                    <button type="button" class="auth-btn" id="registerBtn">
+                        <i data-lucide="user-plus"></i>
+                        Créer mon compte
+                    </button>
+                    <div class="auth-error" id="registerError"></div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Section utilisateur connecté -->
+        <div id="userSection" class="user-section">
+            <div class="user-info">
+                <img id="userAvatar" class="user-avatar" src="" alt="" style="display: none;">
+                <i data-lucide="user-circle" id="userDefaultIcon"></i>
+                <span class="user-name"></span>
+            </div>
+            <button class="logout-btn" id="logoutBtn">
+                <i data-lucide="log-out"></i>
+                Déconnexion
+            </button>
+        </div>
 
         <main class="main-content">
             <h2>Nos solutions</h2>
@@ -34,6 +123,8 @@
     </div>
 
     <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.js"></script>
+    <script src="assets/js/googleAuth.js"></script>
+    <script type="module" src="assets/js/auth.js"></script>
     <script>
         lucide.createIcons();
     </script>

--- a/frontend/tarifs.html
+++ b/frontend/tarifs.html
@@ -8,6 +8,9 @@
     <link rel="stylesheet" href="assets/css/main.css">
 </head>
 <body>
+    <div id="loadingOverlay" class="loading-overlay" style="display:none;">
+        <div class="loading-spinner"></div>
+    </div>
     <div class="container">
         <header class="header">
             <button class="menu-toggle" id="menuToggle">
@@ -23,9 +26,95 @@
                     <li><a href="solutions.html">Solutions</a></li>
                     <li><a href="tarifs.html">Tarifs</a></li>
                     <li><a href="contact.html">Contact</a></li>
+                    <li><a href="#authSection">Login/Signup</a></li>
                 </ul>
             </nav>
         </header>
+        
+        <!-- Section d'authentification -->
+        <div id="authSection" class="auth-section">
+            <div class="auth-container">
+                <div class="auth-tabs">
+                    <button class="auth-tab active" data-tab="login">Connexion</button>
+                    <button class="auth-tab" data-tab="register">Inscription</button>
+                </div>
+
+                <!-- Formulaire de connexion -->
+                <div id="loginForm" class="auth-form">
+                    <h3>Se connecter</h3>
+
+                    <!-- Bouton Google officiel -->
+                    <div class="google-auth-container">
+                        <div id="googleSignInButton"></div>
+                    </div>
+
+                    <div class="auth-separator">
+                        <span>ou</span>
+                    </div>
+
+                    <!-- Formulaire email existant -->
+                    <div class="form-group">
+                        <label for="loginEmail">Email</label>
+                        <input type="email" id="loginEmail" required>
+                    </div>
+                    <div class="form-group">
+                        <label for="loginPassword">Mot de passe</label>
+                        <input type="password" id="loginPassword" required>
+                    </div>
+                    <button type="button" class="auth-btn" id="loginBtn">
+                        <i data-lucide="log-in"></i>
+                        Se connecter
+                    </button>
+                    <div class="auth-error" id="loginError"></div>
+                </div>
+
+                <!-- Formulaire d'inscription -->
+                <div id="registerForm" class="auth-form" style="display: none;">
+                    <h3>Créer un compte</h3>
+
+                    <!-- Bouton Google pour inscription -->
+                    <div class="google-auth-container">
+                        <div id="googleSignInButtonRegister"></div>
+                    </div>
+
+                    <div class="auth-separator">
+                        <span>ou</span>
+                    </div>
+
+                    <!-- Formulaire email existant -->
+                    <div class="form-group">
+                        <label for="registerName">Nom</label>
+                        <input type="text" id="registerName" required>
+                    </div>
+                    <div class="form-group">
+                        <label for="registerEmail">Email</label>
+                        <input type="email" id="registerEmail" required>
+                    </div>
+                    <div class="form-group">
+                        <label for="registerPassword">Mot de passe</label>
+                        <input type="password" id="registerPassword" required>
+                    </div>
+                    <button type="button" class="auth-btn" id="registerBtn">
+                        <i data-lucide="user-plus"></i>
+                        Créer mon compte
+                    </button>
+                    <div class="auth-error" id="registerError"></div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Section utilisateur connecté -->
+        <div id="userSection" class="user-section">
+            <div class="user-info">
+                <img id="userAvatar" class="user-avatar" src="" alt="" style="display: none;">
+                <i data-lucide="user-circle" id="userDefaultIcon"></i>
+                <span class="user-name"></span>
+            </div>
+            <button class="logout-btn" id="logoutBtn">
+                <i data-lucide="log-out"></i>
+                Déconnexion
+            </button>
+        </div>
 
         <main class="main-content">
             <h2>Tarifs</h2>
@@ -34,6 +123,8 @@
     </div>
 
     <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.js"></script>
+    <script src="assets/js/googleAuth.js"></script>
+    <script type="module" src="assets/js/auth.js"></script>
     <script>
         lucide.createIcons();
     </script>


### PR DESCRIPTION
## Summary
- add Login/Signup navigation link on all public pages
- embed authentication section and user panel on contact, solutions and tarifs
- load auth.js and googleAuth.js scripts to handle login/signup

## Testing
- `node frontend/tests/sanitize.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689f6600a768832580fb9906b7e9bb56