### PR TITLE
feat: add marketing and app routing

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -116,13 +116,17 @@ app.use(express.json({ limit: '10mb' }));
 app.use(express.urlencoded({ extended: true }));
 app.use(cookieParser());
 
-// Route pour la page d'accueil
-app.get('/', (req, res) => {
-  res.sendFile(path.join(__dirname, '../../frontend/home.html'));
-});
+// Servir les fichiers statiques pour l'application et le marketing
+app.use('/app', express.static(path.join(__dirname, '../../frontend/app')));
+app.use('/', express.static(path.join(__dirname, '../../frontend/marketing')));
 
-// Servir les fichiers statiques du frontend
-app.use(express.static(path.join(__dirname, '../../frontend')));
+// Routes pour les applications frontend
+app.get('/app*', (_, res) =>
+  res.sendFile(path.join(__dirname, '../../frontend/app/index.html'))
+);
+app.get('/', (_, res) =>
+  res.sendFile(path.join(__dirname, '../../frontend/marketing/index.html'))
+);
 
 // Routes API
 app.use('/api', apiRoutes);


### PR DESCRIPTION
## Summary
- serve marketing and app builds separately
- route `/app*` to app SPA and `/` to marketing landing

## Testing
- `npm test --prefix backend` (fails: Missing script: "test")
- `DATABASE_URL=postgresql://user:pass@localhost:5432/db JWT_SECRET=test npm start --prefix backend` (fails: Cannot find module 'dotenv')

------
https://chatgpt.com/codex/tasks/task_e_68a087a0f1408325be9a273a4c1e2edb