### PR TITLE
Add ARIA attributes and sync menu toggle

### DIFF
--- a/frontend/assets/js/main.js
+++ b/frontend/assets/js/main.js
@@ -48,7 +48,7 @@ function setupEventListeners() {
     const randomSubjectBtn = document.getElementById('randomSubjectBtn');
     const menuToggle = document.getElementById('menuToggle');
     const configPanel = document.querySelector('.configuration-panel');
-    const headerNav = document.querySelector('.header-nav');
+    const headerNav = document.getElementById('headerNav');
     const closeConfigBtn = document.getElementById('closeConfigBtn');
 
     if (generateBtn) generateBtn.addEventListener('click', handleGenerateCourse);
@@ -57,12 +57,16 @@ function setupEventListeners() {
     if (randomSubjectBtn) randomSubjectBtn.addEventListener('click', generateRandomSubject);
 
     if (menuToggle) {
-        menuToggle.setAttribute('aria-expanded', 'false');
+        const updateAria = () => {
+            const expanded = headerNav && headerNav.classList.contains('open');
+            menuToggle.setAttribute('aria-expanded', expanded ? 'true' : 'false');
+        };
+        updateAria();
+
         const toggleNavigation = () => {
-            const expanded = menuToggle.getAttribute('aria-expanded') === 'true';
-            menuToggle.setAttribute('aria-expanded', String(!expanded));
             if (headerNav) headerNav.classList.toggle('open');
             if (configPanel) configPanel.classList.toggle('open');
+            updateAria();
         };
 
         menuToggle.addEventListener('click', toggleNavigation);

--- a/frontend/assets/js/navigation.js
+++ b/frontend/assets/js/navigation.js
@@ -1,18 +1,21 @@
 export function initNavigation() {
   const menuToggle = document.getElementById('menuToggle');
-  const nav = document.querySelector('.header-nav');
+  const nav = document.getElementById('headerNav');
 
   if (!menuToggle || !nav) {
     return;
   }
 
-  // Ensure aria-expanded is set
-  menuToggle.setAttribute('aria-expanded', 'false');
+  const updateAria = () => {
+    const expanded = nav.classList.contains('open');
+    menuToggle.setAttribute('aria-expanded', expanded ? 'true' : 'false');
+  };
+
+  updateAria();
 
   menuToggle.addEventListener('click', () => {
-    const expanded = menuToggle.getAttribute('aria-expanded') === 'true';
-    menuToggle.setAttribute('aria-expanded', String(!expanded));
     nav.classList.toggle('open');
+    updateAria();
   });
 }
 

--- a/frontend/contact.html
+++ b/frontend/contact.html
@@ -13,14 +13,14 @@
     </div>
     <div class="container">
         <header class="header">
-            <button class="menu-toggle" id="menuToggle">
+            <button id="menuToggle" class="menu-toggle" aria-label="Ouvrir le menu" aria-controls="headerNav" aria-expanded="false">
                 <i data-lucide="menu"></i>
             </button>
             <div class="header-text">
                 <h1>Skillence AI</h1>
                 <p>Le savoir accessible à tous</p>
             </div>
-            <nav class="header-nav">
+            <nav id="headerNav" class="header-nav">
                 <ul>
                     <li><a href="home.html">Accueil</a></li>
                     <li><a href="solutions.html">Solutions</a></li>

--- a/frontend/home.html
+++ b/frontend/home.html
@@ -14,14 +14,14 @@
     </div>
     <div class="container">
         <header class="header">
-            <button class="menu-toggle" id="menuToggle">
+            <button id="menuToggle" class="menu-toggle" aria-label="Ouvrir le menu" aria-controls="headerNav" aria-expanded="false">
                 <i data-lucide="menu"></i>
             </button>
             <div class="header-text">
                 <h1>Skillence AI</h1>
                 <p>Le savoir accessible à tous</p>
             </div>
-            <nav class="header-nav">
+            <nav id="headerNav" class="header-nav">
                 <ul>
                     <li><a href="home.html">Accueil</a></li>
                     <li><a href="solutions.html">Solutions</a></li>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -14,14 +14,14 @@
     </div>
     <div class="container">
         <header class="header">
-            <button class="menu-toggle" id="menuToggle">
+            <button id="menuToggle" class="menu-toggle" aria-label="Ouvrir le menu" aria-controls="headerNav" aria-expanded="false">
                 <i data-lucide="menu"></i>
             </button>
             <div class="header-text">
                 <h1>Skillence AI</h1>
                 <p>Le savoir accessible à tous</p>
             </div>
-            <nav class="header-nav">
+            <nav id="headerNav" class="header-nav">
                 <ul>
                     <li><a href="home.html">Accueil</a></li>
                     <li><a href="solutions.html">Solutions</a></li>

--- a/frontend/solutions.html
+++ b/frontend/solutions.html
@@ -13,14 +13,14 @@
     </div>
     <div class="container">
         <header class="header">
-            <button class="menu-toggle" id="menuToggle">
+            <button id="menuToggle" class="menu-toggle" aria-label="Ouvrir le menu" aria-controls="headerNav" aria-expanded="false">
                 <i data-lucide="menu"></i>
             </button>
             <div class="header-text">
                 <h1>Skillence AI</h1>
                 <p>Le savoir accessible à tous</p>
             </div>
-            <nav class="header-nav">
+            <nav id="headerNav" class="header-nav">
                 <ul>
                     <li><a href="home.html">Accueil</a></li>
                     <li><a href="solutions.html">Solutions</a></li>

--- a/frontend/tarifs.html
+++ b/frontend/tarifs.html
@@ -13,14 +13,14 @@
     </div>
     <div class="container">
         <header class="header">
-            <button class="menu-toggle" id="menuToggle">
+            <button id="menuToggle" class="menu-toggle" aria-label="Ouvrir le menu" aria-controls="headerNav" aria-expanded="false">
                 <i data-lucide="menu"></i>
             </button>
             <div class="header-text">
                 <h1>Skillence AI</h1>
                 <p>Le savoir accessible à tous</p>
             </div>
-            <nav class="header-nav">
+            <nav id="headerNav" class="header-nav">
                 <ul>
                     <li><a href="home.html">Accueil</a></li>
                     <li><a href="solutions.html">Solutions</a></li>


### PR DESCRIPTION
## Summary
- add `aria-label`, `aria-controls`, and `aria-expanded` to menu toggle buttons and give header nav an `id`
- sync `aria-expanded` with the menu state in navigation scripts

## Testing
- `npx @axe-core/cli frontend/index.html` (fails: 403 Forbidden)
- `npx pa11y frontend/index.html` (fails: 403 Forbidden)
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68a034b86c608325be9e8f53311ab4cf