### PR TITLE
feat: move quiz on demand to dedicated tab

### DIFF
--- a/frontend/app/assets/css/app.css
+++ b/frontend/app/assets/css/app.css
@@ -2573,6 +2573,15 @@ body::before {
     gap: 15px;
 }
 
+/* Nouvel onglet Quiz sur demande */
+#openQuizOnDemand {
+    display: none;
+}
+
+#quizOnDemandResults {
+    margin-top: 20px;
+}
+
 @media (max-width: 768px) {
     .quiz-options {
         flex-direction: column;

--- a/frontend/app/assets/js/main.js
+++ b/frontend/app/assets/js/main.js
@@ -75,13 +75,10 @@ function setupEventListeners() {
         if (closeConfigBtn) closeConfigBtn.addEventListener('click', toggleNavigation);
     }
 
-    const openQuizOnDemand = document.getElementById('openQuizOnDemand');
-    const closeQuizOnDemand = document.getElementById('closeQuizOnDemand');
     const generateOnDemandQuiz = document.getElementById('generateOnDemandQuiz');
-
-    if (openQuizOnDemand) openQuizOnDemand.addEventListener('click', showQuizOnDemandSection);
-    if (closeQuizOnDemand) closeQuizOnDemand.addEventListener('click', hideQuizOnDemandSection);
-    if (generateOnDemandQuiz) generateOnDemandQuiz.addEventListener('click', handleGenerateOnDemandQuiz);
+    if (generateOnDemandQuiz) {
+        generateOnDemandQuiz.addEventListener('click', handleGenerateOnDemandQuiz);
+    }
 
     // Chat
     setupChatEventListeners();
@@ -345,6 +342,10 @@ function switchTab(tabName) {
     });
     const activeContent = document.getElementById(`${tabName}Tab`);
     if (activeContent) activeContent.style.display = 'block';
+
+    if (tabName === 'quiz-on-demand') {
+        showQuizOnDemandSection();
+    }
 }
 
 // Générer et afficher un quiz
@@ -365,8 +366,8 @@ async function handleGenerateQuiz() {
     }
 }
 
-function displayQuiz(quiz) {
-    const quizSection = document.getElementById('quizSection');
+function displayQuiz(quiz, containerId = 'quizSection') {
+    const quizSection = document.getElementById(containerId);
     if (!quizSection) return;
 
     quizState = { answered: 0, correct: 0 };
@@ -524,28 +525,28 @@ function typewriterEffect(element, text, callback) {
 }
 
 function showQuizOnDemandSection() {
-    const section = document.getElementById('quizOnDemandSection');
-    const emptyState = document.getElementById('emptyState');
-    const courseContent = document.getElementById('courseContent');
-    if (emptyState) emptyState.style.display = 'none';
-    if (courseContent) courseContent.style.display = 'block';
-    if (!section) return;
-    section.style.display = 'block';
+    const form = document.getElementById('quizOnDemandSection');
+    const results = document.getElementById('quizOnDemandResults');
+    if (form) form.style.display = 'block';
+    if (results) results.style.display = 'none';
     const subjectInput = document.getElementById('quizSubject');
     if (subjectInput) subjectInput.focus();
     utils.initializeLucide();
 }
 
 function hideQuizOnDemandSection() {
-    const section = document.getElementById('quizOnDemandSection');
-    if (!section) return;
-    section.style.display = 'none';
-    const subjectInput = document.getElementById('quizSubject');
-    if (subjectInput) subjectInput.value = '';
-    const questionCount = document.getElementById('questionCount');
-    if (questionCount) questionCount.selectedIndex = 0;
-    const levelSelect = document.getElementById('quizLevel');
-    if (levelSelect) levelSelect.value = 'intermediate'; // Valeur par défaut
+    const form = document.getElementById('quizOnDemandSection');
+    const results = document.getElementById('quizOnDemandResults');
+    if (form) {
+        form.style.display = 'none';
+        const subjectInput = document.getElementById('quizSubject');
+        if (subjectInput) subjectInput.value = '';
+        const questionCount = document.getElementById('questionCount');
+        if (questionCount) questionCount.selectedIndex = 0;
+        const levelSelect = document.getElementById('quizLevel');
+        if (levelSelect) levelSelect.value = 'intermediate';
+    }
+    if (results) results.style.display = 'block';
 }
 
 async function handleGenerateOnDemandQuiz() {
@@ -580,12 +581,10 @@ async function handleGenerateOnDemandQuiz() {
             currentOnDemandQuiz = quiz;
             currentQuiz = quiz;
             hideQuizOnDemandSection();
-            document.getElementById('emptyState').style.display = 'none';
-            document.getElementById('courseContent').style.display = 'block';
-            displayQuiz(quiz);
-            const quizSection = document.getElementById('quizSection');
-            if (quizSection) {
-                quizSection.scrollIntoView({ behavior: 'smooth' });
+            displayQuiz(quiz, 'quizOnDemandResults');
+            const resultSection = document.getElementById('quizOnDemandResults');
+            if (resultSection) {
+                resultSection.scrollIntoView({ behavior: 'smooth' });
             }
         } else {
             utils.handleAuthError(data.error || 'Erreur lors de la génération du quiz', true);

--- a/frontend/app/index.html
+++ b/frontend/app/index.html
@@ -91,16 +91,13 @@
                 </details>
                 <div class="config-card secondary-card">
                     <div id="quizStatus" class="quiz-status">Disponible après génération</div>
-                    <button class="quiz-ondemand-btn" id="openQuizOnDemand">
-                        <i data-lucide="brain"></i>
-                        Quiz Sur Demande
-                    </button>
                 </div>
             </div>
 
             <div class="course-display">
                 <div class="tabs">
                     <div class="tab active" data-tab="course">Décryptage</div>
+                    <div class="tab" data-tab="quiz-on-demand">Quiz sur demande</div>
                     <div class="tab" data-tab="history">Mes découvertes</div>
                     <div class="tab" data-tab="paths">Explorations</div>
                 </div>
@@ -137,35 +134,38 @@
                                 </button>
                             </div>
                         </div>
-                        <div class="quiz-ondemand-section" id="quizOnDemandSection" style="display: none;">
-                            <div class="form-group">
-                                <label for="quizSubject">Sujet du quiz</label>
-                                <input type="text" id="quizSubject" placeholder="Ex: La photosynthèse">
-                            </div>
-                            <div class="form-group">
-                                <label for="quizLevel">Niveau</label>
-                                <select id="quizLevel">
-                                    <option value="beginner">Débutant</option>
-                                    <option value="intermediate" selected>Intermédiaire</option>
-                                    <option value="expert">Expert</option>
-                                    <option value="hybrid">Hybride</option>
-                                    <option value="hybridExpert">Hybride Expert</option>
-                                </select>
-                            </div>
-                            <div class="form-group">
-                                <label for="questionCount">Nombre de questions</label>
-                                <select id="questionCount">
-                                    <option value="5">5</option>
-                                    <option value="10">10</option>
-                                    <option value="15">15</option>
-                                </select>
-                            </div>
-                            <button class="generate-btn" id="generateOnDemandQuiz">
-                                <i data-lucide="help-circle"></i>
-                                Générer le quiz
-                            </button>
-                        </div>
                     </div>
+                </div>
+                <div class="tab-content" id="quiz-on-demandTab" style="display: none;">
+                    <div class="quiz-ondemand-section" id="quizOnDemandSection">
+                        <div class="form-group">
+                            <label for="quizSubject">Sujet du quiz</label>
+                            <input type="text" id="quizSubject" placeholder="Ex: La photosynthèse">
+                        </div>
+                        <div class="form-group">
+                            <label for="quizLevel">Niveau</label>
+                            <select id="quizLevel">
+                                <option value="beginner">Débutant</option>
+                                <option value="intermediate" selected>Intermédiaire</option>
+                                <option value="expert">Expert</option>
+                                <option value="hybrid">Hybride</option>
+                                <option value="hybridExpert">Hybride Expert</option>
+                            </select>
+                        </div>
+                        <div class="form-group">
+                            <label for="questionCount">Nombre de questions</label>
+                            <select id="questionCount">
+                                <option value="5">5</option>
+                                <option value="10">10</option>
+                                <option value="15">15</option>
+                            </select>
+                        </div>
+                        <button class="generate-btn" id="generateOnDemandQuiz">
+                            <i data-lucide="help-circle"></i>
+                            Générer le quiz
+                        </button>
+                    </div>
+                    <div id="quizOnDemandResults" style="display: none;"></div>
                 </div>
                 <div class="tab-content" id="historyTab" style="display: none;">
                     <div class="empty-state">

--- a/frontend/tests/modular-config-manager.test.js
+++ b/frontend/tests/modular-config-manager.test.js
@@ -76,9 +76,8 @@ test('preset selection updates advanced controls', async () => {
   assert.ok(intentMaster.classList.contains('active'));
 });
 
-test('quiz buttons reflect quiz availability', async () => {
+test('quiz button reflects quiz availability', async () => {
   const generateQuizBtn = createElement();
-  const openQuizBtn = createElement();
   const statusEl = { textContent: '', style: {} };
 
   global.document = {
@@ -86,7 +85,6 @@ test('quiz buttons reflect quiz availability', async () => {
     querySelector() { return null; },
     getElementById(id) {
       if (id === 'generateQuiz') return generateQuizBtn;
-      if (id === 'openQuizOnDemand') return openQuizBtn;
       if (id === 'quizStatus') return statusEl;
       return null;
     }
@@ -98,7 +96,6 @@ test('quiz buttons reflect quiz availability', async () => {
   manager.init();
 
   assert.ok(generateQuizBtn.disabled);
-  assert.ok(!openQuizBtn.disabled);
   assert.strictEqual(statusEl.textContent, 'Seul le "Quiz du cours" requiert un cours généré');
 
   manager.enableQuizCard();


### PR DESCRIPTION
## Summary
- add `Quiz sur demande` tab and move quiz form into its own panel
- hide legacy on-demand button and style tab results
- update JS to handle new tab, display quiz results, and wire generate action

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a3952fd08c8325a350457c763a90e7