### PR TITLE
feat: enrich onboarding progress

### DIFF
--- a/frontend/app/assets/css/app.css
+++ b/frontend/app/assets/css/app.css
@@ -2424,6 +2424,13 @@ body::before {
 }
 
 .onboarding-step-badge.active {
+    background: #48bb78;
+    color: #fff;
+    opacity: 1;
+    animation: pop 0.3s ease;
+}
+
+.onboarding-step-badge.current {
     background: #4299e1;
     color: #fff;
     opacity: 1;
@@ -2434,6 +2441,31 @@ body::before {
     border-radius: 4px;
     position: relative;
     z-index: 1000;
+}
+
+@keyframes pop {
+    0% { transform: scale(0.8); }
+    50% { transform: scale(1.2); }
+    100% { transform: scale(1); }
+}
+
+.onboarding-motivation {
+    position: fixed;
+    bottom: 20px;
+    left: 50%;
+    transform: translateX(-50%) translateY(20px);
+    background: #48bb78;
+    color: #fff;
+    padding: 8px 16px;
+    border-radius: 8px;
+    opacity: 0;
+    transition: opacity 0.3s, transform 0.3s;
+    z-index: 1002;
+}
+
+.onboarding-motivation.show {
+    opacity: 1;
+    transform: translateX(-50%) translateY(0);
 }
 
 .skip-tutorial-btn {

--- a/frontend/app/assets/js/main.js
+++ b/frontend/app/assets/js/main.js
@@ -136,22 +136,37 @@ function updateGenerateBtnState() {
     }
 }
 
+function showMotivation(message) {
+    const note = document.createElement('div');
+    note.className = 'onboarding-motivation';
+    note.textContent = message;
+    document.body.appendChild(note);
+    requestAnimationFrame(() => note.classList.add('show'));
+    setTimeout(() => {
+        note.classList.remove('show');
+        setTimeout(() => note.remove(), 300);
+    }, 2000);
+}
+
 function showOnboardingTips() {
     const steps = [
         {
             selector: '.example-topics',
             text: 'Choisissez un sujet ou utilisez un exemple ci-dessous',
-            progress: 'Étape 1/3 : Choisissez votre sujet'
+            progress: 'Étape 1/3 : Choisissez votre sujet',
+            message: '🎉 Super, première étape réussie !'
         },
         {
             selector: '.new-selector-container',
             text: "Personnalisez le style, la durée et l'intention",
-            progress: 'Étape 2/3 : Paramétrez votre cours'
+            progress: 'Étape 2/3 : Paramétrez votre cours',
+            message: '💪 Continuez comme ça !'
         },
         {
             selector: '#generateBtn',
             text: 'Cliquez ici pour générer votre cours',
-            progress: 'Étape 3/3 : Décryptez votre sujet'
+            progress: 'Étape 3/3 : Décryptez votre sujet',
+            message: '🚀 Prêt à générer votre cours ?'
         }
     ];
 
@@ -167,7 +182,13 @@ function showOnboardingTips() {
     tip.className = 'onboarding-tip';
     document.body.appendChild(tip);
 
-    let index = 0;
+    let index = parseInt(localStorage.getItem('onboardingIndex') || '0');
+    let completedSteps = JSON.parse(localStorage.getItem('onboardingCompleted') || '[]');
+
+    const saveProgress = () => {
+        localStorage.setItem('onboardingIndex', index.toString());
+        localStorage.setItem('onboardingCompleted', JSON.stringify(completedSteps));
+    };
 
     const endOnboarding = () => {
         const highlighted = document.querySelector('.onboarding-highlight');
@@ -180,9 +201,13 @@ function showOnboardingTips() {
         const skipBtn = document.getElementById('skipTutorial');
         if (skipBtn) skipBtn.remove();
         localStorage.setItem('onboardingSeen', '1');
+        localStorage.removeItem('onboardingIndex');
+        localStorage.removeItem('onboardingCompleted');
+        showMotivation('🎓 Onboarding terminé !');
     };
 
     const showStep = () => {
+        saveProgress();
         const previous = document.querySelector('.onboarding-highlight');
         if (previous) previous.classList.remove('onboarding-highlight');
 
@@ -215,11 +240,12 @@ function showOnboardingTips() {
         if (progressEl) progressEl.textContent = step.progress;
 
         const progressBar = document.querySelector('.onboarding-progress-bar');
-        if (progressBar) progressBar.style.width = `${((index + 1) / steps.length) * 100}%`;
+        if (progressBar) progressBar.style.width = `${(completedSteps.length / steps.length) * 100}%`;
 
         const badges = document.querySelectorAll('.onboarding-step-badge');
         badges.forEach((badge, i) => {
-            badge.classList.toggle('active', i <= index);
+            badge.classList.toggle('active', completedSteps.includes(i));
+            badge.classList.toggle('current', i === index);
         });
 
         const prevBtn = tip.querySelector('.onboarding-prev');
@@ -229,18 +255,25 @@ function showOnboardingTips() {
             prevBtn.disabled = index === 0;
             prevBtn.addEventListener('click', () => {
                 index = Math.max(0, index - 1);
+                saveProgress();
                 showStep();
             });
         }
         if (nextBtn) {
             nextBtn.addEventListener('click', () => {
+                if (!completedSteps.includes(index)) completedSteps.push(index);
                 index++;
+                saveProgress();
+                showMotivation(step.message);
                 showStep();
             });
         }
         if (skipStepBtn) {
             skipStepBtn.addEventListener('click', () => {
+                if (!completedSteps.includes(index)) completedSteps.push(index);
                 index++;
+                saveProgress();
+                showMotivation(step.message);
                 showStep();
             });
         }
@@ -252,6 +285,7 @@ function showOnboardingTips() {
     }
 
     showStep();
+    saveProgress();
 }
 
 // Gestionnaires d'événements principaux


### PR DESCRIPTION
## Summary
- add motivational messages and success animations to onboarding
- persist onboarding progress in localStorage
- highlight completed steps with animated badges

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm test --prefix backend` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a0a5e17d448325a8d3f626b5703358