### PR TITLE
fix: advance onboarding when selecting example topic

### DIFF
--- a/frontend/app/assets/js/main.js
+++ b/frontend/app/assets/js/main.js
@@ -163,16 +163,21 @@ function setupEventListeners() {
 
     exampleTopics.forEach(btn => {
         btn.classList.add('pulse');
-        btn.addEventListener('click', () => {
+    });
+
+    document.addEventListener('click', (e) => {
+        if (e.target.matches('.example-topic')) {
             const subjectField = document.getElementById('subject');
             if (subjectField) {
-                subjectField.value = btn.dataset.subject || btn.textContent;
+                const subject = e.target.dataset.subject || e.target.textContent;
+                subjectField.value = subject;
                 // Déclenche manuellement l'événement d'entrée pour mettre à jour l'état
                 subjectField.dispatchEvent(new Event('input'));
                 // Marquer l'étape comme complétée et avancer automatiquement
-                checkAndProgressOnboarding(0);
+                checkAndProgressOnboarding(0); // Pour passer à l'étape 2/3
+                updateGenerateBtnState();
             }
-        });
+        }
     });
 
     if (menuToggle) {


### PR DESCRIPTION
## Summary
- ensure selecting an example topic advances onboarding to step 2

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a0e2063abc8325a2396fae576eab70