### PR TITLE
Move quiz card below advanced settings

### DIFF
--- a/frontend/app/assets/css/app.css
+++ b/frontend/app/assets/css/app.css
@@ -171,7 +171,7 @@ body::before {
    ========================================================================== */
 .configuration-container {
     display: grid;
-    grid-template-columns: 2fr 1fr 1fr;
+    grid-template-columns: 2fr 1fr;
     gap: 20px;
     padding: 20px;
     height: fit-content;
@@ -201,6 +201,7 @@ body::before {
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
     z-index: 2;
     transition: opacity 0.3s, transform 0.2s;
+    grid-column: 1 / -1;
 }
 
 .config-card.secondary-card.disabled {

--- a/frontend/app/index.html
+++ b/frontend/app/index.html
@@ -57,21 +57,6 @@
                     </div>
                 </div>
 
-                <div class="config-card secondary-card">
-                    <div id="quizStatus" class="quiz-status">Disponible après génération</div>
-                    <div class="level-selector">
-                        <button class="level-btn active" data-level="beginner">Débutant</button>
-                        <button class="level-btn" data-level="intermediate">Intermédiaire</button>
-                        <button class="level-btn" data-level="expert">Expert</button>
-                        <button class="level-btn" data-level="hybrid">Hybride</button>
-                        <button class="level-btn" data-level="hybridExpert">Hybride Expert</button>
-                    </div>
-                    <button class="quiz-ondemand-btn" id="openQuizOnDemand">
-                        <i data-lucide="brain"></i>
-                        Quiz Sur Demande
-                    </button>
-                </div>
-
                 <details class="config-card tertiary-card">
                     <summary>Paramètres avancés</summary>
                     <div class="advanced-settings">
@@ -104,6 +89,20 @@
                         </div>
                     </div>
                 </details>
+                <div class="config-card secondary-card">
+                    <div id="quizStatus" class="quiz-status">Disponible après génération</div>
+                    <div class="level-selector">
+                        <button class="level-btn active" data-level="beginner">Débutant</button>
+                        <button class="level-btn" data-level="intermediate">Intermédiaire</button>
+                        <button class="level-btn" data-level="expert">Expert</button>
+                        <button class="level-btn" data-level="hybrid">Hybride</button>
+                        <button class="level-btn" data-level="hybridExpert">Hybride Expert</button>
+                    </div>
+                    <button class="quiz-ondemand-btn" id="openQuizOnDemand">
+                        <i data-lucide="brain"></i>
+                        Quiz Sur Demande
+                    </button>
+                </div>
             </div>
 
             <div class="course-display">


### PR DESCRIPTION
## Summary
- relocate Quiz sur demande card after advanced settings section
- adjust grid to two columns and span quiz card full width

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a38750ee0c8325b2b53674012f491c