### PR TITLE
refactor: restructure configuration panel

### DIFF
--- a/frontend/app/assets/css/app.css
+++ b/frontend/app/assets/css/app.css
@@ -167,30 +167,38 @@ body::before {
 }
 
 /* ==========================================================================
-   3. Configuration Panel - Style Panneau de Contrôle Éducatif
+   3. Configuration Container & Cards
    ========================================================================== */
-.configuration-panel {
-    background: white;
-    border-radius: 15px;
-    padding: 20px;
-    box-shadow: 0 8px 25px rgba(0, 0, 0, 0.1);
-    border: 2px solid #e2e8f0;
+.configuration-container {
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
     height: fit-content;
     max-height: calc(100vh - 120px);
     overflow-y: auto;
     position: relative;
 }
 
-.configuration-panel::before {
-    content: '🎓';
-    position: absolute;
-    top: -15px;
-    right: 20px;
-    font-size: 2rem;
+.config-card {
     background: white;
-    padding: 5px 10px;
-    border-radius: 50%;
-    box-shadow: 0 4px 15px rgba(0, 0, 0, 0.1);
+    border-radius: 15px;
+    padding: 20px;
+    box-shadow: 0 8px 25px rgba(0, 0, 0, 0.1);
+    border: 2px solid #e2e8f0;
+}
+
+.tertiary-card summary {
+    cursor: pointer;
+    font-weight: 600;
+    list-style: none;
+}
+
+.tertiary-card summary::-webkit-details-marker {
+    display: none;
+}
+
+.advanced-settings {
+    margin-top: 15px;
 }
 
 .config-close-btn {
@@ -202,7 +210,7 @@ body::before {
         grid-template-columns: 1fr;
     }
 
-    .configuration-panel {
+    .configuration-container {
         position: fixed;
         top: 0;
         left: 0;
@@ -214,7 +222,7 @@ body::before {
         z-index: 1000;
     }
 
-    .configuration-panel.open {
+    .configuration-container.open {
         transform: translateX(0);
     }
 
@@ -1894,7 +1902,7 @@ body::before {
         overflow: visible;
     }
     
-    .configuration-panel {
+    .configuration-container {
         order: 1;
         max-height: none;
         overflow-y: visible;
@@ -1936,7 +1944,7 @@ body::before {
         gap: 10px;
     }
     
-    .configuration-panel,
+    .configuration-container,
     .course-display {
         padding: 15px;
         border-radius: 12px;
@@ -1976,7 +1984,7 @@ body::before {
         font-size: 1.5rem;
     }
     
-    .configuration-panel,
+    .configuration-container,
     .course-display {
         padding: 12px;
     }

--- a/frontend/app/assets/js/main.js
+++ b/frontend/app/assets/js/main.js
@@ -50,7 +50,7 @@ function setupEventListeners() {
     const copyContent = document.getElementById('copyContent');
     const randomSubjectBtn = document.getElementById('randomSubjectBtn');
     const menuToggle = document.getElementById('menuToggle');
-    const configPanel = document.querySelector('.configuration-panel');
+    const configPanel = document.querySelector('.configuration-container');
     const headerNav = document.getElementById('headerNav');
     const closeConfigBtn = document.getElementById('closeConfigBtn');
 

--- a/frontend/app/index.html
+++ b/frontend/app/index.html
@@ -28,61 +28,80 @@
         </div>
 
         <div class="main-content">
-            <div class="configuration-panel">
+            <div class="configuration-container">
                 <button class="config-close-btn" id="closeConfigBtn">
                     <i data-lucide="x"></i>
                 </button>
-                <button class="generate-btn" id="generateBtn">
-                    <i data-lucide="sparkles"></i>
-                    Décrypter le sujet
-                </button>
 
-                <button class="quiz-ondemand-btn" id="openQuizOnDemand">
-                    <i data-lucide="brain"></i>
-                    Quiz Sur Demande
-                </button>
-
-                <h2 style="margin: 40px 0 20px 0; color: #F0F0F0;">Configuration</h2>
-                <div class="form-group">
-                    <label for="subject">Sujet à décrypter</label>
-                    <div class="subject-input-container">
-                        <textarea id="subject" placeholder="Ex: Le fonctionnement de la mémoire humaine"></textarea>
-                        <button type="button" class="random-subject-btn" id="randomSubjectBtn">
-                            <i data-lucide="sparkles"></i>
-                            Générer un sujet aléatoire
-                            <i data-lucide="dice-6"></i>
-                        </button>
-                    </div>
-                </div>
-                <div class="form-group">
-                    <div class="new-selector-container">
-                        <div class="selector-group">
-                            <div class="selector-title">🖋️ Style</div>
-                            <div class="selector-buttons">
-                                <button data-type="style" data-value="neutral" class="active">Neutre</button>
-                                <button data-type="style" data-value="pedagogical">Pédagogique</button>
-                                <button data-type="style" data-value="storytelling">Narratif</button>
-                            </div>
-                        </div>
-                        <div class="selector-group">
-                            <div class="selector-title">⏱️ Durée</div>
-                            <div class="selector-buttons">
-                                <button data-type="duration" data-value="short" class="active">Courte</button>
-                                <button data-type="duration" data-value="medium">Moyenne</button>
-                                <button data-type="duration" data-value="long">Longue</button>
-                            </div>
-                        </div>
-                        <div class="selector-group">
-                            <div class="selector-title">🎯 Intention</div>
-                            <div class="selector-buttons">
-                                <button data-type="intent" data-value="discover" class="active">Découvrir</button>
-                                <button data-type="intent" data-value="learn">Apprendre</button>
-                                <button data-type="intent" data-value="master">Maîtriser</button>
-                                <button data-type="intent" data-value="expert">Expert</button>
-                            </div>
+                <div class="config-card primary-card">
+                    <div class="form-group">
+                        <label for="subject">Sujet à décrypter</label>
+                        <div class="subject-input-container">
+                            <textarea id="subject" placeholder="Ex: Le fonctionnement de la mémoire humaine"></textarea>
+                            <button type="button" class="random-subject-btn" id="randomSubjectBtn">
+                                <i data-lucide="sparkles"></i>
+                                Générer un sujet aléatoire
+                                <i data-lucide="dice-6"></i>
+                            </button>
                         </div>
                     </div>
+                    <button class="generate-btn" id="generateBtn">
+                        <i data-lucide="sparkles"></i>
+                        Décrypter le sujet
+                    </button>
                 </div>
+
+                <div class="config-card secondary-card">
+                    <div id="quizStatus" class="quiz-status"></div>
+                    <div class="level-selector">
+                        <button class="level-btn active" data-level="beginner">Débutant</button>
+                        <button class="level-btn" data-level="intermediate">Intermédiaire</button>
+                        <button class="level-btn" data-level="expert">Expert</button>
+                        <button class="level-btn" data-level="hybrid">Hybride</button>
+                        <button class="level-btn" data-level="hybridExpert">Hybride Expert</button>
+                    </div>
+                    <button class="generate-quiz-btn" id="generateQuiz">
+                        <i data-lucide="help-circle"></i>
+                        Quiz du cours
+                    </button>
+                    <button class="quiz-ondemand-btn" id="openQuizOnDemand">
+                        <i data-lucide="brain"></i>
+                        Quiz Sur Demande
+                    </button>
+                </div>
+
+                <details class="config-card tertiary-card">
+                    <summary>Paramètres avancés</summary>
+                    <div class="advanced-settings">
+                        <div class="new-selector-container">
+                            <div class="selector-group">
+                                <div class="selector-title">🖋️ Style</div>
+                                <div class="selector-buttons">
+                                    <button data-type="style" data-value="neutral" class="active">Neutre</button>
+                                    <button data-type="style" data-value="pedagogical">Pédagogique</button>
+                                    <button data-type="style" data-value="storytelling">Narratif</button>
+                                </div>
+                            </div>
+                            <div class="selector-group">
+                                <div class="selector-title">⏱️ Durée</div>
+                                <div class="selector-buttons">
+                                    <button data-type="duration" data-value="short" class="active">Courte</button>
+                                    <button data-type="duration" data-value="medium">Moyenne</button>
+                                    <button data-type="duration" data-value="long">Longue</button>
+                                </div>
+                            </div>
+                            <div class="selector-group">
+                                <div class="selector-title">🎯 Intention</div>
+                                <div class="selector-buttons">
+                                    <button data-type="intent" data-value="discover" class="active">Découvrir</button>
+                                    <button data-type="intent" data-value="learn">Apprendre</button>
+                                    <button data-type="intent" data-value="master">Maîtriser</button>
+                                    <button data-type="intent" data-value="expert">Expert</button>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </details>
             </div>
 
             <div class="course-display">
@@ -112,10 +131,6 @@
                             <button class="action-btn" id="copyContent">
                                 <i data-lucide="copy"></i>
                                 Copier
-                            </button>
-                            <button class="action-btn" id="generateQuiz">
-                                <i data-lucide="help-circle"></i>
-                                Quiz
                             </button>
                         </div>
                         <div id="generatedCourse"></div>

--- a/frontend/marketing/assets/css/marketing.css
+++ b/frontend/marketing/assets/css/marketing.css
@@ -187,9 +187,9 @@ body {
 }
 
 /* ==========================================================================
-   3. Configuration Panel - Style Panneau de Contrôle Éducatif
+   3. Configuration Container
    ========================================================================== */
-.configuration-panel {
+.configuration-container {
     background: white;
     border-radius: 15px;
     padding: 20px;
@@ -199,18 +199,6 @@ body {
     max-height: calc(100vh - 120px);
     overflow-y: auto;
     position: relative;
-}
-
-.configuration-panel::before {
-    content: '🎓';
-    position: absolute;
-    top: -15px;
-    right: 20px;
-    font-size: 2rem;
-    background: white;
-    padding: 5px 10px;
-    border-radius: 50%;
-    box-shadow: 0 4px 15px rgba(0, 0, 0, 0.1);
 }
 
 .config-close-btn {
@@ -234,7 +222,7 @@ body {
         grid-template-columns: 1fr;
     }
 
-    .configuration-panel {
+    .configuration-container {
         position: fixed;
         top: 0;
         left: 0;
@@ -246,7 +234,7 @@ body {
         z-index: 1000;
     }
 
-    .configuration-panel.open {
+    .configuration-container.open {
         transform: translateX(0);
     }
 
@@ -1945,7 +1933,7 @@ body {
         overflow: visible;
     }
     
-    .configuration-panel {
+    .configuration-container {
         order: 1;
         max-height: none;
         overflow-y: visible;
@@ -1987,7 +1975,7 @@ body {
         gap: 10px;
     }
     
-    .configuration-panel,
+    .configuration-container,
     .course-display {
         padding: 15px;
         border-radius: 12px;
@@ -2027,7 +2015,7 @@ body {
         font-size: 1.5rem;
     }
     
-    .configuration-panel,
+    .configuration-container,
     .course-display {
         padding: 12px;
     }

--- a/frontend/marketing/assets/js/main.js
+++ b/frontend/marketing/assets/js/main.js
@@ -20,7 +20,7 @@ function initializeApp() {
 
 function setupEventListeners() {
     const menuToggle = document.getElementById('menuToggle');
-    const configPanel = document.querySelector('.configuration-panel');
+    const configPanel = document.querySelector('.configuration-container');
     const headerNav = document.getElementById('headerNav');
     const closeConfigBtn = document.getElementById('closeConfigBtn');
 


### PR DESCRIPTION
## Summary
- replace `.configuration-panel` with modular `.configuration-container`
- add primary, quiz, and collapsible advanced settings cards
- move quiz controls into dedicated card and drop unused panel markup

## Testing
- `node --test frontend/tests/sanitize.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a341153a8083259ad6b7180a55bcd4