### PR TITLE
feat: add interactive onboarding tutorial

### DIFF
--- a/frontend/app/assets/js/main.js
+++ b/frontend/app/assets/js/main.js
@@ -32,6 +32,11 @@ document.addEventListener('DOMContentLoaded', function() {
     }
     
     utils.initializeLucide();
+
+    if (!localStorage.getItem('onboardingSeen')) {
+        showOnboardingTips();
+    }
+
     console.log('✅ App initialisée');
 });
 
@@ -47,6 +52,7 @@ function setupEventListeners() {
     const generateQuiz = document.getElementById('generateQuiz');
     const copyContent = document.getElementById('copyContent');
     const randomSubjectBtn = document.getElementById('randomSubjectBtn');
+    const exampleTopics = document.querySelectorAll('.example-topic');
     const menuToggle = document.getElementById('menuToggle');
     const configPanel = document.querySelector('.configuration-panel');
     const headerNav = document.getElementById('headerNav');
@@ -56,6 +62,15 @@ function setupEventListeners() {
     if (generateQuiz) generateQuiz.addEventListener('click', handleGenerateQuiz);
     if (copyContent) copyContent.addEventListener('click', () => courseManager && courseManager.copyContent());
     if (randomSubjectBtn) randomSubjectBtn.addEventListener('click', generateRandomSubject);
+
+    exampleTopics.forEach(btn => {
+        btn.addEventListener('click', () => {
+            const subjectField = document.getElementById('subject');
+            if (subjectField) {
+                subjectField.value = btn.dataset.subject || btn.textContent;
+            }
+        });
+    });
 
     if (menuToggle) {
         const updateAria = () => {
@@ -83,6 +98,73 @@ function setupEventListeners() {
 
     // Chat
     setupChatEventListeners();
+}
+
+function showOnboardingTips() {
+    const steps = [
+        {
+            selector: '.example-topics',
+            text: 'Choisissez un sujet ou utilisez un exemple ci-dessous',
+            progress: 'Étape 1/3 : Choisissez votre sujet'
+        },
+        {
+            selector: '.new-selector-container',
+            text: "Personnalisez le style, la durée et l'intention",
+            progress: 'Étape 2/3 : Paramétrez votre cours'
+        },
+        {
+            selector: '#generateBtn',
+            text: 'Cliquez ici pour générer votre cours',
+            progress: 'Étape 3/3 : Décryptez votre sujet'
+        }
+    ];
+
+    const style = document.createElement('style');
+    style.textContent = '.onboarding-highlight{box-shadow:0 0 0 3px #FFD54F;border-radius:4px;position:relative;z-index:1000;} .onboarding-tip{position:absolute;background:#333;color:#fff;padding:8px 12px;border-radius:4px;z-index:1001;max-width:260px;}';
+    document.head.appendChild(style);
+
+    const tip = document.createElement('div');
+    tip.className = 'onboarding-tip';
+    document.body.appendChild(tip);
+
+    let index = 0;
+
+    const showStep = () => {
+        const previous = document.querySelector('.onboarding-highlight');
+        if (previous) previous.classList.remove('onboarding-highlight');
+
+        if (index >= steps.length) {
+            tip.remove();
+            localStorage.setItem('onboardingSeen', '1');
+            return;
+        }
+
+        const step = steps[index];
+        const el = document.querySelector(step.selector);
+        if (!el) {
+            index++;
+            showStep();
+            return;
+        }
+
+        el.classList.add('onboarding-highlight');
+        tip.textContent = step.text;
+        const rect = el.getBoundingClientRect();
+        tip.style.top = `${rect.bottom + window.scrollY + 8}px`;
+        tip.style.left = `${rect.left + window.scrollX}px`;
+
+        const progressEl = document.getElementById('onboardingProgress');
+        if (progressEl) progressEl.textContent = step.progress;
+
+        const advance = () => {
+            el.removeEventListener('click', advance);
+            index++;
+            showStep();
+        };
+        el.addEventListener('click', advance);
+    };
+
+    showStep();
 }
 
 // Gestionnaires d'événements principaux
@@ -542,3 +624,4 @@ window.currentCourse = currentCourse;
 window.handleGenerateCourse = handleGenerateCourse;
 window.displayCourseMetadata = displayCourseMetadata;
 window.initializeApp = initializeApp;
+window.showOnboardingTips = showOnboardingTips;

--- a/frontend/app/index.html
+++ b/frontend/app/index.html
@@ -89,9 +89,13 @@
 
                 <div class="tab-content" id="courseTab">
                     <div class="empty-state" id="emptyState">
-                        <i data-lucide="book-open"></i>
-                        <h3>Prêt à comprendre ?</h3>
-                        <p>Configurez votre cours dans le panneau de gauche et cliquez sur "Générer le cours" pour commencer.</p>
+                        <div id="onboardingProgress" class="onboarding-progress">Étape 1/3 : Choisissez votre sujet</div>
+                        <p>Choisissez un sujet ci-dessous pour commencer :</p>
+                        <div class="example-topics">
+                            <button class="example-topic" data-subject="Intelligence Artificielle" title="Cliquez pour explorer l'Intelligence Artificielle">Intelligence Artificielle</button>
+                            <button class="example-topic" data-subject="Cuisine Italienne" title="Cliquez pour explorer la Cuisine Italienne">Cuisine Italienne</button>
+                            <button class="example-topic" data-subject="Marketing Digital" title="Cliquez pour explorer le Marketing Digital">Marketing Digital</button>
+                        </div>
                     </div>
                     <div class="course-content" id="courseContent" style="display: none;">
                         <div id="quizSection" style="display: none;"></div>


### PR DESCRIPTION
## Summary
- replace empty course state with interactive onboarding and example topics
- guide first-time users with tooltips and progress indicator
- populate subject field when clicking example topics

## Testing
- `node --test frontend/tests/sanitize.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a09cfdd89c8325921b8876220c2ad5