### PR TITLE
feat: track onboarding analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,15 @@ For production deployments you must:
 - provide paths to your TLS files via `TLS_CERT_PATH` and `TLS_KEY_PATH`
 
 With these variables defined the server starts in HTTPS mode. Without them the start script keeps the server in HTTP mode, suitable for local development or environments without TLS.
+
+## Analytics Events
+
+The frontend onboarding sequence sends Google Analytics events to track user progress:
+
+- `onboarding_step_enter`
+  - `step` (number): 1-based step index when a step is displayed.
+- `onboarding_step_exit`
+  - `step` (number): step index that was exited.
+  - `action` (string): reason for leaving the step. Values include `next`, `prev`, `skip`, `complete`, and `abandon`.
+- `onboarding_tutorial_skip`
+  - `step` (number): step where the user abandoned the entire tutorial.

--- a/frontend/app/assets/js/main.js
+++ b/frontend/app/assets/js/main.js
@@ -234,6 +234,10 @@ function showOnboardingTips() {
             return;
         }
 
+        if (typeof gtag === 'function') {
+            gtag('event', 'onboarding_step_enter', { step: index + 1 });
+        }
+
         el.classList.add('onboarding-highlight');
         tip.innerHTML = `
             <div>${step.text}</div>
@@ -264,6 +268,9 @@ function showOnboardingTips() {
         if (prevBtn) {
             prevBtn.disabled = index === 0;
             prevBtn.addEventListener('click', () => {
+                if (typeof gtag === 'function') {
+                    gtag('event', 'onboarding_step_exit', { step: index + 1, action: 'prev' });
+                }
                 index = Math.max(0, index - 1);
                 saveProgress();
                 showStep();
@@ -272,6 +279,12 @@ function showOnboardingTips() {
         if (nextBtn) {
             nextBtn.addEventListener('click', () => {
                 if (!completedSteps.includes(index)) completedSteps.push(index);
+                if (typeof gtag === 'function') {
+                    gtag('event', 'onboarding_step_exit', {
+                        step: index + 1,
+                        action: index === steps.length - 1 ? 'complete' : 'next'
+                    });
+                }
                 index++;
                 saveProgress();
                 showMotivation(step.message);
@@ -281,6 +294,9 @@ function showOnboardingTips() {
         if (skipStepBtn) {
             skipStepBtn.addEventListener('click', () => {
                 if (!completedSteps.includes(index)) completedSteps.push(index);
+                if (typeof gtag === 'function') {
+                    gtag('event', 'onboarding_step_exit', { step: index + 1, action: 'skip' });
+                }
                 index++;
                 saveProgress();
                 showMotivation(step.message);
@@ -291,7 +307,13 @@ function showOnboardingTips() {
 
     const skipTutorialBtn = document.getElementById('skipTutorial');
     if (skipTutorialBtn) {
-        skipTutorialBtn.addEventListener('click', endOnboarding);
+        skipTutorialBtn.addEventListener('click', () => {
+            if (typeof gtag === 'function') {
+                gtag('event', 'onboarding_step_exit', { step: index + 1, action: 'abandon' });
+                gtag('event', 'onboarding_tutorial_skip', { step: index + 1 });
+            }
+            endOnboarding();
+        });
     }
 
     showStep();


### PR DESCRIPTION
## Summary
- add GA events for onboarding step entry and exit
- track step skips and tutorial abandonment
- document analytics event parameters

## Testing
- `npm test` (fails: Missing script: "test")

------
https://chatgpt.com/codex/tasks/task_e_68a0a8f0c42883258f8a5515c29a6c5e