### PR TITLE
Enable on-demand quiz before course generation

### DIFF
--- a/frontend/app/assets/js/modular-config-manager.js
+++ b/frontend/app/assets/js/modular-config-manager.js
@@ -83,17 +83,15 @@ export class ModularConfigManager {
     }
 
     updateQuizCardState() {
-        const quizCard = document.querySelector('.config-card.secondary-card');
         const statusEl = document.getElementById('quizStatus');
-        if (!quizCard || !statusEl) return;
+        if (!statusEl) return;
 
         const enabled = this.cardStates.quizEnabled;
-        quizCard.classList.toggle('disabled', !enabled);
-        quizCard.style.opacity = enabled ? '1' : '0.5';
-        quizCard.querySelectorAll('button').forEach(btn => {
-            btn.disabled = !enabled;
-        });
-        statusEl.textContent = enabled ? 'Prêt' : 'Disponible après génération';
+        const generateQuizBtn = document.getElementById('generateQuiz');
+        if (generateQuizBtn) {
+            generateQuizBtn.disabled = !enabled;
+        }
+        statusEl.textContent = enabled ? 'Prêt' : 'Seul le "Quiz du cours" requiert un cours généré';
         statusEl.style.color = enabled ? '#38a169' : '#718096';
     }
 

--- a/frontend/app/index.html
+++ b/frontend/app/index.html
@@ -64,7 +64,7 @@
                         <i data-lucide="help-circle"></i>
                         Quiz du cours
                     </button>
-                    <button class="quiz-ondemand-btn" id="openQuizOnDemand" disabled>
+                    <button class="quiz-ondemand-btn" id="openQuizOnDemand">
                         <i data-lucide="brain"></i>
                         Quiz Sur Demande
                     </button>

--- a/frontend/tests/modular-config-manager.test.js
+++ b/frontend/tests/modular-config-manager.test.js
@@ -76,24 +76,19 @@ test('preset selection updates advanced controls', async () => {
   assert.ok(intentMaster.classList.contains('active'));
 });
 
-test('quiz card disabled then enabled', async () => {
-  const quizBtn = createElement();
-  const quizCard = createElement({ className: 'config-card secondary-card' });
-  quizCard.querySelectorAll = (sel) => sel === 'button' ? [quizBtn] : [];
-
+test('quiz buttons reflect quiz availability', async () => {
+  const generateQuizBtn = createElement();
+  const openQuizBtn = createElement();
   const statusEl = { textContent: '', style: {} };
+
   global.document = {
-    querySelectorAll(selector) {
-      if (selector === '.quick-config [data-preset]') return [];
-      if (selector === '.selector-group button') return [];
-      return [];
-    },
-    querySelector(selector) {
-      if (selector === '.config-card.secondary-card') return quizCard;
-      return null;
-    },
+    querySelectorAll() { return []; },
+    querySelector() { return null; },
     getElementById(id) {
-      return id === 'quizStatus' ? statusEl : null;
+      if (id === 'generateQuiz') return generateQuizBtn;
+      if (id === 'openQuizOnDemand') return openQuizBtn;
+      if (id === 'quizStatus') return statusEl;
+      return null;
     }
   };
   global.window = { Event: class { constructor(type) { this.type = type; } } };
@@ -102,12 +97,11 @@ test('quiz card disabled then enabled', async () => {
   const manager = new ModularConfigManager();
   manager.init();
 
-  assert.ok(quizBtn.disabled);
-  assert.ok(quizCard.classList.contains('disabled'));
-  assert.strictEqual(statusEl.textContent, 'Disponible après génération');
+  assert.ok(generateQuizBtn.disabled);
+  assert.ok(!openQuizBtn.disabled);
+  assert.strictEqual(statusEl.textContent, 'Seul le "Quiz du cours" requiert un cours généré');
 
   manager.enableQuizCard();
-  assert.ok(!quizBtn.disabled);
-  assert.ok(!quizCard.classList.contains('disabled'));
+  assert.ok(!generateQuizBtn.disabled);
   assert.strictEqual(statusEl.textContent, 'Prêt');
 });


### PR DESCRIPTION
## Summary
- Allow Quiz on Demand button to be used immediately by removing its disabled state in the HTML.
- Update quiz card logic so only the course quiz is disabled when the course isn't generated, and update status messaging accordingly.
- Adjust tests to reflect the new quiz button behavior.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a36da5fd94832590c4c846f105358f