### PR TITLE
feat: add quiz on demand button

### DIFF
--- a/frontend/app/index.html
+++ b/frontend/app/index.html
@@ -37,6 +37,11 @@
                     Décrypter le sujet
                 </button>
 
+                <button class="quiz-ondemand-btn" id="openQuizOnDemand">
+                    <i data-lucide="brain"></i>
+                    Quiz Sur Demande
+                </button>
+
                 <h2 style="margin: 40px 0 20px 0; color: #F0F0F0;">Configuration</h2>
                 <div class="form-group">
                     <label for="subject">Sujet à décrypter</label>


### PR DESCRIPTION
## Summary
- add Quiz Sur Demande button in configuration panel before configuration heading

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a32d7d2e8c8325a05dc537cea21a0f