### PR TITLE
feat: display logo in marketing header

### DIFF
--- a/frontend/marketing/assets/css/marketing.css
+++ b/frontend/marketing/assets/css/marketing.css
@@ -72,6 +72,17 @@ body {
     flex: 1;
 }
 
+.header-logo {
+    display: flex;
+    align-items: center;
+}
+
+.logo {
+    height: 40px;
+    width: auto;
+    max-width: 200px;
+}
+
 .header h1 {
     font-family: 'Inter', sans-serif;
     font-size: 2rem;

--- a/frontend/marketing/auth.html
+++ b/frontend/marketing/auth.html
@@ -17,9 +17,8 @@
             <button id="menuToggle" class="menu-toggle" aria-label="Ouvrir le menu" aria-controls="headerNav" aria-expanded="false">
                 <i data-lucide="menu"></i>
             </button>
-            <div class="header-text">
-                <h1>Skillence AI</h1>
-                <p>Le savoir accessible à tous</p>
+            <div class="header-logo">
+                <img src="assets/images/logo.JPG" alt="Skillence AI" class="logo">
             </div>
             <nav id="headerNav" class="header-nav">
                 <ul>

--- a/frontend/marketing/contact.html
+++ b/frontend/marketing/contact.html
@@ -16,9 +16,8 @@
             <button id="menuToggle" class="menu-toggle" aria-label="Ouvrir le menu" aria-controls="headerNav" aria-expanded="false">
                 <i data-lucide="menu"></i>
             </button>
-            <div class="header-text">
-                <h1>Skillence AI</h1>
-                <p>Le savoir accessible à tous</p>
+            <div class="header-logo">
+                <img src="assets/images/logo.JPG" alt="Skillence AI" class="logo">
             </div>
             <nav id="headerNav" class="header-nav">
                 <ul>

--- a/frontend/marketing/index.html
+++ b/frontend/marketing/index.html
@@ -17,9 +17,8 @@
             <button id="menuToggle" class="menu-toggle" aria-label="Ouvrir le menu" aria-controls="headerNav" aria-expanded="false">
                 <i data-lucide="menu"></i>
             </button>
-            <div class="header-text">
-                <h1>Skillence AI</h1>
-                <p>Le savoir accessible à tous</p>
+            <div class="header-logo">
+                <img src="assets/images/logo.JPG" alt="Skillence AI" class="logo">
             </div>
             <nav id="headerNav" class="header-nav">
                 <ul>

--- a/frontend/marketing/solutions.html
+++ b/frontend/marketing/solutions.html
@@ -16,9 +16,8 @@
             <button id="menuToggle" class="menu-toggle" aria-label="Ouvrir le menu" aria-controls="headerNav" aria-expanded="false">
                 <i data-lucide="menu"></i>
             </button>
-            <div class="header-text">
-                <h1>Skillence AI</h1>
-                <p>Le savoir accessible à tous</p>
+            <div class="header-logo">
+                <img src="assets/images/logo.JPG" alt="Skillence AI" class="logo">
             </div>
             <nav id="headerNav" class="header-nav">
                 <ul>

--- a/frontend/marketing/tarifs.html
+++ b/frontend/marketing/tarifs.html
@@ -16,9 +16,8 @@
             <button id="menuToggle" class="menu-toggle" aria-label="Ouvrir le menu" aria-controls="headerNav" aria-expanded="false">
                 <i data-lucide="menu"></i>
             </button>
-            <div class="header-text">
-                <h1>Skillence AI</h1>
-                <p>Le savoir accessible à tous</p>
+            <div class="header-logo">
+                <img src="assets/images/logo.JPG" alt="Skillence AI" class="logo">
             </div>
             <nav id="headerNav" class="header-nav">
                 <ul>


### PR DESCRIPTION
## Summary
- replace "Skillence AI" header text with logo on marketing pages
- add CSS styles for header logo and image

## Testing
- `node frontend/tests/sanitize.test.js`
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a2381d4f00832591356840df1979ee