### PR TITLE
Clean marketing pages and navigation

### DIFF
--- a/frontend/assets/js/auth-check.js
+++ b/frontend/assets/js/auth-check.js
@@ -3,8 +3,19 @@ function isLoggedIn() {
 }
 
 document.addEventListener('DOMContentLoaded', () => {
-    if (isLoggedIn() && window.location.pathname !== '/app.html') {
-        window.location.href = '/app.html';
+    const authLink = document.getElementById('authNavLink');
+    const authSection = document.getElementById('authSection');
+
+    if (authLink) {
+        if (isLoggedIn()) {
+            authLink.textContent = 'Mon espace';
+            authLink.href = '/app.html';
+            if (authSection) authSection.style.display = 'none';
+        } else {
+            authLink.textContent = 'Login/Signup';
+            authLink.href = '#authSection';
+            if (authSection) authSection.style.display = '';
+        }
     }
 });
 

--- a/frontend/contact.html
+++ b/frontend/contact.html
@@ -102,20 +102,6 @@
                 </div>
             </div>
         </div>
-
-        <!-- Section utilisateur connecté -->
-        <div id="userSection" class="user-section">
-            <div class="user-info">
-                <img id="userAvatar" class="user-avatar" src="" alt="" style="display: none;">
-                <i data-lucide="user-circle" id="userDefaultIcon"></i>
-                <span class="user-name"></span>
-            </div>
-            <button class="logout-btn" id="logoutBtn">
-                <i data-lucide="log-out"></i>
-                Déconnexion
-            </button>
-        </div>
-
         <main class="marketing-content">
             <h2>Contact</h2>
             <p>Une question ou une suggestion&nbsp;? Écrivez-nous à <a href="mailto:contact@skillence.ai">contact@skillence.ai</a>.</p>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -25,9 +25,9 @@
             <nav class="header-nav">
                 <ul>
                     <li><a href="index.html">Accueil</a></li>
-                    <li><a href="#solutions">Solutions</a></li>
-                    <li><a href="#tarifs">Tarifs</a></li>
-                    <li><a href="#contact">Contact</a></li>
+                    <li><a href="solutions.html">Solutions</a></li>
+                    <li><a href="tarifs.html">Tarifs</a></li>
+                    <li><a href="contact.html">Contact</a></li>
                     <li><a id="authNavLink" href="#authSection">Login/Signup</a></li>
                 </ul>
             </nav>

--- a/frontend/solutions.html
+++ b/frontend/solutions.html
@@ -102,20 +102,6 @@
                 </div>
             </div>
         </div>
-
-        <!-- Section utilisateur connecté -->
-        <div id="userSection" class="user-section">
-            <div class="user-info">
-                <img id="userAvatar" class="user-avatar" src="" alt="" style="display: none;">
-                <i data-lucide="user-circle" id="userDefaultIcon"></i>
-                <span class="user-name"></span>
-            </div>
-            <button class="logout-btn" id="logoutBtn">
-                <i data-lucide="log-out"></i>
-                Déconnexion
-            </button>
-        </div>
-
         <main class="marketing-content">
             <h2>Nos solutions</h2>
             <p>Découvrez comment Skillence AI peut vous aider à apprendre plus efficacement grâce à des cours personnalisés et des outils interactifs.</p>

--- a/frontend/tarifs.html
+++ b/frontend/tarifs.html
@@ -102,20 +102,6 @@
                 </div>
             </div>
         </div>
-
-        <!-- Section utilisateur connecté -->
-        <div id="userSection" class="user-section">
-            <div class="user-info">
-                <img id="userAvatar" class="user-avatar" src="" alt="" style="display: none;">
-                <i data-lucide="user-circle" id="userDefaultIcon"></i>
-                <span class="user-name"></span>
-            </div>
-            <button class="logout-btn" id="logoutBtn">
-                <i data-lucide="log-out"></i>
-                Déconnexion
-            </button>
-        </div>
-
         <main class="marketing-content">
             <h2>Tarifs</h2>
             <p>Choisissez le plan qui vous convient, de l'accès gratuit aux fonctionnalités avancées pour les apprenants passionnés.</p>


### PR DESCRIPTION
## Summary
- Remove app-specific user sections from marketing pages
- Update landing navigation links and toggle app link based on login

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f7977b3b88325b2f5ef29a4234750