### PR TITLE
Ensure onboarding tips refresh after progress

### DIFF
--- a/frontend/app/assets/js/main.js
+++ b/frontend/app/assets/js/main.js
@@ -491,9 +491,7 @@ function checkAndProgressOnboarding(stepIndex) {
             showMotivation(`${badge.emoji} Badge déverrouillé : ${badge.label} !`);
         }
         updateOnboardingProgress();
-        if (document.querySelector('.onboarding-tip')) {
-            showOnboardingTips();
-        }
+        showOnboardingTips();
     }
 }
 


### PR DESCRIPTION
## Summary
- Always call `showOnboardingTips` after updating onboarding progress so the UI reflects the next step immediately.

## Testing
- `node /tmp/test_onboarding.js`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a0b39f74388325969cfc5ed88816f7