### PR TITLE
Remove contact section from frontend index

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -118,10 +118,6 @@
                 <p>Choisissez le plan qui vous convient, de l'accès gratuit aux fonctionnalités avancées pour les apprenants passionnés.</p>
             </section>
 
-            <section id="contact" class="marketing-section">
-                <h2>Contact</h2>
-                <p>Une question ou une suggestion&nbsp;? Écrivez-nous à <a href="mailto:contact@skillence.ai">contact@skillence.ai</a>.</p>
-            </section>
         </main>
 
     </div>


### PR DESCRIPTION
## Summary
- remove obsolete contact section from frontend landing page to hide contact email

## Testing
- `node --test frontend/tests/sanitize.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689f9560f3408325bf384a0c333e18b2