### PR TITLE
Remove quiz status card and streamline quiz activation

### DIFF
--- a/frontend/app/assets/css/app.css
+++ b/frontend/app/assets/css/app.css
@@ -196,33 +196,6 @@ body::before {
 }
 
 
-.config-card.secondary-card {
-    border-color: #cbd5e0;
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
-    z-index: 2;
-    transition: opacity 0.3s, transform 0.2s;
-    grid-column: 1 / -1;
-}
-
-.config-card.secondary-card.disabled {
-    opacity: 0.5;
-}
-
-.config-card.secondary-card.activated {
-    animation: quiz-card-activate 0.3s ease;
-}
-
-@keyframes quiz-card-activate {
-    0% { transform: scale(1); }
-    50% { transform: scale(1.03); }
-    100% { transform: scale(1); }
-}
-
-.quiz-status {
-    margin-bottom: 10px;
-    font-size: 0.9rem;
-    color: #718096;
-}
 
 .config-card.tertiary-card {
     border-color: #e2e8f0;

--- a/frontend/app/assets/js/modular-config-manager.js
+++ b/frontend/app/assets/js/modular-config-manager.js
@@ -1,7 +1,6 @@
 export class ModularConfigManager {
     constructor() {
         this.currentPreset = 'default';
-        this.cardStates = { quizEnabled: false };
         this.presets = {
             default: { style: 'neutral', duration: 'short', intent: 'discover' },
             balanced: { style: 'pedagogical', duration: 'medium', intent: 'learn' },
@@ -14,7 +13,6 @@ export class ModularConfigManager {
         this.setupCardInteractions();
         this.setupPresets();
         this.setupCollapsibles();
-        this.updateQuizCardState();
     }
 
     getConfig() {
@@ -82,26 +80,10 @@ export class ModularConfigManager {
         });
     }
 
-    updateQuizCardState() {
-        const statusEl = document.getElementById('quizStatus');
-        if (!statusEl) return;
-
-        const enabled = this.cardStates.quizEnabled;
+    enableQuizCard() {
         const generateQuizBtn = document.getElementById('generateQuiz');
         if (generateQuizBtn) {
-            generateQuizBtn.disabled = !enabled;
-        }
-        statusEl.textContent = enabled ? 'Prêt' : 'Seul le "Quiz du cours" requiert un cours généré';
-        statusEl.style.color = enabled ? '#38a169' : '#718096';
-    }
-
-    enableQuizCard() {
-        this.cardStates.quizEnabled = true;
-        this.updateQuizCardState();
-        const quizCard = document.querySelector('.config-card.secondary-card');
-        if (quizCard) {
-            quizCard.classList.add('activated');
-            setTimeout(() => quizCard.classList.remove('activated'), 300);
+            generateQuizBtn.disabled = false;
         }
     }
 }

--- a/frontend/app/index.html
+++ b/frontend/app/index.html
@@ -99,9 +99,6 @@
                         </div>
                     </div>
 
-                    <div class="config-card secondary-card">
-                        <div id="quizStatus" class="quiz-status">Disponible après génération</div>
-                    </div>
                 </div>
                 <div class="empty-state" id="emptyState">
                     <i data-lucide="book-open"></i>

--- a/frontend/tests/modular-config-manager.test.js
+++ b/frontend/tests/modular-config-manager.test.js
@@ -38,7 +38,6 @@ test('preset selection updates advanced controls', async () => {
   const intentMaster = createElement({ dataset: { type: 'intent', value: 'master' } });
   const allButtons = [styleNeutral, styleStory, durationShort, durationLong, intentDiscover, intentMaster];
 
-  const statusEl = { textContent: '', style: {} };
   global.document = {
     querySelectorAll(selector) {
       if (selector === '.quick-config [data-preset]') return [presetDefault, presetExpert];
@@ -51,11 +50,10 @@ test('preset selection updates advanced controls', async () => {
       if (selector === '[data-type="style"][data-value="storytelling"]') return styleStory;
       if (selector === '[data-type="duration"][data-value="long"]') return durationLong;
       if (selector === '[data-type="intent"][data-value="master"]') return intentMaster;
-      if (selector === '.config-card.secondary-card') return null; // not used here
       return null;
     },
-    getElementById(id) {
-      return id === 'quizStatus' ? statusEl : null;
+    getElementById() {
+      return null;
     }
   };
   global.window = { Event: class { constructor(type) { this.type = type; } } };
@@ -78,14 +76,13 @@ test('preset selection updates advanced controls', async () => {
 
 test('quiz button reflects quiz availability', async () => {
   const generateQuizBtn = createElement();
-  const statusEl = { textContent: '', style: {} };
+  generateQuizBtn.disabled = true;
 
   global.document = {
     querySelectorAll() { return []; },
     querySelector() { return null; },
     getElementById(id) {
       if (id === 'generateQuiz') return generateQuizBtn;
-      if (id === 'quizStatus') return statusEl;
       return null;
     }
   };
@@ -96,9 +93,7 @@ test('quiz button reflects quiz availability', async () => {
   manager.init();
 
   assert.ok(generateQuizBtn.disabled);
-  assert.strictEqual(statusEl.textContent, 'Seul le "Quiz du cours" requiert un cours généré');
 
   manager.enableQuizCard();
   assert.ok(!generateQuizBtn.disabled);
-  assert.strictEqual(statusEl.textContent, 'Prêt');
 });


### PR DESCRIPTION
## Summary
- remove quiz status card from frontend markup and styles
- simplify modular-config-manager by dropping state tracking and directly enabling quiz generation button
- update tests to check only quiz button availability

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4777cf1088325a429fb8b11577a25