### PR TITLE
feat: progress onboarding after selector selection

### DIFF
--- a/frontend/marketing/assets/js/main.js
+++ b/frontend/marketing/assets/js/main.js
@@ -247,6 +247,7 @@ function setupNewSelectors() {
             btn.setAttribute('aria-describedby', tooltip.id);
             btn.addEventListener('click', () => {
                 updateSelection(type, value, btn);
+                checkAndProgressOnboarding(1);
             });
             btn.addEventListener('keydown', (e) => {
                 if (['ArrowRight', 'ArrowDown'].includes(e.key)) {


### PR DESCRIPTION
## Summary
- trigger onboarding step progression after selection updates in marketing selectors

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node frontend/tests/sanitize.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a0e4841fe08325b43ea7040b4dd632