### PR TITLE
feat: separate auth section into dedicated page

### DIFF
--- a/frontend/assets/js/auth-check.js
+++ b/frontend/assets/js/auth-check.js
@@ -13,7 +13,7 @@ document.addEventListener('DOMContentLoaded', () => {
             if (authSection) authSection.style.display = 'none';
         } else {
             authLink.textContent = 'Login/Signup';
-            authLink.href = authSection ? '#authSection' : 'index.html#authSection';
+            authLink.href = 'auth.html';
         }
     }
 });

--- a/frontend/assets/js/auth.js
+++ b/frontend/assets/js/auth.js
@@ -231,7 +231,7 @@ class AuthManager {
             if (userSection) userSection.style.display = 'none';
             if (mainContent) mainContent.style.display = 'none';
             if (authNavLink) {
-                authNavLink.href = '#authSection';
+                authNavLink.href = 'auth.html';
                 authNavLink.textContent = 'Login/Signup';
             }
         }
@@ -409,21 +409,14 @@ async function initializeGoogleAuth() {
 document.addEventListener('DOMContentLoaded', function() {
     console.log('DOM chargé, configuration de l\'authentification...');
 
-    const separators = document.querySelectorAll('.auth-separator');
-    separators.forEach(el => el.style.display = 'none');
-
-    const authNavLink = document.getElementById('authNavLink');
     const authSection = document.getElementById('authSection');
-    if (authNavLink && authSection) {
-        authNavLink.addEventListener('click', (e) => {
-            e.preventDefault();
-            authSection.style.display = 'block';
-            authSection.scrollIntoView({ behavior: 'smooth' });
-        });
-    }
+    if (authSection) {
+        const separators = document.querySelectorAll('.auth-separator');
+        separators.forEach(el => el.style.display = 'none');
 
-    setupAuthListeners();
-    initializeGoogleAuth();
+        setupAuthListeners();
+        initializeGoogleAuth();
+    }
 });
 
 // Export global

--- a/frontend/auth.html
+++ b/frontend/auth.html
@@ -1,0 +1,119 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Skillence AI - Le savoir accessible à tous</title>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="preconnect" href="https://accounts.google.com">
+    <link rel="stylesheet" href="assets/css/main.css">
+</head>
+<body>
+    <div id="loadingOverlay" class="loading-overlay" style="display:none;">
+        <div class="loading-spinner"></div>
+    </div>
+    <div class="container">
+        <header class="header">
+            <button id="menuToggle" class="menu-toggle" aria-label="Ouvrir le menu" aria-controls="headerNav" aria-expanded="false">
+                <i data-lucide="menu"></i>
+            </button>
+            <div class="header-text">
+                <h1>Skillence AI</h1>
+                <p>Le savoir accessible à tous</p>
+            </div>
+            <nav id="headerNav" class="header-nav">
+                <ul>
+                    <li><a href="home.html">Accueil</a></li>
+                    <li><a href="solutions.html">Solutions</a></li>
+                    <li><a href="tarifs.html">Tarifs</a></li>
+                    <li><a href="contact.html">Contact</a></li>
+                    <li><a id="authNavLink" href="auth.html">Login/Signup</a></li>
+                </ul>
+            </nav>
+        </header>
+
+        <!-- Section d'authentification -->
+        <div id="authSection" class="auth-section" style="display:block;">
+            <div class="auth-container">
+                <div class="auth-tabs">
+                    <button class="auth-tab active" data-tab="login">Connexion</button>
+                    <button class="auth-tab" data-tab="register">Inscription</button>
+                </div>
+
+                <!-- Formulaire de connexion -->
+                <div id="loginForm" class="auth-form">
+                    <h3>Se connecter</h3>
+
+                    <!-- Bouton Google officiel -->
+                    <div class="google-auth-container">
+                        <div id="googleSignInButton"></div>
+                    </div>
+
+                    <div class="auth-separator">
+                        <span>ou</span>
+                    </div>
+
+                    <!-- Formulaire email existant -->
+                    <div class="form-group">
+                        <label for="loginEmail">Email</label>
+                        <input type="email" id="loginEmail" required>
+                    </div>
+                    <div class="form-group">
+                        <label for="loginPassword">Mot de passe</label>
+                        <input type="password" id="loginPassword" required>
+                    </div>
+                    <button type="button" class="auth-btn" id="loginBtn">
+                        <i data-lucide="log-in"></i>
+                        Se connecter
+                    </button>
+                    <div class="auth-error" id="loginError"></div>
+                </div>
+
+                <!-- Formulaire d'inscription -->
+                <div id="registerForm" class="auth-form" style="display: none;">
+                    <h3>Créer un compte</h3>
+
+                    <!-- Bouton Google pour inscription -->
+                    <div class="google-auth-container">
+                        <div id="googleSignInButtonRegister"></div>
+                    </div>
+
+                    <div class="auth-separator">
+                        <span>ou</span>
+                    </div>
+
+                    <!-- Formulaire email existant -->
+                    <div class="form-group">
+                        <label for="registerName">Nom</label>
+                        <input type="text" id="registerName" required>
+                    </div>
+                    <div class="form-group">
+                        <label for="registerEmail">Email</label>
+                        <input type="email" id="registerEmail" required>
+                    </div>
+                    <div class="form-group">
+                        <label for="registerPassword">Mot de passe</label>
+                        <input type="password" id="registerPassword" required>
+                    </div>
+                    <button type="button" class="auth-btn" id="registerBtn">
+                        <i data-lucide="user-plus"></i>
+                        Créer mon compte
+                    </button>
+                    <div class="auth-error" id="registerError"></div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Scripts - Dans l'ordre de dépendance -->
+    <script src="assets/js/auth-check.js"></script>
+    <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.js"></script>
+    <script type="module" src="assets/js/navigation.js"></script>
+    <script>
+        lucide.createIcons();
+    </script>
+    <script type="module" src="assets/js/utils.js"></script>
+    <script src="assets/js/googleAuth.js"></script>
+    <script type="module" src="assets/js/auth.js"></script>
+</body>
+</html>

--- a/frontend/contact.html
+++ b/frontend/contact.html
@@ -26,82 +26,10 @@
                     <li><a href="solutions.html">Solutions</a></li>
                     <li><a href="tarifs.html">Tarifs</a></li>
                     <li><a href="contact.html">Contact</a></li>
-                    <li><a id="authNavLink" href="#authSection">Login/Signup</a></li>
+                    <li><a id="authNavLink" href="auth.html">Login/Signup</a></li>
                 </ul>
             </nav>
         </header>
-        
-        <!-- Section d'authentification -->
-        <div id="authSection" class="auth-section">
-            <div class="auth-container">
-                <div class="auth-tabs">
-                    <button class="auth-tab active" data-tab="login">Connexion</button>
-                    <button class="auth-tab" data-tab="register">Inscription</button>
-                </div>
-
-                <!-- Formulaire de connexion -->
-                <div id="loginForm" class="auth-form">
-                    <h3>Se connecter</h3>
-
-                    <!-- Bouton Google officiel -->
-                    <div class="google-auth-container">
-                        <div id="googleSignInButton"></div>
-                    </div>
-
-                    <div class="auth-separator">
-                        <span>ou</span>
-                    </div>
-
-                    <!-- Formulaire email existant -->
-                    <div class="form-group">
-                        <label for="loginEmail">Email</label>
-                        <input type="email" id="loginEmail" required>
-                    </div>
-                    <div class="form-group">
-                        <label for="loginPassword">Mot de passe</label>
-                        <input type="password" id="loginPassword" required>
-                    </div>
-                    <button type="button" class="auth-btn" id="loginBtn">
-                        <i data-lucide="log-in"></i>
-                        Se connecter
-                    </button>
-                    <div class="auth-error" id="loginError"></div>
-                </div>
-
-                <!-- Formulaire d'inscription -->
-                <div id="registerForm" class="auth-form" style="display: none;">
-                    <h3>Créer un compte</h3>
-
-                    <!-- Bouton Google pour inscription -->
-                    <div class="google-auth-container">
-                        <div id="googleSignInButtonRegister"></div>
-                    </div>
-
-                    <div class="auth-separator">
-                        <span>ou</span>
-                    </div>
-
-                    <!-- Formulaire email existant -->
-                    <div class="form-group">
-                        <label for="registerName">Nom</label>
-                        <input type="text" id="registerName" required>
-                    </div>
-                    <div class="form-group">
-                        <label for="registerEmail">Email</label>
-                        <input type="email" id="registerEmail" required>
-                    </div>
-                    <div class="form-group">
-                        <label for="registerPassword">Mot de passe</label>
-                        <input type="password" id="registerPassword" required>
-                    </div>
-                    <button type="button" class="auth-btn" id="registerBtn">
-                        <i data-lucide="user-plus"></i>
-                        Créer mon compte
-                    </button>
-                    <div class="auth-error" id="registerError"></div>
-                </div>
-            </div>
-        </div>
         <main class="marketing-content">
             <h2>Contact</h2>
             <p>Une question ou une suggestion&nbsp;? Écrivez-nous à <a href="mailto:contact@skillence.ai">contact@skillence.ai</a>.</p>
@@ -110,8 +38,6 @@
 
     <script src="assets/js/auth-check.js"></script>
     <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.js"></script>
-    <script src="assets/js/googleAuth.js"></script>
-    <script type="module" src="assets/js/auth.js"></script>
     <script type="module" src="assets/js/navigation.js"></script>
     <script>
         lucide.createIcons();

--- a/frontend/home.html
+++ b/frontend/home.html
@@ -27,7 +27,7 @@
                     <li><a href="solutions.html">Solutions</a></li>
                     <li><a href="tarifs.html">Tarifs</a></li>
                     <li><a href="contact.html">Contact</a></li>
-                    <li><a id="authNavLink" href="index.html">Login/Signup</a></li>
+                    <li><a id="authNavLink" href="auth.html">Login/Signup</a></li>
                 </ul>
             </nav>
         </header>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,7 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Skillence AI - Le savoir accessible à tous</title>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
-    <link rel="preconnect" href="https://accounts.google.com">
     <link rel="stylesheet" href="assets/css/main.css">
 </head>
 <body>
@@ -27,84 +26,10 @@
                     <li><a href="solutions.html">Solutions</a></li>
                     <li><a href="tarifs.html">Tarifs</a></li>
                     <li><a href="contact.html">Contact</a></li>
-                    <li><a id="authNavLink" href="#authSection">Login/Signup</a></li>
+                    <li><a id="authNavLink" href="auth.html">Login/Signup</a></li>
                 </ul>
             </nav>
         </header>
-
-        <!-- Section d'authentification -->
-        <div id="authSection" class="auth-section">
-            <div class="auth-container">
-                <div class="auth-tabs">
-                    <button class="auth-tab active" data-tab="login">Connexion</button>
-                    <button class="auth-tab" data-tab="register">Inscription</button>
-                </div>
-
-                <!-- Formulaire de connexion -->
-                <div id="loginForm" class="auth-form">
-                    <h3>Se connecter</h3>
-                    
-                    <!-- Bouton Google officiel -->
-                    <div class="google-auth-container">
-                        <div id="googleSignInButton"></div>
-                    </div>
-
-                    <div class="auth-separator">
-                        <span>ou</span>
-                    </div>
-
-                    <!-- Formulaire email existant -->
-                    <div class="form-group">
-                        <label for="loginEmail">Email</label>
-                        <input type="email" id="loginEmail" required>
-                    </div>
-                    <div class="form-group">
-                        <label for="loginPassword">Mot de passe</label>
-                        <input type="password" id="loginPassword" required>
-                    </div>
-                    <button type="button" class="auth-btn" id="loginBtn">
-                        <i data-lucide="log-in"></i>
-                        Se connecter
-                    </button>
-                    <div class="auth-error" id="loginError"></div>
-                </div>
-
-                <!-- Formulaire d'inscription -->
-                <div id="registerForm" class="auth-form" style="display: none;">
-                    <h3>Créer un compte</h3>
-                    
-                    <!-- Bouton Google pour inscription -->
-                    <div class="google-auth-container">
-                        <div id="googleSignInButtonRegister"></div>
-                    </div>
-
-                    <div class="auth-separator">
-                        <span>ou</span>
-                    </div>
-
-                    <!-- Formulaire email existant -->
-                    <div class="form-group">
-                        <label for="registerName">Nom</label>
-                        <input type="text" id="registerName" required>
-                    </div>
-                    <div class="form-group">
-                        <label for="registerEmail">Email</label>
-                        <input type="email" id="registerEmail" required>
-                    </div>
-                    <div class="form-group">
-                        <label for="registerPassword">Mot de passe</label>
-                        <input type="password" id="registerPassword" required>
-                    </div>
-                    <button type="button" class="auth-btn" id="registerBtn">
-                        <i data-lucide="user-plus"></i>
-                        Créer mon compte
-                    </button>
-                    <div class="auth-error" id="registerError"></div>
-                </div>
-            </div>
-        </div>
-
-        <!-- Section utilisateur connecté et contenu principal déplacés vers app.html -->
     </div>
 
     <!-- Scripts - Dans l'ordre de dépendance -->
@@ -115,10 +40,5 @@
         lucide.createIcons();
     </script>
     <script type="module" src="assets/js/utils.js"></script>
-    <script src="assets/js/googleAuth.js"></script>
-    <script type="module" src="assets/js/auth.js"></script>
-    <!-- Scripts de l'application déplacés vers app.html -->
-
-    <!-- Suppression de l'ancienne initialisation Google; la logique est gérée par assets/js/googleAuth.js -->
 </body>
 </html>

--- a/frontend/solutions.html
+++ b/frontend/solutions.html
@@ -26,82 +26,10 @@
                     <li><a href="solutions.html">Solutions</a></li>
                     <li><a href="tarifs.html">Tarifs</a></li>
                     <li><a href="contact.html">Contact</a></li>
-                    <li><a id="authNavLink" href="#authSection">Login/Signup</a></li>
+                    <li><a id="authNavLink" href="auth.html">Login/Signup</a></li>
                 </ul>
             </nav>
         </header>
-        
-        <!-- Section d'authentification -->
-        <div id="authSection" class="auth-section">
-            <div class="auth-container">
-                <div class="auth-tabs">
-                    <button class="auth-tab active" data-tab="login">Connexion</button>
-                    <button class="auth-tab" data-tab="register">Inscription</button>
-                </div>
-
-                <!-- Formulaire de connexion -->
-                <div id="loginForm" class="auth-form">
-                    <h3>Se connecter</h3>
-
-                    <!-- Bouton Google officiel -->
-                    <div class="google-auth-container">
-                        <div id="googleSignInButton"></div>
-                    </div>
-
-                    <div class="auth-separator">
-                        <span>ou</span>
-                    </div>
-
-                    <!-- Formulaire email existant -->
-                    <div class="form-group">
-                        <label for="loginEmail">Email</label>
-                        <input type="email" id="loginEmail" required>
-                    </div>
-                    <div class="form-group">
-                        <label for="loginPassword">Mot de passe</label>
-                        <input type="password" id="loginPassword" required>
-                    </div>
-                    <button type="button" class="auth-btn" id="loginBtn">
-                        <i data-lucide="log-in"></i>
-                        Se connecter
-                    </button>
-                    <div class="auth-error" id="loginError"></div>
-                </div>
-
-                <!-- Formulaire d'inscription -->
-                <div id="registerForm" class="auth-form" style="display: none;">
-                    <h3>Créer un compte</h3>
-
-                    <!-- Bouton Google pour inscription -->
-                    <div class="google-auth-container">
-                        <div id="googleSignInButtonRegister"></div>
-                    </div>
-
-                    <div class="auth-separator">
-                        <span>ou</span>
-                    </div>
-
-                    <!-- Formulaire email existant -->
-                    <div class="form-group">
-                        <label for="registerName">Nom</label>
-                        <input type="text" id="registerName" required>
-                    </div>
-                    <div class="form-group">
-                        <label for="registerEmail">Email</label>
-                        <input type="email" id="registerEmail" required>
-                    </div>
-                    <div class="form-group">
-                        <label for="registerPassword">Mot de passe</label>
-                        <input type="password" id="registerPassword" required>
-                    </div>
-                    <button type="button" class="auth-btn" id="registerBtn">
-                        <i data-lucide="user-plus"></i>
-                        Créer mon compte
-                    </button>
-                    <div class="auth-error" id="registerError"></div>
-                </div>
-            </div>
-        </div>
         <main class="marketing-content">
             <h2>Nos solutions</h2>
             <p>Découvrez comment Skillence AI peut vous aider à apprendre plus efficacement grâce à des cours personnalisés et des outils interactifs.</p>
@@ -110,8 +38,6 @@
 
     <script src="assets/js/auth-check.js"></script>
     <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.js"></script>
-    <script src="assets/js/googleAuth.js"></script>
-    <script type="module" src="assets/js/auth.js"></script>
     <script type="module" src="assets/js/navigation.js"></script>
     <script>
         lucide.createIcons();

--- a/frontend/tarifs.html
+++ b/frontend/tarifs.html
@@ -26,82 +26,10 @@
                     <li><a href="solutions.html">Solutions</a></li>
                     <li><a href="tarifs.html">Tarifs</a></li>
                     <li><a href="contact.html">Contact</a></li>
-                    <li><a id="authNavLink" href="#authSection">Login/Signup</a></li>
+                    <li><a id="authNavLink" href="auth.html">Login/Signup</a></li>
                 </ul>
             </nav>
         </header>
-        
-        <!-- Section d'authentification -->
-        <div id="authSection" class="auth-section">
-            <div class="auth-container">
-                <div class="auth-tabs">
-                    <button class="auth-tab active" data-tab="login">Connexion</button>
-                    <button class="auth-tab" data-tab="register">Inscription</button>
-                </div>
-
-                <!-- Formulaire de connexion -->
-                <div id="loginForm" class="auth-form">
-                    <h3>Se connecter</h3>
-
-                    <!-- Bouton Google officiel -->
-                    <div class="google-auth-container">
-                        <div id="googleSignInButton"></div>
-                    </div>
-
-                    <div class="auth-separator">
-                        <span>ou</span>
-                    </div>
-
-                    <!-- Formulaire email existant -->
-                    <div class="form-group">
-                        <label for="loginEmail">Email</label>
-                        <input type="email" id="loginEmail" required>
-                    </div>
-                    <div class="form-group">
-                        <label for="loginPassword">Mot de passe</label>
-                        <input type="password" id="loginPassword" required>
-                    </div>
-                    <button type="button" class="auth-btn" id="loginBtn">
-                        <i data-lucide="log-in"></i>
-                        Se connecter
-                    </button>
-                    <div class="auth-error" id="loginError"></div>
-                </div>
-
-                <!-- Formulaire d'inscription -->
-                <div id="registerForm" class="auth-form" style="display: none;">
-                    <h3>Créer un compte</h3>
-
-                    <!-- Bouton Google pour inscription -->
-                    <div class="google-auth-container">
-                        <div id="googleSignInButtonRegister"></div>
-                    </div>
-
-                    <div class="auth-separator">
-                        <span>ou</span>
-                    </div>
-
-                    <!-- Formulaire email existant -->
-                    <div class="form-group">
-                        <label for="registerName">Nom</label>
-                        <input type="text" id="registerName" required>
-                    </div>
-                    <div class="form-group">
-                        <label for="registerEmail">Email</label>
-                        <input type="email" id="registerEmail" required>
-                    </div>
-                    <div class="form-group">
-                        <label for="registerPassword">Mot de passe</label>
-                        <input type="password" id="registerPassword" required>
-                    </div>
-                    <button type="button" class="auth-btn" id="registerBtn">
-                        <i data-lucide="user-plus"></i>
-                        Créer mon compte
-                    </button>
-                    <div class="auth-error" id="registerError"></div>
-                </div>
-            </div>
-        </div>
         <main class="marketing-content">
             <h2>Tarifs</h2>
             <p>Choisissez le plan qui vous convient, de l'accès gratuit aux fonctionnalités avancées pour les apprenants passionnés.</p>
@@ -110,8 +38,6 @@
 
     <script src="assets/js/auth-check.js"></script>
     <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.js"></script>
-    <script src="assets/js/googleAuth.js"></script>
-    <script type="module" src="assets/js/auth.js"></script>
     <script type="module" src="assets/js/navigation.js"></script>
     <script>
         lucide.createIcons();


### PR DESCRIPTION
## Summary
- move authentication UI into new `auth.html`
- strip auth section from marketing pages and point nav links to `auth.html`
- update auth scripts to target `auth.html` and initialize only when needed

## Testing
- `node --test frontend/tests/sanitize.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a07c2036d8832595eb4334da4b335f