### PR TITLE
Refactor decryptage controls layout

### DIFF
--- a/frontend/app/index.html
+++ b/frontend/app/index.html
@@ -11,9 +11,6 @@
         <div class="loading-spinner"></div>
     </div>
     <div class="container">
-        <button id="menuToggle" class="menu-toggle" aria-label="Ouvrir la configuration">
-            <i data-lucide="menu"></i>
-        </button>
         <!-- Section utilisateur connecté -->
         <div id="userSection" class="user-section">
             <div class="user-info">
@@ -28,65 +25,6 @@
         </div>
 
         <div class="main-content">
-            <div class="configuration-container">
-                <button class="config-close-btn" id="closeConfigBtn">
-                    <i data-lucide="x"></i>
-                </button>
-
-                <div class="config-card primary-card">
-                    <div class="form-group">
-                        <label for="subject">Sujet à décrypter</label>
-                        <div class="subject-input-container">
-                            <textarea id="subject" placeholder="Ex: Le fonctionnement de la mémoire humaine"></textarea>
-                            <button type="button" class="random-subject-btn" id="randomSubjectBtn">
-                                <i data-lucide="sparkles"></i>
-                                Générer un sujet aléatoire
-                                <i data-lucide="dice-6"></i>
-                            </button>
-                        </div>
-                    </div>
-                    <div id="advancedSettings" class="advanced-settings">
-                        <div class="new-selector-container">
-                            <div class="selector-group">
-                                <div class="selector-title">🖋️ Style</div>
-                                <div class="selector-buttons">
-                                    <button data-type="style" data-value="neutral" class="active">Neutre</button>
-                                    <button data-type="style" data-value="pedagogical">Pédagogique</button>
-                                    <button data-type="style" data-value="storytelling">Narratif</button>
-                                </div>
-                            </div>
-                            <div class="selector-group">
-                                <div class="selector-title">⏱️ Durée</div>
-                                <div class="selector-buttons">
-                                    <button data-type="duration" data-value="short" class="active">Courte</button>
-                                    <button data-type="duration" data-value="medium">Moyenne</button>
-                                    <button data-type="duration" data-value="long">Longue</button>
-                                </div>
-                            </div>
-                            <div class="selector-group">
-                                <div class="selector-title">🎯 Intention</div>
-                                <div class="selector-buttons">
-                                    <button data-type="intent" data-value="discover" class="active">Découvrir</button>
-                                    <button data-type="intent" data-value="learn">Apprendre</button>
-                                    <button data-type="intent" data-value="master">Maîtriser</button>
-                                    <button data-type="intent" data-value="expert">Expert</button>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="action-buttons">
-                        <button class="generate-btn" id="generateBtn">
-                            <i data-lucide="sparkles"></i>
-                            Décrypter le sujet
-                        </button>
-                        <button class="generate-quiz-btn" id="generateQuiz" disabled>
-                            <i data-lucide="help-circle"></i>
-                            Quiz du cours
-                        </button>
-                    </div>
-                </div>
-
-            </div>
             <div class="course-display">
                 <div class="tabs">
                 <div class="tab active" data-tab="course">Décryptage</div>
@@ -100,6 +38,60 @@
                     <i data-lucide="book-open"></i>
                     <h3>Prêt à comprendre ?</h3>
                     <p>Configurez votre cours dans le panneau de gauche et cliquez sur "Générer le cours" pour commencer.</p>
+                </div>
+                <div class="decryptage-controls">
+                    <div class="config-card primary-card">
+                        <div class="form-group">
+                            <label for="subject">Sujet à décrypter</label>
+                            <div class="subject-input-container">
+                                <textarea id="subject" placeholder="Ex: Le fonctionnement de la mémoire humaine"></textarea>
+                                <button type="button" class="random-subject-btn" id="randomSubjectBtn">
+                                    <i data-lucide="sparkles"></i>
+                                    Générer un sujet aléatoire
+                                    <i data-lucide="dice-6"></i>
+                                </button>
+                            </div>
+                        </div>
+                        <div id="advancedSettings" class="advanced-settings">
+                            <div class="new-selector-container">
+                                <div class="selector-group">
+                                    <div class="selector-title">🖋️ Style</div>
+                                    <div class="selector-buttons">
+                                        <button data-type="style" data-value="neutral" class="active">Neutre</button>
+                                        <button data-type="style" data-value="pedagogical">Pédagogique</button>
+                                        <button data-type="style" data-value="storytelling">Narratif</button>
+                                    </div>
+                                </div>
+                                <div class="selector-group">
+                                    <div class="selector-title">⏱️ Durée</div>
+                                    <div class="selector-buttons">
+                                        <button data-type="duration" data-value="short" class="active">Courte</button>
+                                        <button data-type="duration" data-value="medium">Moyenne</button>
+                                        <button data-type="duration" data-value="long">Longue</button>
+                                    </div>
+                                </div>
+                                <div class="selector-group">
+                                    <div class="selector-title">🎯 Intention</div>
+                                    <div class="selector-buttons">
+                                        <button data-type="intent" data-value="discover" class="active">Découvrir</button>
+                                        <button data-type="intent" data-value="learn">Apprendre</button>
+                                        <button data-type="intent" data-value="master">Maîtriser</button>
+                                        <button data-type="intent" data-value="expert">Expert</button>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="action-buttons">
+                            <button class="generate-btn" id="generateBtn">
+                                <i data-lucide="sparkles"></i>
+                                Décrypter le sujet
+                            </button>
+                            <button class="generate-quiz-btn" id="generateQuiz" disabled>
+                                <i data-lucide="help-circle"></i>
+                                Quiz du cours
+                            </button>
+                        </div>
+                    </div>
                 </div>
                 <div class="course-content" id="courseContent" style="display: none;">
                         <div id="quizSection" style="display: none;"></div>


### PR DESCRIPTION
## Summary
- move decryptage configuration into the course tab
- wrap configuration card in `.decryptage-controls`
- remove obsolete menu and close buttons

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a48126ab4c83259a2bd466c942fca0