### PR TITLE
Reorganize configuration panel layout

### DIFF
--- a/frontend/app/assets/css/app.css
+++ b/frontend/app/assets/css/app.css
@@ -180,6 +180,14 @@ body::before {
     position: relative;
 }
 
+.configuration-container.hidden {
+    display: none;
+}
+
+.configuration-container.hidden + .course-display {
+    grid-column: 1 / -1;
+}
+
 .config-card {
     background: #fff;
     border-radius: 15px;

--- a/frontend/app/index.html
+++ b/frontend/app/index.html
@@ -28,8 +28,71 @@
         </div>
 
         <div class="main-content">
-        <div class="course-display">
-            <div class="tabs">
+            <div class="configuration-container">
+                <button class="config-close-btn" id="closeConfigBtn">
+                    <i data-lucide="x"></i>
+                </button>
+
+                <div class="config-card primary-card">
+                    <div class="form-group">
+                        <label for="subject">Sujet à décrypter</label>
+                        <div class="subject-input-container">
+                            <textarea id="subject" placeholder="Ex: Le fonctionnement de la mémoire humaine"></textarea>
+                            <button type="button" class="random-subject-btn" id="randomSubjectBtn">
+                                <i data-lucide="sparkles"></i>
+                                Générer un sujet aléatoire
+                                <i data-lucide="dice-6"></i>
+                            </button>
+                        </div>
+                    </div>
+                    <button id="advancedToggle" class="advanced-toggle" aria-expanded="false" aria-controls="advancedSettings">
+                        <i data-lucide="chevron-down" class="chevron"></i>
+                        Options avancées
+                    </button>
+                    <div id="advancedSettings" class="advanced-settings" hidden>
+                        <div class="new-selector-container">
+                            <div class="selector-group">
+                                <div class="selector-title">🖋️ Style</div>
+                                <div class="selector-buttons">
+                                    <button data-type="style" data-value="neutral" class="active">Neutre</button>
+                                    <button data-type="style" data-value="pedagogical">Pédagogique</button>
+                                    <button data-type="style" data-value="storytelling">Narratif</button>
+                                </div>
+                            </div>
+                            <div class="selector-group">
+                                <div class="selector-title">⏱️ Durée</div>
+                                <div class="selector-buttons">
+                                    <button data-type="duration" data-value="short" class="active">Courte</button>
+                                    <button data-type="duration" data-value="medium">Moyenne</button>
+                                    <button data-type="duration" data-value="long">Longue</button>
+                                </div>
+                            </div>
+                            <div class="selector-group">
+                                <div class="selector-title">🎯 Intention</div>
+                                <div class="selector-buttons">
+                                    <button data-type="intent" data-value="discover" class="active">Découvrir</button>
+                                    <button data-type="intent" data-value="learn">Apprendre</button>
+                                    <button data-type="intent" data-value="master">Maîtriser</button>
+                                    <button data-type="intent" data-value="expert">Expert</button>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="action-buttons">
+                        <button class="generate-btn" id="generateBtn">
+                            <i data-lucide="sparkles"></i>
+                            Décrypter le sujet
+                        </button>
+                        <button class="generate-quiz-btn" id="generateQuiz" disabled>
+                            <i data-lucide="help-circle"></i>
+                            Quiz du cours
+                        </button>
+                    </div>
+                </div>
+
+            </div>
+            <div class="course-display">
+                <div class="tabs">
                 <div class="tab active" data-tab="course">Décryptage</div>
                 <div class="tab" data-tab="quiz-on-demand">Quiz sur demande</div>
                 <div class="tab" data-tab="history">Mes découvertes</div>
@@ -37,69 +100,6 @@
             </div>
 
             <div class="tab-content" id="courseTab">
-                <div class="configuration-container">
-                    <button class="config-close-btn" id="closeConfigBtn">
-                        <i data-lucide="x"></i>
-                    </button>
-
-                    <div class="config-card primary-card">
-                        <div class="form-group">
-                            <label for="subject">Sujet à décrypter</label>
-                            <div class="subject-input-container">
-                                <textarea id="subject" placeholder="Ex: Le fonctionnement de la mémoire humaine"></textarea>
-                                <button type="button" class="random-subject-btn" id="randomSubjectBtn">
-                                    <i data-lucide="sparkles"></i>
-                                    Générer un sujet aléatoire
-                                    <i data-lucide="dice-6"></i>
-                                </button>
-                            </div>
-                        </div>
-                        <button id="advancedToggle" class="advanced-toggle" aria-expanded="false" aria-controls="advancedSettings">
-                            <i data-lucide="chevron-down" class="chevron"></i>
-                            Options avancées
-                        </button>
-                        <div id="advancedSettings" class="advanced-settings" hidden>
-                            <div class="new-selector-container">
-                                <div class="selector-group">
-                                    <div class="selector-title">🖋️ Style</div>
-                                    <div class="selector-buttons">
-                                        <button data-type="style" data-value="neutral" class="active">Neutre</button>
-                                        <button data-type="style" data-value="pedagogical">Pédagogique</button>
-                                        <button data-type="style" data-value="storytelling">Narratif</button>
-                                    </div>
-                                </div>
-                                <div class="selector-group">
-                                    <div class="selector-title">⏱️ Durée</div>
-                                    <div class="selector-buttons">
-                                        <button data-type="duration" data-value="short" class="active">Courte</button>
-                                        <button data-type="duration" data-value="medium">Moyenne</button>
-                                        <button data-type="duration" data-value="long">Longue</button>
-                                    </div>
-                                </div>
-                                <div class="selector-group">
-                                    <div class="selector-title">🎯 Intention</div>
-                                    <div class="selector-buttons">
-                                        <button data-type="intent" data-value="discover" class="active">Découvrir</button>
-                                        <button data-type="intent" data-value="learn">Apprendre</button>
-                                        <button data-type="intent" data-value="master">Maîtriser</button>
-                                        <button data-type="intent" data-value="expert">Expert</button>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="action-buttons">
-                            <button class="generate-btn" id="generateBtn">
-                                <i data-lucide="sparkles"></i>
-                                Décrypter le sujet
-                            </button>
-                            <button class="generate-quiz-btn" id="generateQuiz" disabled>
-                                <i data-lucide="help-circle"></i>
-                                Quiz du cours
-                            </button>
-                        </div>
-                    </div>
-
-                </div>
                 <div class="empty-state" id="emptyState">
                     <i data-lucide="book-open"></i>
                     <h3>Prêt à comprendre ?</h3>


### PR DESCRIPTION
## Summary
- Move configuration panel outside course display so it's the first child of `main-content`
- Support two-column layout with full-width course display when configuration is hidden

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a47a1e02c8832583739dcc8dc41ac8