### PR TITLE
Add onboarding progress bar with step badges

### DIFF
--- a/frontend/app/assets/css/app.css
+++ b/frontend/app/assets/css/app.css
@@ -2319,3 +2319,49 @@ body::before {
     margin-right: 10px;
 }
 
+/* Onboarding progress components */
+.onboarding-progress-container {
+    margin-bottom: 12px;
+}
+
+.onboarding-progress-bar {
+    height: 4px;
+    background: #4299e1;
+    width: 0;
+    transition: width 0.3s ease;
+}
+
+.onboarding-step-badges {
+    display: flex;
+    justify-content: space-between;
+    margin-bottom: 6px;
+}
+
+.onboarding-step-badge {
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+    background: #e2e8f0;
+    color: #4a5568;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.9rem;
+    font-weight: 600;
+    opacity: 0.5;
+    transition: background 0.3s ease, color 0.3s ease, opacity 0.3s ease;
+}
+
+.onboarding-step-badge.active {
+    background: #4299e1;
+    color: #fff;
+    opacity: 1;
+}
+
+.onboarding-highlight {
+    box-shadow: 0 0 0 3px #FFD54F, 0 0 8px #FFD54F;
+    border-radius: 4px;
+    position: relative;
+    z-index: 1000;
+}
+

--- a/frontend/app/assets/js/main.js
+++ b/frontend/app/assets/js/main.js
@@ -120,7 +120,7 @@ function showOnboardingTips() {
     ];
 
     const style = document.createElement('style');
-    style.textContent = '.onboarding-highlight{box-shadow:0 0 0 3px #FFD54F;border-radius:4px;position:relative;z-index:1000;} .onboarding-tip{position:absolute;background:#333;color:#fff;padding:8px 12px;border-radius:4px;z-index:1001;max-width:260px;}';
+    style.textContent = '.onboarding-tip{position:absolute;background:#333;color:#fff;padding:8px 12px;border-radius:4px;z-index:1001;max-width:260px;}';
     document.head.appendChild(style);
 
     const tip = document.createElement('div');
@@ -134,6 +134,10 @@ function showOnboardingTips() {
         if (previous) previous.classList.remove('onboarding-highlight');
 
         if (index >= steps.length) {
+            const progressBar = document.querySelector('.onboarding-progress-bar');
+            if (progressBar) progressBar.style.width = '100%';
+            const badges = document.querySelectorAll('.onboarding-step-badge');
+            badges.forEach(b => b.classList.add('active'));
             tip.remove();
             localStorage.setItem('onboardingSeen', '1');
             return;
@@ -155,6 +159,14 @@ function showOnboardingTips() {
 
         const progressEl = document.getElementById('onboardingProgress');
         if (progressEl) progressEl.textContent = step.progress;
+
+        const progressBar = document.querySelector('.onboarding-progress-bar');
+        if (progressBar) progressBar.style.width = `${((index + 1) / steps.length) * 100}%`;
+
+        const badges = document.querySelectorAll('.onboarding-step-badge');
+        badges.forEach((badge, i) => {
+            badge.classList.toggle('active', i <= index);
+        });
 
         const advance = () => {
             el.removeEventListener('click', advance);

--- a/frontend/app/index.html
+++ b/frontend/app/index.html
@@ -89,6 +89,14 @@
 
                 <div class="tab-content" id="courseTab">
                     <div class="empty-state" id="emptyState">
+                        <div class="onboarding-progress-container">
+                            <div class="onboarding-step-badges">
+                                <div class="onboarding-step-badge" data-step="1">1</div>
+                                <div class="onboarding-step-badge" data-step="2">2</div>
+                                <div class="onboarding-step-badge" data-step="3">3</div>
+                            </div>
+                            <div class="onboarding-progress-bar"></div>
+                        </div>
                         <div id="onboardingProgress" class="onboarding-progress">Étape 1/3 : Choisissez votre sujet</div>
                         <p>Choisissez un sujet ci-dessous pour commencer :</p>
                         <div class="example-topics">


### PR DESCRIPTION
## Summary
- add markup for onboarding progress bar and numbered step badges
- style onboarding progress elements and strengthen highlight contrast
- update onboarding tips script to drive progress bar and badge activation

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a0a1ef34888325a660fb07c553ff1b