### PR TITLE
Deduplicate Lucide script tags and initialize icons

### DIFF
--- a/frontend/app.html
+++ b/frontend/app.html
@@ -143,6 +143,9 @@
     <script src="assets/js/auth-check.js"></script>
     <script src="assets/js/app-auth-check.js"></script>
     <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.js"></script>
+    <script>
+        lucide.createIcons();
+    </script>
     <script type="module" src="assets/js/utils.js"></script>
     <script src="assets/js/googleAuth.js"></script>
     <script type="module" src="assets/js/auth.js"></script>

--- a/frontend/home.html
+++ b/frontend/home.html
@@ -6,7 +6,6 @@
     <title>Skillence AI - Accueil</title>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="preconnect" href="https://accounts.google.com">
-    <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.js"></script>
     <link rel="stylesheet" href="assets/css/main.css">
 </head>
 <body>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -6,7 +6,6 @@
     <title>Skillence AI - Le savoir accessible à tous</title>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="preconnect" href="https://accounts.google.com">
-    <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.js"></script>
     <link rel="stylesheet" href="assets/css/main.css">
 </head>
 <body>
@@ -111,6 +110,9 @@
     <!-- Scripts - Dans l'ordre de dépendance -->
     <script src="assets/js/auth-check.js"></script>
     <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.js"></script>
+    <script>
+        lucide.createIcons();
+    </script>
     <script type="module" src="assets/js/utils.js"></script>
     <script src="assets/js/googleAuth.js"></script>
     <script type="module" src="assets/js/auth.js"></script>


### PR DESCRIPTION
## Summary
- remove duplicate Lucide script tag from home.html and index.html
- initialize Lucide icons after script include on index.html and app.html

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689fa07bbd908325823f66001df5e112