### PR TITLE
Align quiz button with subject action

### DIFF
--- a/frontend/app/assets/css/app.css
+++ b/frontend/app/assets/css/app.css
@@ -666,9 +666,15 @@ body::before {
     font-weight: 500;
 }
 
+.action-buttons {
+    display: flex;
+    gap: 10px;
+}
+
 /* --- Main Generate Button - Style CTA Attractif --- */
 .generate-btn {
-    width: 100%;
+    flex: 1;
+    width: auto;
     padding: 18px;
     background: linear-gradient(135deg, #4299e1, #3182ce, #2c5282);
     color: white;
@@ -2517,7 +2523,8 @@ body::before {
 }
 
 .generate-quiz-btn {
-    width: 100%;
+    flex: 1;
+    width: auto;
     padding: 12px 20px;
     border: none;
     border-radius: 8px;

--- a/frontend/app/index.html
+++ b/frontend/app/index.html
@@ -45,10 +45,16 @@
                             </button>
                         </div>
                     </div>
-                    <button class="generate-btn" id="generateBtn">
-                        <i data-lucide="sparkles"></i>
-                        Décrypter le sujet
-                    </button>
+                    <div class="action-buttons">
+                        <button class="generate-btn" id="generateBtn">
+                            <i data-lucide="sparkles"></i>
+                            Décrypter le sujet
+                        </button>
+                        <button class="generate-quiz-btn" id="generateQuiz" disabled>
+                            <i data-lucide="help-circle"></i>
+                            Quiz du cours
+                        </button>
+                    </div>
                 </div>
 
                 <div class="config-card secondary-card">
@@ -60,10 +66,6 @@
                         <button class="level-btn" data-level="hybrid">Hybride</button>
                         <button class="level-btn" data-level="hybridExpert">Hybride Expert</button>
                     </div>
-                    <button class="generate-quiz-btn" id="generateQuiz" disabled>
-                        <i data-lucide="help-circle"></i>
-                        Quiz du cours
-                    </button>
                     <button class="quiz-ondemand-btn" id="openQuizOnDemand">
                         <i data-lucide="brain"></i>
                         Quiz Sur Demande


### PR DESCRIPTION
## Summary
- group course generation and quiz buttons in primary config card
- flex layout for action buttons and buttons share horizontal space

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a385a0da48832583724b2c005e8d8e