### PR TITLE
Normalize auth routes and marketing navigation

### DIFF
--- a/frontend/app/assets/js/app-auth-check.js
+++ b/frontend/app/assets/js/app-auth-check.js
@@ -1,6 +1,6 @@
 document.addEventListener('DOMContentLoaded', () => {
     if (!window.isLoggedIn || !window.isLoggedIn()) {
-        window.location.href = '/index.html';
+        window.location.href = '/auth.html';
     }
 });
 

--- a/frontend/app/assets/js/auth-check.js
+++ b/frontend/app/assets/js/auth-check.js
@@ -9,11 +9,11 @@ document.addEventListener('DOMContentLoaded', () => {
     if (authLink) {
         if (isLoggedIn()) {
             authLink.textContent = 'Mon espace';
-            authLink.href = '../app/index.html';
+            authLink.href = '/app/';
             if (authSection) authSection.style.display = 'none';
         } else {
             authLink.textContent = 'Login/Signup';
-            authLink.href = '../marketing/auth.html';
+            authLink.href = '/auth.html';
         }
     }
 });

--- a/frontend/app/assets/js/auth.js
+++ b/frontend/app/assets/js/auth.js
@@ -67,7 +67,7 @@ class AuthManager {
                     courseManager.loadUserCourses();
                 }
 
-                window.location.href = '../app/index.html';
+                window.location.href = '/app/';
                 return { success: true };
             } else if (data.code === 'IA_TIMEOUT') {
                 this.showAction(data.error || 'Service indisponible', 'Réessayer', () => this.handleGoogleLogin(googleResponse));
@@ -103,7 +103,7 @@ class AuthManager {
                 localStorage.setItem('authToken', this.token);
                 localStorage.setItem('user', JSON.stringify(this.user));
                 this.updateUI();
-                window.location.href = '../app/index.html';
+                window.location.href = '/app/';
                 return { success: true };
             } else if (data.code === 'IA_TIMEOUT') {
                 this.showAction(data.error || 'Service indisponible', 'Réessayer', () => this.login(email, password));
@@ -140,7 +140,7 @@ class AuthManager {
                 localStorage.setItem('authToken', this.token);
                 localStorage.setItem('user', JSON.stringify(this.user));
                 this.updateUI();
-                window.location.href = '../app/index.html';
+                window.location.href = '/app/';
                 return { success: true };
             } else if (data.code === 'IA_TIMEOUT') {
                 this.showAction(data.error || 'Service indisponible', 'Réessayer', () => this.register(name, email, password));
@@ -171,7 +171,7 @@ class AuthManager {
         }
 
         this.updateUI();
-        window.location.href = '../marketing/index.html';
+        window.location.href = '/';
     }
 
     // VÉRIFIER SI CONNECTÉ
@@ -223,7 +223,7 @@ class AuthManager {
             }
             if (mainContent) mainContent.style.display = 'grid';
             if (authNavLink) {
-                authNavLink.href = '../app/index.html';
+                authNavLink.href = '/app/';
                 authNavLink.textContent = "Accéder à l'app";
             }
         } else {
@@ -231,7 +231,7 @@ class AuthManager {
             if (userSection) userSection.style.display = 'none';
             if (mainContent) mainContent.style.display = 'none';
             if (authNavLink) {
-                authNavLink.href = '../marketing/auth.html';
+                authNavLink.href = '/auth.html';
                 authNavLink.textContent = 'Login/Signup';
             }
         }

--- a/frontend/marketing/assets/js/app-auth-check.js
+++ b/frontend/marketing/assets/js/app-auth-check.js
@@ -1,6 +1,6 @@
 document.addEventListener('DOMContentLoaded', () => {
     if (!window.isLoggedIn || !window.isLoggedIn()) {
-        window.location.href = '/index.html';
+        window.location.href = '/auth.html';
     }
 });
 

--- a/frontend/marketing/assets/js/auth-check.js
+++ b/frontend/marketing/assets/js/auth-check.js
@@ -9,11 +9,14 @@ document.addEventListener('DOMContentLoaded', () => {
     if (authLink) {
         if (isLoggedIn()) {
             authLink.textContent = 'Mon espace';
-            authLink.href = '../app/index.html';
-            if (authSection) authSection.style.display = 'none';
+            authLink.href = '/app/';
+            if (authSection) {
+                authSection.style.display = 'none';
+                window.location.href = '/app/';
+            }
         } else {
             authLink.textContent = 'Login/Signup';
-            authLink.href = '../marketing/auth.html';
+            authLink.href = '/auth.html';
         }
     }
 });

--- a/frontend/marketing/assets/js/auth.js
+++ b/frontend/marketing/assets/js/auth.js
@@ -67,7 +67,7 @@ class AuthManager {
                     courseManager.loadUserCourses();
                 }
 
-                window.location.href = '../app/index.html';
+                window.location.href = '/app/';
                 return { success: true };
             } else if (data.code === 'IA_TIMEOUT') {
                 this.showAction(data.error || 'Service indisponible', 'Réessayer', () => this.handleGoogleLogin(googleResponse));
@@ -103,7 +103,7 @@ class AuthManager {
                 localStorage.setItem('authToken', this.token);
                 localStorage.setItem('user', JSON.stringify(this.user));
                 this.updateUI();
-                window.location.href = '../app/index.html';
+                window.location.href = '/app/';
                 return { success: true };
             } else if (data.code === 'IA_TIMEOUT') {
                 this.showAction(data.error || 'Service indisponible', 'Réessayer', () => this.login(email, password));
@@ -140,7 +140,7 @@ class AuthManager {
                 localStorage.setItem('authToken', this.token);
                 localStorage.setItem('user', JSON.stringify(this.user));
                 this.updateUI();
-                window.location.href = '../app/index.html';
+                window.location.href = '/app/';
                 return { success: true };
             } else if (data.code === 'IA_TIMEOUT') {
                 this.showAction(data.error || 'Service indisponible', 'Réessayer', () => this.register(name, email, password));
@@ -171,7 +171,7 @@ class AuthManager {
         }
 
         this.updateUI();
-        window.location.href = '../marketing/index.html';
+        window.location.href = '/';
     }
 
     // VÉRIFIER SI CONNECTÉ
@@ -223,7 +223,7 @@ class AuthManager {
             }
             if (mainContent) mainContent.style.display = 'grid';
             if (authNavLink) {
-                authNavLink.href = '../app/index.html';
+                authNavLink.href = '/app/';
                 authNavLink.textContent = "Accéder à l'app";
             }
         } else {
@@ -231,7 +231,7 @@ class AuthManager {
             if (userSection) userSection.style.display = 'none';
             if (mainContent) mainContent.style.display = 'none';
             if (authNavLink) {
-                authNavLink.href = '../marketing/auth.html';
+                authNavLink.href = '/auth.html';
                 authNavLink.textContent = 'Login/Signup';
             }
         }

--- a/frontend/marketing/auth.html
+++ b/frontend/marketing/auth.html
@@ -23,11 +23,11 @@
             </div>
             <nav id="headerNav" class="header-nav">
                 <ul>
-                    <li><a href="index.html">Accueil</a></li>
-                    <li><a href="solutions.html">Solutions</a></li>
-                    <li><a href="tarifs.html">Tarifs</a></li>
-                    <li><a href="contact.html">Contact</a></li>
-                    <li><a id="authNavLink" href="auth.html">Login/Signup</a></li>
+                    <li><a href="/">Accueil</a></li>
+                    <li><a href="/solutions.html">Solutions</a></li>
+                    <li><a href="/tarifs.html">Tarifs</a></li>
+                    <li><a href="/contact.html">Contact</a></li>
+                    <li><a id="authNavLink" href="/auth.html">Login/Signup</a></li>
                 </ul>
             </nav>
         </header>

--- a/frontend/marketing/contact.html
+++ b/frontend/marketing/contact.html
@@ -22,11 +22,11 @@
             </div>
             <nav id="headerNav" class="header-nav">
                 <ul>
-                    <li><a href="index.html">Accueil</a></li>
-                    <li><a href="solutions.html">Solutions</a></li>
-                    <li><a href="tarifs.html">Tarifs</a></li>
-                    <li><a href="contact.html">Contact</a></li>
-                    <li><a id="authNavLink" href="auth.html">Login/Signup</a></li>
+                    <li><a href="/">Accueil</a></li>
+                    <li><a href="/solutions.html">Solutions</a></li>
+                    <li><a href="/tarifs.html">Tarifs</a></li>
+                    <li><a href="/contact.html">Contact</a></li>
+                    <li><a id="authNavLink" href="/auth.html">Login/Signup</a></li>
                 </ul>
             </nav>
         </header>

--- a/frontend/marketing/index.html
+++ b/frontend/marketing/index.html
@@ -23,11 +23,11 @@
             </div>
             <nav id="headerNav" class="header-nav">
                 <ul>
-                    <li><a href="index.html">Accueil</a></li>
-                    <li><a href="solutions.html">Solutions</a></li>
-                    <li><a href="tarifs.html">Tarifs</a></li>
-                    <li><a href="contact.html">Contact</a></li>
-                    <li><a id="authNavLink" href="auth.html">Login/Signup</a></li>
+                    <li><a href="/">Accueil</a></li>
+                    <li><a href="/solutions.html">Solutions</a></li>
+                    <li><a href="/tarifs.html">Tarifs</a></li>
+                    <li><a href="/contact.html">Contact</a></li>
+                    <li><a id="authNavLink" href="/auth.html">Login/Signup</a></li>
                 </ul>
             </nav>
         </header>

--- a/frontend/marketing/solutions.html
+++ b/frontend/marketing/solutions.html
@@ -22,11 +22,11 @@
             </div>
             <nav id="headerNav" class="header-nav">
                 <ul>
-                    <li><a href="index.html">Accueil</a></li>
-                    <li><a href="solutions.html">Solutions</a></li>
-                    <li><a href="tarifs.html">Tarifs</a></li>
-                    <li><a href="contact.html">Contact</a></li>
-                    <li><a id="authNavLink" href="auth.html">Login/Signup</a></li>
+                    <li><a href="/">Accueil</a></li>
+                    <li><a href="/solutions.html">Solutions</a></li>
+                    <li><a href="/tarifs.html">Tarifs</a></li>
+                    <li><a href="/contact.html">Contact</a></li>
+                    <li><a id="authNavLink" href="/auth.html">Login/Signup</a></li>
                 </ul>
             </nav>
         </header>

--- a/frontend/marketing/tarifs.html
+++ b/frontend/marketing/tarifs.html
@@ -22,11 +22,11 @@
             </div>
             <nav id="headerNav" class="header-nav">
                 <ul>
-                    <li><a href="index.html">Accueil</a></li>
-                    <li><a href="solutions.html">Solutions</a></li>
-                    <li><a href="tarifs.html">Tarifs</a></li>
-                    <li><a href="contact.html">Contact</a></li>
-                    <li><a id="authNavLink" href="auth.html">Login/Signup</a></li>
+                    <li><a href="/">Accueil</a></li>
+                    <li><a href="/solutions.html">Solutions</a></li>
+                    <li><a href="/tarifs.html">Tarifs</a></li>
+                    <li><a href="/contact.html">Contact</a></li>
+                    <li><a id="authNavLink" href="/auth.html">Login/Signup</a></li>
                 </ul>
             </nav>
         </header>


### PR DESCRIPTION
## Summary
- switch marketing navigation to absolute URLs
- route all auth flows to `/app/` after login and `/` on logout
- send unauthenticated users to `/auth.html`

## Testing
- `node frontend/tests/sanitize.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68a090331cc08325845e2e96a87623e9