### PR TITLE
feat: add mobile navigation toggle

### DIFF
--- a/frontend/assets/js/navigation.js
+++ b/frontend/assets/js/navigation.js
@@ -1,0 +1,26 @@
+export function initNavigation() {
+  const menuToggle = document.getElementById('menuToggle');
+  const nav = document.querySelector('.header-nav');
+
+  if (!menuToggle || !nav) {
+    return;
+  }
+
+  // Ensure aria-expanded is set
+  menuToggle.setAttribute('aria-expanded', 'false');
+
+  menuToggle.addEventListener('click', () => {
+    const expanded = menuToggle.getAttribute('aria-expanded') === 'true';
+    menuToggle.setAttribute('aria-expanded', String(!expanded));
+    nav.classList.toggle('open');
+  });
+}
+
+// Initialize immediately after import
+if (typeof window !== 'undefined') {
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initNavigation);
+  } else {
+    initNavigation();
+  }
+}

--- a/frontend/contact.html
+++ b/frontend/contact.html
@@ -112,6 +112,7 @@
     <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.js"></script>
     <script src="assets/js/googleAuth.js"></script>
     <script type="module" src="assets/js/auth.js"></script>
+    <script type="module" src="assets/js/navigation.js"></script>
     <script>
         lucide.createIcons();
     </script>

--- a/frontend/home.html
+++ b/frontend/home.html
@@ -47,6 +47,7 @@
 
     <script src="assets/js/auth-check.js"></script>
     <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.js"></script>
+    <script type="module" src="assets/js/navigation.js"></script>
     <script>
         lucide.createIcons();
     </script>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -110,6 +110,7 @@
     <!-- Scripts - Dans l'ordre de dépendance -->
     <script src="assets/js/auth-check.js"></script>
     <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.js"></script>
+    <script type="module" src="assets/js/navigation.js"></script>
     <script>
         lucide.createIcons();
     </script>

--- a/frontend/solutions.html
+++ b/frontend/solutions.html
@@ -112,6 +112,7 @@
     <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.js"></script>
     <script src="assets/js/googleAuth.js"></script>
     <script type="module" src="assets/js/auth.js"></script>
+    <script type="module" src="assets/js/navigation.js"></script>
     <script>
         lucide.createIcons();
     </script>

--- a/frontend/tarifs.html
+++ b/frontend/tarifs.html
@@ -112,6 +112,7 @@
     <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.js"></script>
     <script src="assets/js/googleAuth.js"></script>
     <script type="module" src="assets/js/auth.js"></script>
+    <script type="module" src="assets/js/navigation.js"></script>
     <script>
         lucide.createIcons();
     </script>


### PR DESCRIPTION
## Summary
- add navigation script that toggles menu and aria-expanded state
- load navigation module on marketing pages for responsive header

## Testing
- `node --input-type=module - <<'NODE' ... NODE`
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68a02f943ec88325a4a0fc789b25d1d1