### PR TITLE
feat: add auth guard before app initialization

### DIFF
--- a/frontend/app/assets/js/auth.js
+++ b/frontend/app/assets/js/auth.js
@@ -419,6 +419,7 @@ document.addEventListener('DOMContentLoaded', () => {
 // Export global
 window.authManager = authManager;
 window.setupAuthListeners = setupAuthListeners;
+window.AuthManager = AuthManager;
 
 console.log('Script auth.js chargé');
 

--- a/frontend/app/assets/js/main.js
+++ b/frontend/app/assets/js/main.js
@@ -19,8 +19,9 @@ let currentConfig = {
 // Initialisation de l'application
 document.addEventListener('DOMContentLoaded', function() {
     console.log('🚀 Initialisation Hermès App');
-    
-    initializeApp();
+
+    // L'initialisation de l'interface est désormais gérée dans index.html
+    // pour permettre la vérification d'authentification avant chargement.
     setupEventListeners();
     
     // Charger l'historique selon l'authentification
@@ -540,3 +541,4 @@ function typewriterEffect(element, text, callback) {
 window.currentCourse = currentCourse;
 window.handleGenerateCourse = handleGenerateCourse;
 window.displayCourseMetadata = displayCourseMetadata;
+window.initializeApp = initializeApp;

--- a/frontend/app/index.html
+++ b/frontend/app/index.html
@@ -152,6 +152,16 @@
     <script type="module" src="assets/js/utils/utils.js"></script>
     <script src="assets/js/googleAuth.js"></script>
     <script type="module" src="assets/js/auth.js"></script>
+    <script type="module">
+      document.addEventListener('DOMContentLoaded', () => {
+        const authManager = new AuthManager();
+        if (!authManager.isAuthenticated()) {
+          window.location.href = '/auth.html';
+          return;
+        }
+        initializeApp();
+      });
+    </script>
     <script type="module" src="assets/js/course-manager.js"></script>
     <script type="module" src="assets/js/main.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- delay app UI initialization until authentication is verified
- expose AuthManager and initializeApp globally for HTML modules

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a09378e6c08325855f7e89a82da718