### PR TITLE
feat: onboarding badges and challenge

### DIFF
--- a/frontend/app/assets/css/app.css
+++ b/frontend/app/assets/css/app.css
@@ -2502,3 +2502,51 @@ body::before {
     margin: 8px 0;
 }
 
+/* Confetti animation */
+.confetti {
+    position: fixed;
+    top: -10px;
+    width: 8px;
+    height: 8px;
+    opacity: 0.9;
+    z-index: 2000;
+    animation: confetti-fall 3s linear forwards;
+}
+
+@keyframes confetti-fall {
+    to {
+        transform: translateY(100vh) rotate(720deg);
+        opacity: 0;
+    }
+}
+
+/* Earned badges */
+.earned-badges {
+    display: flex;
+    gap: 4px;
+    margin-left: 8px;
+}
+
+.earned-badge {
+    background: #ffd700;
+    color: #333;
+    padding: 2px 6px;
+    border-radius: 4px;
+    font-size: 0.8rem;
+    display: flex;
+    align-items: center;
+}
+
+.earned-badge span {
+    margin-left: 4px;
+}
+
+/* First course challenge */
+.first-course-challenge {
+    background: #fffae6;
+    border-left: 4px solid #ffcb2b;
+    padding: 10px;
+    margin-bottom: 10px;
+    border-radius: 4px;
+}
+

--- a/frontend/app/assets/js/main.js
+++ b/frontend/app/assets/js/main.js
@@ -109,8 +109,10 @@ document.addEventListener('DOMContentLoaded', function() {
     } else if (courseManager) {
         courseManager.updateHistoryDisplay();
     }
-    
+
     utils.initializeLucide();
+
+    displayEarnedBadges();
 
     if (!localStorage.getItem('onboardingSeen')) {
         showOnboardingTips();
@@ -272,6 +274,9 @@ function showOnboardingTips() {
         localStorage.removeItem('onboardingIndex');
         localStorage.removeItem('onboardingCompleted');
         showMotivation('🎓 Onboarding terminé !');
+        launchConfetti();
+        saveBadge('onboarding', 'Onboarding terminé', '🎓');
+        displayEarnedBadges();
     };
 
     const showStep = () => {
@@ -378,6 +383,59 @@ function showOnboardingTips() {
     saveProgress();
 }
 
+function launchConfetti() {
+    for (let i = 0; i < 100; i++) {
+        const confetti = document.createElement('div');
+        confetti.className = 'confetti';
+        confetti.style.left = Math.random() * 100 + '%';
+        confetti.style.backgroundColor = `hsl(${Math.random() * 360}, 100%, 50%)`;
+        confetti.style.animationDelay = Math.random() + 's';
+        document.body.appendChild(confetti);
+        setTimeout(() => confetti.remove(), 3000);
+    }
+}
+
+function saveBadge(id, label, emoji) {
+    const badges = JSON.parse(localStorage.getItem('earnedBadges') || '[]');
+    if (!badges.some(b => b.id === id)) {
+        badges.push({ id, label, emoji });
+        localStorage.setItem('earnedBadges', JSON.stringify(badges));
+    }
+}
+
+function displayEarnedBadges() {
+    const badges = JSON.parse(localStorage.getItem('earnedBadges') || '[]');
+    if (!badges.length) return;
+    let container = document.getElementById('earnedBadges');
+    if (!container) {
+        container = document.createElement('div');
+        container.id = 'earnedBadges';
+        container.className = 'earned-badges';
+        const userSection = document.getElementById('userSection');
+        if (userSection) {
+            userSection.appendChild(container);
+        } else {
+            document.body.appendChild(container);
+        }
+    }
+    container.innerHTML = '';
+    badges.forEach(b => {
+        const badgeEl = document.createElement('div');
+        badgeEl.className = 'earned-badge';
+        badgeEl.innerHTML = `${b.emoji || '🏅'}<span>${b.label}</span>`;
+        container.appendChild(badgeEl);
+    });
+}
+
+function showFirstCourseChallenge() {
+    const container = document.getElementById('generatedCourse');
+    if (!container) return;
+    const challenge = document.createElement('div');
+    challenge.className = 'first-course-challenge';
+    challenge.innerHTML = '<strong>Défi :</strong> Résumez ce cours en une phrase dans le chat !';
+    container.prepend(challenge);
+}
+
 // Gestionnaires d'événements principaux
 async function handleGenerateCourse() {
     const subject = document.getElementById('subject').value.trim();
@@ -403,6 +461,11 @@ async function handleGenerateCourse() {
                 const durationLabel = DURATION_LABELS[course.duration] || course.duration;
                 const intentLabel = INTENT_LABELS[course.intent] || course.intent;
                 displayCourseMetadata(styleLabel, durationLabel, intentLabel);
+
+                if (!localStorage.getItem('firstCourseChallengeShown')) {
+                    showFirstCourseChallenge();
+                    localStorage.setItem('firstCourseChallengeShown', '1');
+                }
 
                 if (typeof gtag === 'function') {
                     gtag('event', 'course_generation', {


### PR DESCRIPTION
## Summary
- celebrate onboarding completion with confetti and earned badges
- show engagement challenge after first course generation
- persist badges to display on future visits

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a0ab036b1c83259c3df664f4adb66f