### PR TITLE
fix: serve home page at root

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -122,9 +122,9 @@ app.use(express.static(path.join(__dirname, '../../frontend')));
 // Routes API
 app.use('/api', apiRoutes);
 
-// Route pour servir le frontend
+// Route pour la page d'accueil
 app.get('/', (req, res) => {
-  res.sendFile(path.join(__dirname, '../../frontend/index.html'));
+  res.sendFile(path.join(__dirname, '../../frontend/home.html'));
 });
 
 // Middleware de gestion des erreurs globales


### PR DESCRIPTION
## Summary
- serve home.html when accessing `/`

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689f99dae16883258b95be27733da529