### PR TITLE
Add advanced settings toggle with icon initialization

### DIFF
--- a/frontend/app/assets/js/advanced-toggle.js
+++ b/frontend/app/assets/js/advanced-toggle.js
@@ -1,0 +1,19 @@
+lucide.createIcons();
+
+const ADV_KEY = 'noza-advanced-open';
+const toggleBtn = document.getElementById('advancedToggle');
+const advBox   = document.getElementById('advancedSettings');
+
+function setState(open) {
+  advBox.classList.toggle('open', open);
+  advBox.hidden = !open;
+  toggleBtn.setAttribute('aria-expanded', open);
+  toggleBtn.querySelector('.chevron').style.transform = open ? 'rotate(180deg)' : '';
+}
+setState(localStorage.getItem(ADV_KEY) === 'true');
+
+toggleBtn.addEventListener('click', () => {
+  const open = !advBox.classList.contains('open');
+  setState(open);
+  localStorage.setItem(ADV_KEY, open);
+});

--- a/frontend/app/index.html
+++ b/frontend/app/index.html
@@ -188,9 +188,6 @@
     <script src="assets/js/auth-check.js"></script>
     <script src="assets/js/app-auth-check.js"></script>
     <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.js"></script>
-    <script>
-        lucide.createIcons();
-    </script>
     <script type="module" src="assets/js/utils/utils.js"></script>
     <script src="assets/js/googleAuth.js"></script>
     <script type="module" src="assets/js/auth.js"></script>
@@ -208,6 +205,7 @@
         initializeApp();
       });
     </script>
+    <script src="assets/js/advanced-toggle.js"></script>
     <script type="module" src="assets/js/course-manager.js"></script>
     <script type="module" src="assets/js/main.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- add advanced settings toggle script that remembers state and rotates chevron
- load new toggle script in index and initialize lucide icons after DOM is ready

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a434ec7db083258ad3f33d78e36417