### PR TITLE
feat: add on-demand quiz section

### DIFF
--- a/frontend/app/index.html
+++ b/frontend/app/index.html
@@ -123,6 +123,34 @@
                                 </button>
                             </div>
                         </div>
+                        <div class="quiz-ondemand-section" id="quizOnDemandSection" style="display: none;">
+                            <div class="form-group">
+                                <label for="quizSubject">Sujet du quiz</label>
+                                <input type="text" id="quizSubject" placeholder="Ex: La photosynthèse">
+                            </div>
+                            <div class="form-group">
+                                <label for="quizLevel">Niveau</label>
+                                <select id="quizLevel">
+                                    <option value="beginner">Débutant</option>
+                                    <option value="intermediate" selected>Intermédiaire</option>
+                                    <option value="expert">Expert</option>
+                                    <option value="hybrid">Hybride</option>
+                                    <option value="hybridExpert">Hybride Expert</option>
+                                </select>
+                            </div>
+                            <div class="form-group">
+                                <label for="questionCount">Nombre de questions</label>
+                                <select id="questionCount">
+                                    <option value="5">5</option>
+                                    <option value="10">10</option>
+                                    <option value="15">15</option>
+                                </select>
+                            </div>
+                            <button class="generate-btn" id="generateOnDemandQuiz">
+                                <i data-lucide="help-circle"></i>
+                                Générer le quiz
+                            </button>
+                        </div>
                     </div>
                 </div>
                 <div class="tab-content" id="historyTab" style="display: none;">


### PR DESCRIPTION
## Summary
- add on-demand quiz section markup for subject, level, and question count selectors

## Testing
- `node frontend/tests/sanitize.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a32d783be08325a22ec14bfad8365d