### PR TITLE
Refactor on-demand quiz level selection to use modal select

### DIFF
--- a/frontend/app/assets/js/main.js
+++ b/frontend/app/assets/js/main.js
@@ -9,7 +9,6 @@ let currentCourse = null;
 let currentQuiz = null;
 let quizState = { answered: 0, correct: 0 };
 let currentOnDemandQuiz = null;
-let selectedQuizLevel = 'beginner';
 
 
 // Initialisation de l'application
@@ -83,15 +82,6 @@ function setupEventListeners() {
     if (openQuizOnDemand) openQuizOnDemand.addEventListener('click', showQuizOnDemandSection);
     if (closeQuizOnDemand) closeQuizOnDemand.addEventListener('click', hideQuizOnDemandSection);
     if (generateOnDemandQuiz) generateOnDemandQuiz.addEventListener('click', handleGenerateOnDemandQuiz);
-
-    const levelButtons = document.querySelectorAll('.level-btn');
-    levelButtons.forEach(btn => {
-        btn.addEventListener('click', () => {
-            levelButtons.forEach(b => b.classList.remove('active'));
-            btn.classList.add('active');
-            selectedQuizLevel = btn.dataset.level;
-        });
-    });
 
     // Chat
     setupChatEventListeners();
@@ -555,10 +545,7 @@ function hideQuizOnDemandSection() {
     const questionCount = document.getElementById('questionCount');
     if (questionCount) questionCount.selectedIndex = 0;
     const levelSelect = document.getElementById('quizLevel');
-    if (levelSelect) levelSelect.value = 'beginner';
-    const levelButtons = document.querySelectorAll('.level-btn');
-    levelButtons.forEach(btn => btn.classList.remove('active'));
-    selectedQuizLevel = 'beginner';
+    if (levelSelect) levelSelect.value = 'intermediate'; // Valeur par défaut
 }
 
 async function handleGenerateOnDemandQuiz() {
@@ -575,13 +562,15 @@ async function handleGenerateOnDemandQuiz() {
     utils.showLoading(['generateOnDemandQuiz']);
 
     try {
+        const levelSelect = document.getElementById('quizLevel');
+        const level = levelSelect ? levelSelect.value : 'intermediate';
         const response = await fetch(`${API_BASE_URL}/ai/generate-ondemand-quiz`, {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
                 ...authManager.getAuthHeaders()
             },
-            body: JSON.stringify({ subject, level: selectedQuizLevel, questionCount })
+            body: JSON.stringify({ subject, level, questionCount })
         });
 
         const data = await response.json();

--- a/frontend/app/index.html
+++ b/frontend/app/index.html
@@ -91,13 +91,6 @@
                 </details>
                 <div class="config-card secondary-card">
                     <div id="quizStatus" class="quiz-status">Disponible après génération</div>
-                    <div class="level-selector">
-                        <button class="level-btn active" data-level="beginner">Débutant</button>
-                        <button class="level-btn" data-level="intermediate">Intermédiaire</button>
-                        <button class="level-btn" data-level="expert">Expert</button>
-                        <button class="level-btn" data-level="hybrid">Hybride</button>
-                        <button class="level-btn" data-level="hybridExpert">Hybride Expert</button>
-                    </div>
                     <button class="quiz-ondemand-btn" id="openQuizOnDemand">
                         <i data-lucide="brain"></i>
                         Quiz Sur Demande


### PR DESCRIPTION
## Summary
- Remove sidebar level buttons and associated state
- Read quiz level directly from modal select with default intermediate
- Clean up markup to rely solely on modal selection

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3928d73048325a1518168af5cea49