### PR TITLE
Remove courseManager dependency from auth flow

### DIFF
--- a/frontend/marketing/assets/js/auth.js
+++ b/frontend/marketing/assets/js/auth.js
@@ -62,11 +62,6 @@ class AuthManager {
 
                 showNotification('Connexion Google réussie !', 'success');
                 
-                // Charger les cours de l'utilisateur
-                if (typeof courseManager !== 'undefined' && courseManager.loadUserCourses) {
-                    courseManager.loadUserCourses();
-                }
-
                 window.location.href = '/app/';
                 return { success: true };
             } else if (data.code === 'IA_TIMEOUT') {
@@ -289,10 +284,6 @@ function setupAuthListeners() {
 
             if (result.success) {
                 showNotification('Connexion réussie !', 'success');
-                // Charger les cours de l'utilisateur si la fonction existe
-                if (typeof courseManager !== 'undefined' && courseManager.loadUserCourses) {
-                    courseManager.loadUserCourses();
-                }
             } else {
                 utils.handleAuthError(result);
             }


### PR DESCRIPTION
## Summary
- Remove courseManager course loading from Google and email login success handlers
- Ensure auth flow still redirects to `/app/`

## Testing
- `node test-auth.mjs` (custom script)
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a0f7aa24f88325a6e6ff5d5f588279