### PR TITLE
fix: show course section before on-demand quiz

### DIFF
--- a/frontend/app/assets/js/main.js
+++ b/frontend/app/assets/js/main.js
@@ -610,7 +610,13 @@ async function handleGenerateOnDemandQuiz() {
             currentOnDemandQuiz = quiz;
             currentQuiz = quiz;
             hideQuizOnDemandSection();
+            document.getElementById('emptyState').style.display = 'none';
+            document.getElementById('courseContent').style.display = 'block';
             displayQuiz(quiz);
+            const quizSection = document.getElementById('quizSection');
+            if (quizSection) {
+                quizSection.scrollIntoView({ behavior: 'smooth' });
+            }
         } else {
             utils.handleAuthError(data.error || 'Erreur lors de la génération du quiz', true);
         }


### PR DESCRIPTION
## Summary
- Ensure on-demand quizzes show by hiding empty state and displaying course content container
- Smoothly scroll to quiz section after it renders

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a335b00ff883258a73ca0f95144ccf