### PR TITLE
feat: add mobile configuration menu toggle

### DIFF
--- a/frontend/app.html
+++ b/frontend/app.html
@@ -11,6 +11,9 @@
         <div class="loading-spinner"></div>
     </div>
     <div class="container">
+        <button id="menuToggle" class="menu-toggle" aria-label="Ouvrir la configuration">
+            <i data-lucide="menu"></i>
+        </button>
         <!-- Section utilisateur connecté -->
         <div id="userSection" class="user-section">
             <div class="user-info">


### PR DESCRIPTION
## Summary
- add hamburger button to open configuration panel on mobile

## Testing
- `npm test` (fails: Missing script: "test")
- `node - <<'NODE'
class MockClassList {
  constructor() { this.classes = new Set(); }
  toggle(cls) { this.classes.has(cls) ? this.classes.delete(cls) : this.classes.add(cls); }
  contains(cls) { return this.classes.has(cls); }
}

const configPanel = { classList: new MockClassList() };
const menuToggle = { handler: null, addEventListener: function(event, cb){ if(event==='click') this.handler = cb; } };
const toggleNavigation = () => configPanel.classList.toggle('open');
menuToggle.addEventListener('click', toggleNavigation);
console.log('Initial open:', configPanel.classList.contains('open'));
menuToggle.handler();
console.log('After 1st click:', configPanel.classList.contains('open'));
menuToggle.handler();
console.log('After 2nd click:', configPanel.classList.contains('open'));
NODE`


------
https://chatgpt.com/codex/tasks/task_e_68a0372696288325b40dcb55a5820210