### PR TITLE
Hide auth section by default and reveal via link click

### DIFF
--- a/frontend/assets/css/main.css
+++ b/frontend/assets/css/main.css
@@ -1999,6 +1999,7 @@ body::before {
 /* === STYLES D'AUTHENTIFICATION === */
 
 .auth-section {
+    display: none;
     background: white;
     border-radius: 20px;
     padding: 40px;

--- a/frontend/assets/js/auth-check.js
+++ b/frontend/assets/js/auth-check.js
@@ -14,7 +14,6 @@ document.addEventListener('DOMContentLoaded', () => {
         } else {
             authLink.textContent = 'Login/Signup';
             authLink.href = '#authSection';
-            if (authSection) authSection.style.display = '';
         }
     }
 });

--- a/frontend/assets/js/auth.js
+++ b/frontend/assets/js/auth.js
@@ -228,7 +228,6 @@ class AuthManager {
             }
         } else {
             // Utilisateur non connecté
-            if (authSection) authSection.style.display = 'block';
             if (userSection) userSection.style.display = 'none';
             if (mainContent) mainContent.style.display = 'none';
             if (authNavLink) {
@@ -412,6 +411,16 @@ document.addEventListener('DOMContentLoaded', function() {
 
     const separators = document.querySelectorAll('.auth-separator');
     separators.forEach(el => el.style.display = 'none');
+
+    const authNavLink = document.getElementById('authNavLink');
+    const authSection = document.getElementById('authSection');
+    if (authNavLink && authSection) {
+        authNavLink.addEventListener('click', (e) => {
+            e.preventDefault();
+            authSection.style.display = 'block';
+            authSection.scrollIntoView({ behavior: 'smooth' });
+        });
+    }
 
     setupAuthListeners();
     initializeGoogleAuth();


### PR DESCRIPTION
## Summary
- Hide authentication section by default in CSS
- Remove automatic auth section display in JavaScript
- Show auth section and scroll when login/signup link is clicked

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689f92ccd6c88325a948f8fb3cafa55b