### PR TITLE
refactor: inline advanced options in config card

### DIFF
--- a/frontend/app/assets/js/main.js
+++ b/frontend/app/assets/js/main.js
@@ -45,6 +45,8 @@ function setupEventListeners() {
     const configPanel = document.querySelector('.configuration-container');
     const headerNav = document.getElementById('headerNav');
     const closeConfigBtn = document.getElementById('closeConfigBtn');
+    const advancedToggle = document.getElementById('advancedToggle');
+    const advancedSettings = document.getElementById('advancedSettings');
 
     if (generateBtn) generateBtn.addEventListener('click', handleGenerateCourse);
     if (generateQuiz) generateQuiz.addEventListener('click', handleGenerateQuiz);
@@ -78,6 +80,18 @@ function setupEventListeners() {
     const generateOnDemandQuiz = document.getElementById('generateOnDemandQuiz');
     if (generateOnDemandQuiz) {
         generateOnDemandQuiz.addEventListener('click', handleGenerateOnDemandQuiz);
+    }
+
+    if (advancedToggle && advancedSettings) {
+        advancedToggle.addEventListener('click', () => {
+            const expanded = advancedToggle.getAttribute('aria-expanded') === 'true';
+            advancedToggle.setAttribute('aria-expanded', (!expanded).toString());
+            advancedSettings.hidden = expanded;
+            const icon = advancedToggle.querySelector('.chevron');
+            if (icon) {
+                icon.style.transform = expanded ? '' : 'rotate(180deg)';
+            }
+        });
     }
 
     // Chat

--- a/frontend/app/index.html
+++ b/frontend/app/index.html
@@ -28,87 +28,87 @@
         </div>
 
         <div class="main-content">
-            <div class="configuration-container">
-                <button class="config-close-btn" id="closeConfigBtn">
-                    <i data-lucide="x"></i>
-                </button>
+        <div class="course-display">
+            <div class="tabs">
+                <div class="tab active" data-tab="course">Décryptage</div>
+                <div class="tab" data-tab="quiz-on-demand">Quiz sur demande</div>
+                <div class="tab" data-tab="history">Mes découvertes</div>
+                <div class="tab" data-tab="paths">Explorations</div>
+            </div>
 
-                <div class="config-card primary-card">
-                    <div class="form-group">
-                        <label for="subject">Sujet à décrypter</label>
-                        <div class="subject-input-container">
-                            <textarea id="subject" placeholder="Ex: Le fonctionnement de la mémoire humaine"></textarea>
-                            <button type="button" class="random-subject-btn" id="randomSubjectBtn">
+            <div class="tab-content" id="courseTab">
+                <div class="configuration-container">
+                    <button class="config-close-btn" id="closeConfigBtn">
+                        <i data-lucide="x"></i>
+                    </button>
+
+                    <div class="config-card primary-card">
+                        <div class="form-group">
+                            <label for="subject">Sujet à décrypter</label>
+                            <div class="subject-input-container">
+                                <textarea id="subject" placeholder="Ex: Le fonctionnement de la mémoire humaine"></textarea>
+                                <button type="button" class="random-subject-btn" id="randomSubjectBtn">
+                                    <i data-lucide="sparkles"></i>
+                                    Générer un sujet aléatoire
+                                    <i data-lucide="dice-6"></i>
+                                </button>
+                            </div>
+                        </div>
+                        <button id="advancedToggle" class="advanced-toggle" aria-expanded="false" aria-controls="advancedSettings">
+                            <i data-lucide="chevron-down" class="chevron"></i>
+                            Options avancées
+                        </button>
+                        <div id="advancedSettings" class="advanced-settings" hidden>
+                            <div class="new-selector-container">
+                                <div class="selector-group">
+                                    <div class="selector-title">🖋️ Style</div>
+                                    <div class="selector-buttons">
+                                        <button data-type="style" data-value="neutral" class="active">Neutre</button>
+                                        <button data-type="style" data-value="pedagogical">Pédagogique</button>
+                                        <button data-type="style" data-value="storytelling">Narratif</button>
+                                    </div>
+                                </div>
+                                <div class="selector-group">
+                                    <div class="selector-title">⏱️ Durée</div>
+                                    <div class="selector-buttons">
+                                        <button data-type="duration" data-value="short" class="active">Courte</button>
+                                        <button data-type="duration" data-value="medium">Moyenne</button>
+                                        <button data-type="duration" data-value="long">Longue</button>
+                                    </div>
+                                </div>
+                                <div class="selector-group">
+                                    <div class="selector-title">🎯 Intention</div>
+                                    <div class="selector-buttons">
+                                        <button data-type="intent" data-value="discover" class="active">Découvrir</button>
+                                        <button data-type="intent" data-value="learn">Apprendre</button>
+                                        <button data-type="intent" data-value="master">Maîtriser</button>
+                                        <button data-type="intent" data-value="expert">Expert</button>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="action-buttons">
+                            <button class="generate-btn" id="generateBtn">
                                 <i data-lucide="sparkles"></i>
-                                Générer un sujet aléatoire
-                                <i data-lucide="dice-6"></i>
+                                Décrypter le sujet
+                            </button>
+                            <button class="generate-quiz-btn" id="generateQuiz" disabled>
+                                <i data-lucide="help-circle"></i>
+                                Quiz du cours
                             </button>
                         </div>
                     </div>
-                    <div class="action-buttons">
-                        <button class="generate-btn" id="generateBtn">
-                            <i data-lucide="sparkles"></i>
-                            Décrypter le sujet
-                        </button>
-                        <button class="generate-quiz-btn" id="generateQuiz" disabled>
-                            <i data-lucide="help-circle"></i>
-                            Quiz du cours
-                        </button>
+
+                    <div class="config-card secondary-card">
+                        <div id="quizStatus" class="quiz-status">Disponible après génération</div>
                     </div>
                 </div>
-
-                <details class="config-card tertiary-card">
-                    <summary>Paramètres avancés</summary>
-                    <div class="advanced-settings">
-                        <div class="new-selector-container">
-                            <div class="selector-group">
-                                <div class="selector-title">🖋️ Style</div>
-                                <div class="selector-buttons">
-                                    <button data-type="style" data-value="neutral" class="active">Neutre</button>
-                                    <button data-type="style" data-value="pedagogical">Pédagogique</button>
-                                    <button data-type="style" data-value="storytelling">Narratif</button>
-                                </div>
-                            </div>
-                            <div class="selector-group">
-                                <div class="selector-title">⏱️ Durée</div>
-                                <div class="selector-buttons">
-                                    <button data-type="duration" data-value="short" class="active">Courte</button>
-                                    <button data-type="duration" data-value="medium">Moyenne</button>
-                                    <button data-type="duration" data-value="long">Longue</button>
-                                </div>
-                            </div>
-                            <div class="selector-group">
-                                <div class="selector-title">🎯 Intention</div>
-                                <div class="selector-buttons">
-                                    <button data-type="intent" data-value="discover" class="active">Découvrir</button>
-                                    <button data-type="intent" data-value="learn">Apprendre</button>
-                                    <button data-type="intent" data-value="master">Maîtriser</button>
-                                    <button data-type="intent" data-value="expert">Expert</button>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </details>
-                <div class="config-card secondary-card">
-                    <div id="quizStatus" class="quiz-status">Disponible après génération</div>
+                <div class="empty-state" id="emptyState">
+                    <i data-lucide="book-open"></i>
+                    <h3>Prêt à comprendre ?</h3>
+                    <p>Configurez votre cours dans le panneau de gauche et cliquez sur "Générer le cours" pour commencer.</p>
                 </div>
-            </div>
-
-            <div class="course-display">
-                <div class="tabs">
-                    <div class="tab active" data-tab="course">Décryptage</div>
-                    <div class="tab" data-tab="quiz-on-demand">Quiz sur demande</div>
-                    <div class="tab" data-tab="history">Mes découvertes</div>
-                    <div class="tab" data-tab="paths">Explorations</div>
-                </div>
-
-                <div class="tab-content" id="courseTab">
-                    <div class="empty-state" id="emptyState">
-                        <i data-lucide="book-open"></i>
-                        <h3>Prêt à comprendre ?</h3>
-                        <p>Configurez votre cours dans le panneau de gauche et cliquez sur "Générer le cours" pour commencer.</p>
-                    </div>
-                    <div class="course-content" id="courseContent" style="display: none;">
+                <div class="course-content" id="courseContent" style="display: none;">
                         <div id="quizSection" style="display: none;"></div>
                         <div class="course-actions">
                             <button class="action-btn" id="exportPdf">


### PR DESCRIPTION
## Summary
- move course configuration into `courseTab`
- replace advanced `<details>` with toggle button inside primary card
- add JS handler to show/hide advanced settings

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a431b2be90832588512248930ce02b