### PR TITLE
Improve quiz card activation flow

### DIFF
--- a/frontend/app/assets/css/app.css
+++ b/frontend/app/assets/css/app.css
@@ -195,10 +195,32 @@ body::before {
     z-index: 3;
 }
 
+
 .config-card.secondary-card {
     border-color: #cbd5e0;
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
     z-index: 2;
+    transition: opacity 0.3s, transform 0.2s;
+}
+
+.config-card.secondary-card.disabled {
+    opacity: 0.5;
+}
+
+.config-card.secondary-card.activated {
+    animation: quiz-card-activate 0.3s ease;
+}
+
+@keyframes quiz-card-activate {
+    0% { transform: scale(1); }
+    50% { transform: scale(1.03); }
+    100% { transform: scale(1); }
+}
+
+.quiz-status {
+    margin-bottom: 10px;
+    font-size: 0.9rem;
+    color: #718096;
 }
 
 .config-card.tertiary-card {
@@ -2510,6 +2532,17 @@ body::before {
 .generate-quiz-btn:hover {
     background: linear-gradient(135deg, #68d391, #48bb78);
     transform: translateY(-2px);
+}
+
+.generate-quiz-btn:disabled,
+.quiz-ondemand-btn:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+}
+
+.generate-quiz-btn:disabled:hover,
+.quiz-ondemand-btn:disabled:hover {
+    transform: none;
 }
 
 .quiz-ondemand-btn {

--- a/frontend/app/assets/js/modular-config-manager.js
+++ b/frontend/app/assets/js/modular-config-manager.js
@@ -84,16 +84,27 @@ export class ModularConfigManager {
 
     updateQuizCardState() {
         const quizCard = document.querySelector('.config-card.secondary-card');
-        if (!quizCard) return;
-        quizCard.classList.toggle('disabled', !this.cardStates.quizEnabled);
+        const statusEl = document.getElementById('quizStatus');
+        if (!quizCard || !statusEl) return;
+
+        const enabled = this.cardStates.quizEnabled;
+        quizCard.classList.toggle('disabled', !enabled);
+        quizCard.style.opacity = enabled ? '1' : '0.5';
         quizCard.querySelectorAll('button').forEach(btn => {
-            btn.disabled = !this.cardStates.quizEnabled;
+            btn.disabled = !enabled;
         });
+        statusEl.textContent = enabled ? 'Prêt' : 'Disponible après génération';
+        statusEl.style.color = enabled ? '#38a169' : '#718096';
     }
 
     enableQuizCard() {
         this.cardStates.quizEnabled = true;
         this.updateQuizCardState();
+        const quizCard = document.querySelector('.config-card.secondary-card');
+        if (quizCard) {
+            quizCard.classList.add('activated');
+            setTimeout(() => quizCard.classList.remove('activated'), 300);
+        }
     }
 }
 

--- a/frontend/app/index.html
+++ b/frontend/app/index.html
@@ -52,7 +52,7 @@
                 </div>
 
                 <div class="config-card secondary-card">
-                    <div id="quizStatus" class="quiz-status"></div>
+                    <div id="quizStatus" class="quiz-status">Disponible après génération</div>
                     <div class="level-selector">
                         <button class="level-btn active" data-level="beginner">Débutant</button>
                         <button class="level-btn" data-level="intermediate">Intermédiaire</button>
@@ -60,11 +60,11 @@
                         <button class="level-btn" data-level="hybrid">Hybride</button>
                         <button class="level-btn" data-level="hybridExpert">Hybride Expert</button>
                     </div>
-                    <button class="generate-quiz-btn" id="generateQuiz">
+                    <button class="generate-quiz-btn" id="generateQuiz" disabled>
                         <i data-lucide="help-circle"></i>
                         Quiz du cours
                     </button>
-                    <button class="quiz-ondemand-btn" id="openQuizOnDemand">
+                    <button class="quiz-ondemand-btn" id="openQuizOnDemand" disabled>
                         <i data-lucide="brain"></i>
                         Quiz Sur Demande
                     </button>

--- a/frontend/tests/modular-config-manager.test.js
+++ b/frontend/tests/modular-config-manager.test.js
@@ -20,6 +20,7 @@ function createElement({ className = '', dataset = {} } = {}) {
       contains(cls) { return this.classes.has(cls); }
     },
     disabled: false,
+    style: {},
     eventListeners: {},
     addEventListener(type, cb) { (this.eventListeners[type] ||= []).push(cb); },
     dispatchEvent(evt) { (this.eventListeners[evt.type] || []).forEach(cb => cb(evt)); }
@@ -37,6 +38,7 @@ test('preset selection updates advanced controls', async () => {
   const intentMaster = createElement({ dataset: { type: 'intent', value: 'master' } });
   const allButtons = [styleNeutral, styleStory, durationShort, durationLong, intentDiscover, intentMaster];
 
+  const statusEl = { textContent: '', style: {} };
   global.document = {
     querySelectorAll(selector) {
       if (selector === '.quick-config [data-preset]') return [presetDefault, presetExpert];
@@ -51,6 +53,9 @@ test('preset selection updates advanced controls', async () => {
       if (selector === '[data-type="intent"][data-value="master"]') return intentMaster;
       if (selector === '.config-card.secondary-card') return null; // not used here
       return null;
+    },
+    getElementById(id) {
+      return id === 'quizStatus' ? statusEl : null;
     }
   };
   global.window = { Event: class { constructor(type) { this.type = type; } } };
@@ -76,6 +81,7 @@ test('quiz card disabled then enabled', async () => {
   const quizCard = createElement({ className: 'config-card secondary-card' });
   quizCard.querySelectorAll = (sel) => sel === 'button' ? [quizBtn] : [];
 
+  const statusEl = { textContent: '', style: {} };
   global.document = {
     querySelectorAll(selector) {
       if (selector === '.quick-config [data-preset]') return [];
@@ -85,6 +91,9 @@ test('quiz card disabled then enabled', async () => {
     querySelector(selector) {
       if (selector === '.config-card.secondary-card') return quizCard;
       return null;
+    },
+    getElementById(id) {
+      return id === 'quizStatus' ? statusEl : null;
     }
   };
   global.window = { Event: class { constructor(type) { this.type = type; } } };
@@ -95,8 +104,10 @@ test('quiz card disabled then enabled', async () => {
 
   assert.ok(quizBtn.disabled);
   assert.ok(quizCard.classList.contains('disabled'));
+  assert.strictEqual(statusEl.textContent, 'Disponible après génération');
 
   manager.enableQuizCard();
   assert.ok(!quizBtn.disabled);
   assert.ok(!quizCard.classList.contains('disabled'));
+  assert.strictEqual(statusEl.textContent, 'Prêt');
 });


### PR DESCRIPTION
## Summary
- Add default quiz status message and disable quiz actions until course generation completes
- Style quiz card and buttons for disabled state with activation animation when enabled
- Expand configuration manager and tests to update quiz status text, opacity and button states

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a3473ceca0832583c815076ca1c0f1