### PR TITLE
Redirect logout to home page

### DIFF
--- a/frontend/assets/js/auth.js
+++ b/frontend/assets/js/auth.js
@@ -171,7 +171,7 @@ class AuthManager {
         }
 
         this.updateUI();
-        window.location.href = 'index.html';
+        window.location.href = 'home.html';
     }
 
     // VÉRIFIER SI CONNECTÉ


### PR DESCRIPTION
## Summary
- Redirect logout to `home.html` instead of `index.html` so users land on the homepage after signing out.

## Testing
- `npm test` *(fails: Missing script: "test")*
- `python3 -m http.server 8080 --directory frontend` & `curl -I http://127.0.0.1:8080/home.html`


------
https://chatgpt.com/codex/tasks/task_e_689f9caa5ad483259811205c79506992