### PR TITLE
feat: add login guards

### DIFF
--- a/frontend/app.html
+++ b/frontend/app.html
@@ -140,6 +140,8 @@
         </div>
     </div>
 
+    <script src="assets/js/auth-check.js"></script>
+    <script src="assets/js/app-auth-check.js"></script>
     <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.js"></script>
     <script type="module" src="assets/js/utils.js"></script>
     <script src="assets/js/googleAuth.js"></script>

--- a/frontend/assets/js/app-auth-check.js
+++ b/frontend/assets/js/app-auth-check.js
@@ -1,0 +1,6 @@
+document.addEventListener('DOMContentLoaded', () => {
+    if (!window.isLoggedIn || !window.isLoggedIn()) {
+        window.location.href = '/index.html';
+    }
+});
+

--- a/frontend/assets/js/auth-check.js
+++ b/frontend/assets/js/auth-check.js
@@ -3,8 +3,8 @@ function isLoggedIn() {
 }
 
 document.addEventListener('DOMContentLoaded', () => {
-    if (isLoggedIn()) {
-        window.location.href = 'app.html';
+    if (isLoggedIn() && window.location.pathname !== '/app.html') {
+        window.location.href = '/app.html';
     }
 });
 


### PR DESCRIPTION
## Summary
- Redirect logged-in users to `/app.html` from public pages
- Add app-level guard that sends unauthenticated users back to `/index.html`

## Testing
- `node --test frontend/tests/sanitize.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689f783f1cb08325b39f419f5f456aec