### PR TITLE
fix: align notifications with new course tab

### DIFF
--- a/frontend/app/assets/js/course-manager.js
+++ b/frontend/app/assets/js/course-manager.js
@@ -92,7 +92,9 @@ class CourseManager {
     };
     notification.appendChild(text);
     notification.appendChild(btn);
-    document.body.appendChild(notification);
+    // Place notifications within the course tab when available to match the new in-tab layout
+    const container = document.querySelector('#courseTab') || document.body;
+    container.appendChild(notification);
   }
 
   savePendingRequest(payload) {


### PR DESCRIPTION
## Summary
- scope notifications to active course tab instead of document body

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a4363624708325836b70cc7d16c75b