### PR TITLE
feat: split marketing content into dedicated homepage

### DIFF
--- a/frontend/assets/js/auth-check.js
+++ b/frontend/assets/js/auth-check.js
@@ -13,7 +13,7 @@ document.addEventListener('DOMContentLoaded', () => {
             if (authSection) authSection.style.display = 'none';
         } else {
             authLink.textContent = 'Login/Signup';
-            authLink.href = '#authSection';
+            authLink.href = authSection ? '#authSection' : 'index.html#authSection';
         }
     }
 });

--- a/frontend/contact.html
+++ b/frontend/contact.html
@@ -22,7 +22,7 @@
             </div>
             <nav class="header-nav">
                 <ul>
-                    <li><a href="index.html">Accueil</a></li>
+                    <li><a href="home.html">Accueil</a></li>
                     <li><a href="solutions.html">Solutions</a></li>
                     <li><a href="tarifs.html">Tarifs</a></li>
                     <li><a href="contact.html">Contact</a></li>

--- a/frontend/home.html
+++ b/frontend/home.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Skillence AI - Accueil</title>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="preconnect" href="https://accounts.google.com">
+    <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.js"></script>
+    <link rel="stylesheet" href="assets/css/main.css">
+</head>
+<body>
+    <div id="loadingOverlay" class="loading-overlay" style="display:none;">
+        <div class="loading-spinner"></div>
+    </div>
+    <div class="container">
+        <header class="header">
+            <button class="menu-toggle" id="menuToggle">
+                <i data-lucide="menu"></i>
+            </button>
+            <div class="header-text">
+                <h1>Skillence AI</h1>
+                <p>Le savoir accessible à tous</p>
+            </div>
+            <nav class="header-nav">
+                <ul>
+                    <li><a href="home.html">Accueil</a></li>
+                    <li><a href="solutions.html">Solutions</a></li>
+                    <li><a href="tarifs.html">Tarifs</a></li>
+                    <li><a href="contact.html">Contact</a></li>
+                    <li><a id="authNavLink" href="index.html">Login/Signup</a></li>
+                </ul>
+            </nav>
+        </header>
+
+        <main class="marketing-content">
+            <section id="solutions" class="marketing-section">
+                <h2>Nos solutions</h2>
+                <p>Découvrez comment Skillence AI peut vous aider à apprendre plus efficacement grâce à des cours personnalisés et des outils interactifs.</p>
+            </section>
+
+            <section id="tarifs" class="marketing-section">
+                <h2>Tarifs</h2>
+                <p>Choisissez le plan qui vous convient, de l'accès gratuit aux fonctionnalités avancées pour les apprenants passionnés.</p>
+            </section>
+        </main>
+    </div>
+
+    <script src="assets/js/auth-check.js"></script>
+    <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.js"></script>
+    <script>
+        lucide.createIcons();
+    </script>
+</body>
+</html>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -24,7 +24,7 @@
             </div>
             <nav class="header-nav">
                 <ul>
-                    <li><a href="index.html">Accueil</a></li>
+                    <li><a href="home.html">Accueil</a></li>
                     <li><a href="solutions.html">Solutions</a></li>
                     <li><a href="tarifs.html">Tarifs</a></li>
                     <li><a href="contact.html">Contact</a></li>
@@ -106,20 +106,6 @@
         </div>
 
         <!-- Section utilisateur connecté et contenu principal déplacés vers app.html -->
-
-        <main class="marketing-content">
-            <section id="solutions" class="marketing-section">
-                <h2>Nos solutions</h2>
-                <p>Découvrez comment Skillence AI peut vous aider à apprendre plus efficacement grâce à des cours personnalisés et des outils interactifs.</p>
-            </section>
-
-            <section id="tarifs" class="marketing-section">
-                <h2>Tarifs</h2>
-                <p>Choisissez le plan qui vous convient, de l'accès gratuit aux fonctionnalités avancées pour les apprenants passionnés.</p>
-            </section>
-
-        </main>
-
     </div>
 
     <!-- Scripts - Dans l'ordre de dépendance -->

--- a/frontend/solutions.html
+++ b/frontend/solutions.html
@@ -22,7 +22,7 @@
             </div>
             <nav class="header-nav">
                 <ul>
-                    <li><a href="index.html">Accueil</a></li>
+                    <li><a href="home.html">Accueil</a></li>
                     <li><a href="solutions.html">Solutions</a></li>
                     <li><a href="tarifs.html">Tarifs</a></li>
                     <li><a href="contact.html">Contact</a></li>

--- a/frontend/tarifs.html
+++ b/frontend/tarifs.html
@@ -22,7 +22,7 @@
             </div>
             <nav class="header-nav">
                 <ul>
-                    <li><a href="index.html">Accueil</a></li>
+                    <li><a href="home.html">Accueil</a></li>
                     <li><a href="solutions.html">Solutions</a></li>
                     <li><a href="tarifs.html">Tarifs</a></li>
                     <li><a href="contact.html">Contact</a></li>


### PR DESCRIPTION
## Summary
- remove marketing content from login page so it only includes authentication forms
- add standalone home page with marketing sections and link navbars to it
- adjust auth link logic when pages lack an auth section

## Testing
- `npm test` *(fails: Missing script "test")*
- `node --test frontend/tests/sanitize.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689f9784cebc832590eba5132b984bed