### PR TITLE
feat: add modular configuration manager

### DIFF
--- a/frontend/app/assets/js/modular-config-manager.js
+++ b/frontend/app/assets/js/modular-config-manager.js
@@ -1,0 +1,102 @@
+export class ModularConfigManager {
+    constructor() {
+        this.currentPreset = 'default';
+        this.cardStates = { quizEnabled: false };
+        this.presets = {
+            default: { style: 'neutral', duration: 'short', intent: 'discover' },
+            balanced: { style: 'pedagogical', duration: 'medium', intent: 'learn' },
+            expert: { style: 'storytelling', duration: 'long', intent: 'master' }
+        };
+        this.currentValues = { ...this.presets[this.currentPreset] };
+    }
+
+    init() {
+        this.setupCardInteractions();
+        this.setupPresets();
+        this.setupCollapsibles();
+        this.updateQuizCardState();
+    }
+
+    getConfig() {
+        return { ...this.currentValues };
+    }
+
+    // Attach listeners to advanced selector buttons
+    setupCardInteractions() {
+        const buttons = document.querySelectorAll('.selector-group button');
+        buttons.forEach(btn => {
+            btn.addEventListener('click', () => {
+                const type = btn.dataset.type;
+                const value = btn.dataset.value;
+                this.currentValues[type] = value;
+                this.currentPreset = 'custom';
+
+                document.querySelectorAll(`.selector-group button[data-type="${type}"]`).forEach(b => {
+                    b.classList.remove('active');
+                });
+                btn.classList.add('active');
+
+                // Remove active state from preset buttons when custom value chosen
+                document.querySelectorAll('.quick-config [data-preset]').forEach(p => p.classList.remove('active'));
+            });
+        });
+    }
+
+    // Setup quick preset buttons
+    setupPresets() {
+        const presetButtons = document.querySelectorAll('.quick-config [data-preset]');
+        presetButtons.forEach(btn => {
+            btn.addEventListener('click', () => {
+                const preset = btn.dataset.preset;
+                const values = this.presets[preset];
+                if (!values) return;
+
+                this.currentPreset = preset;
+                this.currentValues = { ...values };
+
+                // Update advanced controls
+                ['style', 'duration', 'intent'].forEach(type => {
+                    const val = values[type];
+                    document.querySelectorAll(`.selector-group button[data-type="${type}"]`).forEach(b => {
+                        b.classList.toggle('active', b.dataset.value === val);
+                    });
+                });
+
+                // Update preset visuals
+                presetButtons.forEach(p => p.classList.remove('active'));
+                btn.classList.add('active');
+            });
+        });
+    }
+
+    // Simple collapsible handling
+    setupCollapsibles() {
+        document.querySelectorAll('.collapsible').forEach(el => {
+            const icon = el.querySelector('.toggle-icon');
+            el.addEventListener('click', () => {
+                el.classList.toggle('open');
+                if (icon) {
+                    icon.style.transform = el.classList.contains('open') ? 'rotate(180deg)' : '';
+                }
+            });
+        });
+    }
+
+    updateQuizCardState() {
+        const quizCard = document.querySelector('.config-card.secondary-card');
+        if (!quizCard) return;
+        quizCard.classList.toggle('disabled', !this.cardStates.quizEnabled);
+        quizCard.querySelectorAll('button').forEach(btn => {
+            btn.disabled = !this.cardStates.quizEnabled;
+        });
+    }
+
+    enableQuizCard() {
+        this.cardStates.quizEnabled = true;
+        this.updateQuizCardState();
+    }
+}
+
+if (typeof window !== 'undefined') {
+    window.ModularConfigManager = ModularConfigManager;
+}

--- a/frontend/app/index.html
+++ b/frontend/app/index.html
@@ -201,7 +201,11 @@
     <script src="assets/js/googleAuth.js"></script>
     <script type="module" src="assets/js/auth.js"></script>
     <script type="module">
+      import { ModularConfigManager } from './assets/js/modular-config-manager.js';
       document.addEventListener('DOMContentLoaded', () => {
+        window.configManager = new ModularConfigManager();
+        configManager.init();
+
         const authManager = new AuthManager();
         if (!authManager.isAuthenticated()) {
           window.location.href = '/auth.html';

--- a/frontend/tests/modular-config-manager.test.js
+++ b/frontend/tests/modular-config-manager.test.js
@@ -1,0 +1,102 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const load = () => import('../app/assets/js/modular-config-manager.js');
+
+function createElement({ className = '', dataset = {} } = {}) {
+  return {
+    dataset,
+    classList: {
+      classes: new Set(className.split(/\s+/).filter(Boolean)),
+      add(cls) { this.classes.add(cls); },
+      remove(cls) { this.classes.delete(cls); },
+      toggle(cls, force) {
+        if (force === undefined) {
+          if (this.classes.has(cls)) this.classes.delete(cls); else this.classes.add(cls);
+        } else {
+          if (force) this.classes.add(cls); else this.classes.delete(cls);
+        }
+      },
+      contains(cls) { return this.classes.has(cls); }
+    },
+    disabled: false,
+    eventListeners: {},
+    addEventListener(type, cb) { (this.eventListeners[type] ||= []).push(cb); },
+    dispatchEvent(evt) { (this.eventListeners[evt.type] || []).forEach(cb => cb(evt)); }
+  };
+}
+
+test('preset selection updates advanced controls', async () => {
+  const presetDefault = createElement({ dataset: { preset: 'default' }, className: 'preset' });
+  const presetExpert = createElement({ dataset: { preset: 'expert' }, className: 'preset' });
+  const styleNeutral = createElement({ dataset: { type: 'style', value: 'neutral' } });
+  const styleStory = createElement({ dataset: { type: 'style', value: 'storytelling' } });
+  const durationShort = createElement({ dataset: { type: 'duration', value: 'short' } });
+  const durationLong = createElement({ dataset: { type: 'duration', value: 'long' } });
+  const intentDiscover = createElement({ dataset: { type: 'intent', value: 'discover' } });
+  const intentMaster = createElement({ dataset: { type: 'intent', value: 'master' } });
+  const allButtons = [styleNeutral, styleStory, durationShort, durationLong, intentDiscover, intentMaster];
+
+  global.document = {
+    querySelectorAll(selector) {
+      if (selector === '.quick-config [data-preset]') return [presetDefault, presetExpert];
+      if (selector === '.selector-group button') return allButtons;
+      const typeMatch = selector.match(/\.selector-group button\[data-type="([^\"]+)"\]/);
+      if (typeMatch) return allButtons.filter(b => b.dataset.type === typeMatch[1]);
+      return [];
+    },
+    querySelector(selector) {
+      if (selector === '[data-type="style"][data-value="storytelling"]') return styleStory;
+      if (selector === '[data-type="duration"][data-value="long"]') return durationLong;
+      if (selector === '[data-type="intent"][data-value="master"]') return intentMaster;
+      if (selector === '.config-card.secondary-card') return null; // not used here
+      return null;
+    }
+  };
+  global.window = { Event: class { constructor(type) { this.type = type; } } };
+
+  const { ModularConfigManager } = await load();
+  const manager = new ModularConfigManager();
+  manager.init();
+
+  presetExpert.dispatchEvent({ type: 'click' });
+
+  assert.strictEqual(manager.currentPreset, 'expert');
+  const cfg = manager.getConfig();
+  assert.strictEqual(cfg.style, 'storytelling');
+  assert.strictEqual(cfg.duration, 'long');
+  assert.strictEqual(cfg.intent, 'master');
+  assert.ok(styleStory.classList.contains('active'));
+  assert.ok(durationLong.classList.contains('active'));
+  assert.ok(intentMaster.classList.contains('active'));
+});
+
+test('quiz card disabled then enabled', async () => {
+  const quizBtn = createElement();
+  const quizCard = createElement({ className: 'config-card secondary-card' });
+  quizCard.querySelectorAll = (sel) => sel === 'button' ? [quizBtn] : [];
+
+  global.document = {
+    querySelectorAll(selector) {
+      if (selector === '.quick-config [data-preset]') return [];
+      if (selector === '.selector-group button') return [];
+      return [];
+    },
+    querySelector(selector) {
+      if (selector === '.config-card.secondary-card') return quizCard;
+      return null;
+    }
+  };
+  global.window = { Event: class { constructor(type) { this.type = type; } } };
+
+  const { ModularConfigManager } = await load();
+  const manager = new ModularConfigManager();
+  manager.init();
+
+  assert.ok(quizBtn.disabled);
+  assert.ok(quizCard.classList.contains('disabled'));
+
+  manager.enableQuizCard();
+  assert.ok(!quizBtn.disabled);
+  assert.ok(!quizCard.classList.contains('disabled'));
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,15 @@
+{
+  "name": "upskill-ai",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "upskill-ai",
+      "version": "1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "scripts": {
     "build": "npm install --prefix backend",
-    "start": "npm start --prefix backend"
+    "start": "npm start --prefix backend",
+    "test": "node --test frontend/tests/*.js"
   },
   "engines": {
     "node": ">=18"


### PR DESCRIPTION
## Summary
- add configurable ModularConfigManager handling presets and quiz card state
- hook config manager into index.html and main flow for course generation
- cover preset selection and quiz card enabling in unit tests

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a344b199048325b54a17af101cd50f