### PR TITLE
Add marketing sections and auth-aware navigation

### DIFF
--- a/frontend/assets/css/main.css
+++ b/frontend/assets/css/main.css
@@ -155,6 +155,17 @@ body::before {
     overflow: hidden;
 }
 
+.marketing-content {
+    padding: 40px 20px;
+    max-width: 800px;
+    margin: 0 auto;
+    text-align: center;
+}
+
+.marketing-section {
+    margin-bottom: 60px;
+}
+
 /* ==========================================================================
    3. Configuration Panel - Style Panneau de Contrôle Éducatif
    ========================================================================== */

--- a/frontend/assets/js/auth.js
+++ b/frontend/assets/js/auth.js
@@ -186,6 +186,7 @@ class AuthManager {
         const authSection = document.getElementById('authSection');
         const userSection = document.getElementById('userSection');
         const mainContent = document.querySelector('.main-content');
+        const authNavLink = document.getElementById('authNavLink');
 
         console.log('Mise à jour UI, authentifié:', this.isAuthenticated());
 
@@ -218,11 +219,19 @@ class AuthManager {
                 }
             }
             if (mainContent) mainContent.style.display = 'grid';
+            if (authNavLink) {
+                authNavLink.href = 'app.html';
+                authNavLink.textContent = "Accéder à l'app";
+            }
         } else {
             // Utilisateur non connecté
             if (authSection) authSection.style.display = 'block';
             if (userSection) userSection.style.display = 'none';
             if (mainContent) mainContent.style.display = 'none';
+            if (authNavLink) {
+                authNavLink.href = '#authSection';
+                authNavLink.textContent = 'Login/Signup';
+            }
         }
     }
 }

--- a/frontend/contact.html
+++ b/frontend/contact.html
@@ -26,7 +26,7 @@
                     <li><a href="solutions.html">Solutions</a></li>
                     <li><a href="tarifs.html">Tarifs</a></li>
                     <li><a href="contact.html">Contact</a></li>
-                    <li><a href="#authSection">Login/Signup</a></li>
+                    <li><a id="authNavLink" href="#authSection">Login/Signup</a></li>
                 </ul>
             </nav>
         </header>
@@ -116,7 +116,7 @@
             </button>
         </div>
 
-        <main class="main-content">
+        <main class="marketing-content">
             <h2>Contact</h2>
             <p>Une question ou une suggestion&nbsp;? Écrivez-nous à <a href="mailto:contact@skillence.ai">contact@skillence.ai</a>.</p>
         </main>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -25,10 +25,10 @@
             <nav class="header-nav">
                 <ul>
                     <li><a href="index.html">Accueil</a></li>
-                    <li><a href="solutions.html">Solutions</a></li>
-                    <li><a href="tarifs.html">Tarifs</a></li>
-                    <li><a href="contact.html">Contact</a></li>
-                    <li><a href="#authSection">Login/Signup</a></li>
+                    <li><a href="#solutions">Solutions</a></li>
+                    <li><a href="#tarifs">Tarifs</a></li>
+                    <li><a href="#contact">Contact</a></li>
+                    <li><a id="authNavLink" href="#authSection">Login/Signup</a></li>
                 </ul>
             </nav>
         </header>
@@ -106,6 +106,24 @@
         </div>
 
         <!-- Section utilisateur connecté et contenu principal déplacés vers app.html -->
+
+        <main class="marketing-content">
+            <section id="solutions" class="marketing-section">
+                <h2>Nos solutions</h2>
+                <p>Découvrez comment Skillence AI peut vous aider à apprendre plus efficacement grâce à des cours personnalisés et des outils interactifs.</p>
+            </section>
+
+            <section id="tarifs" class="marketing-section">
+                <h2>Tarifs</h2>
+                <p>Choisissez le plan qui vous convient, de l'accès gratuit aux fonctionnalités avancées pour les apprenants passionnés.</p>
+            </section>
+
+            <section id="contact" class="marketing-section">
+                <h2>Contact</h2>
+                <p>Une question ou une suggestion&nbsp;? Écrivez-nous à <a href="mailto:contact@skillence.ai">contact@skillence.ai</a>.</p>
+            </section>
+        </main>
+
     </div>
 
     <!-- Scripts - Dans l'ordre de dépendance -->

--- a/frontend/solutions.html
+++ b/frontend/solutions.html
@@ -26,7 +26,7 @@
                     <li><a href="solutions.html">Solutions</a></li>
                     <li><a href="tarifs.html">Tarifs</a></li>
                     <li><a href="contact.html">Contact</a></li>
-                    <li><a href="#authSection">Login/Signup</a></li>
+                    <li><a id="authNavLink" href="#authSection">Login/Signup</a></li>
                 </ul>
             </nav>
         </header>
@@ -116,7 +116,7 @@
             </button>
         </div>
 
-        <main class="main-content">
+        <main class="marketing-content">
             <h2>Nos solutions</h2>
             <p>Découvrez comment Skillence AI peut vous aider à apprendre plus efficacement grâce à des cours personnalisés et des outils interactifs.</p>
         </main>

--- a/frontend/tarifs.html
+++ b/frontend/tarifs.html
@@ -26,7 +26,7 @@
                     <li><a href="solutions.html">Solutions</a></li>
                     <li><a href="tarifs.html">Tarifs</a></li>
                     <li><a href="contact.html">Contact</a></li>
-                    <li><a href="#authSection">Login/Signup</a></li>
+                    <li><a id="authNavLink" href="#authSection">Login/Signup</a></li>
                 </ul>
             </nav>
         </header>
@@ -116,7 +116,7 @@
             </button>
         </div>
 
-        <main class="main-content">
+        <main class="marketing-content">
             <h2>Tarifs</h2>
             <p>Choisissez le plan qui vous convient, de l'accès gratuit aux fonctionnalités avancées pour les apprenants passionnés.</p>
         </main>


### PR DESCRIPTION
## Summary
- Integrate marketing sections for solutions, pricing, and contact into the landing page and style them.
- Update login navigation across pages so authenticated users go to `app.html`.
- Add styles for new marketing content blocks.

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689f751d44788325a1b195f40d3ce041