### PR TITLE
Hide empty state when opening quiz on demand

### DIFF
--- a/frontend/app/assets/js/main.js
+++ b/frontend/app/assets/js/main.js
@@ -558,6 +558,10 @@ function typewriterEffect(element, text, callback) {
 
 function showQuizOnDemandSection() {
     const section = document.getElementById('quizOnDemandSection');
+    const emptyState = document.getElementById('emptyState');
+    const courseContent = document.getElementById('courseContent');
+    if (emptyState) emptyState.style.display = 'none';
+    if (courseContent) courseContent.style.display = 'block';
     if (!section) return;
     section.style.display = 'block';
     const subjectInput = document.getElementById('quizSubject');


### PR DESCRIPTION
## Summary
- Hide the empty state and reveal course content when the quiz-on-demand section is opened

## Testing
- `node --test frontend/tests/sanitize.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68a33bc61cfc83258ea80a8432f5d620