### PR TITLE
Initialize auth listeners on DOMContentLoaded

### DIFF
--- a/frontend/assets/js/auth.js
+++ b/frontend/assets/js/auth.js
@@ -406,15 +406,12 @@ async function initializeGoogleAuth() {
 }
 
 // Initialiser les event listeners quand le DOM est chargé
-document.addEventListener('DOMContentLoaded', function() {
-    console.log('DOM chargé, configuration de l\'authentification...');
-
+document.addEventListener('DOMContentLoaded', () => {
+    console.log("DOM chargé, configuration de l'authentification...");
+    setupAuthListeners();
     const authSection = document.getElementById('authSection');
     if (authSection) {
-        const separators = document.querySelectorAll('.auth-separator');
-        separators.forEach(el => el.style.display = 'none');
-
-        setupAuthListeners();
+        document.querySelectorAll('.auth-separator').forEach(el => el.style.display = 'none');
         initializeGoogleAuth();
     }
 });


### PR DESCRIPTION
## Summary
- Setup authentication listeners regardless of auth section presence
- Ensure Google Auth UI tweaks only if auth section exists

## Testing
- `npm test` *(fails: Missing script "test")*
- `node - <<'NODE' ... NODE`

------
https://chatgpt.com/codex/tasks/task_e_68a0814569508325845df5c2121b5354