### PR TITLE
Serve home route before static middleware

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -116,16 +116,16 @@ app.use(express.json({ limit: '10mb' }));
 app.use(express.urlencoded({ extended: true }));
 app.use(cookieParser());
 
+// Route pour la page d'accueil
+app.get('/', (req, res) => {
+  res.sendFile(path.join(__dirname, '../../frontend/home.html'));
+});
+
 // Servir les fichiers statiques du frontend
 app.use(express.static(path.join(__dirname, '../../frontend')));
 
 // Routes API
 app.use('/api', apiRoutes);
-
-// Route pour la page d'accueil
-app.get('/', (req, res) => {
-  res.sendFile(path.join(__dirname, '../../frontend/home.html'));
-});
 
 // Middleware de gestion des erreurs globales
 app.use((err, req, res, next) => {


### PR DESCRIPTION
## Summary
- Register home route before static middleware so `/` serves the custom `home.html` file.

## Testing
- `npm test` *(fails: Missing script "test")*
- `node --test` *(fails: test failures)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/cookie-parser)*


------
https://chatgpt.com/codex/tasks/task_e_689f9e4503708325b0620ecbb7065472