### PR TITLE
Add rate limiting and routes for quiz history

### DIFF
--- a/backend/src/routes/ai.js
+++ b/backend/src/routes/ai.js
@@ -25,6 +25,8 @@ const generateQuizLimiter = createRateLimiter(RATE_LIMITS.AI.GENERATE_QUIZ);
 const suggestQuestionsLimiter = createRateLimiter(RATE_LIMITS.AI.SUGGEST_QUESTIONS);
 const randomSubjectLimiter = createRateLimiter(RATE_LIMITS.AI.RANDOM_SUBJECT);
 const subjectCategoriesLimiter = createRateLimiter(RATE_LIMITS.AI.SUBJECT_CATEGORIES);
+const generateOnDemandQuizLimiter = createRateLimiter(RATE_LIMITS.AI.GENERATE_QUIZ);
+const quizHistoryLimiter = createRateLimiter(RATE_LIMITS.AI.SUGGEST_QUESTIONS);
 
 // Toutes les routes nécessitent une authentification
 router.use(authenticate);
@@ -37,5 +39,7 @@ router.post('/generate-quiz', generateQuizLimiter, asyncHandler(aiController.gen
 router.post('/suggest-questions', suggestQuestionsLimiter, asyncHandler(aiController.suggestQuestions));
 router.get('/random-subject', randomSubjectLimiter, asyncHandler(aiController.getRandomSubject));
 router.get('/subject-categories', subjectCategoriesLimiter, asyncHandler(aiController.getSubjectCategories));
+router.post('/generate-ondemand-quiz', generateOnDemandQuizLimiter, asyncHandler(aiController.generateOnDemandQuiz));
+router.get('/quiz-history', quizHistoryLimiter, asyncHandler(aiController.getQuizHistory));
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- add rate limiters for on-demand quiz and quiz history routes
- expose routes for generating on-demand quiz and fetching quiz history

## Testing
- `npm test --prefix backend` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a32d7100cc8325885870c8f040c662