### PR TITLE
test: align config selectors with decryptage controls

### DIFF
--- a/frontend/tests/course-generation.integration.test.js
+++ b/frontend/tests/course-generation.integration.test.js
@@ -1,0 +1,81 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+function createElement({ className = '', dataset = {} } = {}) {
+  return {
+    dataset,
+    classList: {
+      classes: new Set(className.split(/\s+/).filter(Boolean)),
+      add(cls) { this.classes.add(cls); },
+      remove(cls) { this.classes.delete(cls); },
+      toggle(cls, force) {
+        if (force === undefined) {
+          if (this.classes.has(cls)) this.classes.delete(cls); else this.classes.add(cls);
+        } else {
+          if (force) this.classes.add(cls); else this.classes.delete(cls);
+        }
+      },
+      contains(cls) { return this.classes.has(cls); }
+    },
+    value: '',
+    disabled: false,
+    style: {},
+    eventListeners: {},
+    addEventListener(type, cb) { (this.eventListeners[type] ||= []).push(cb); },
+    dispatchEvent(evt) { (this.eventListeners[evt.type] || []).forEach(cb => cb(evt)); }
+  };
+}
+
+test('course generation triggered from decryptage controls', async () => {
+  let calledWith = null;
+
+  const subjectInput = createElement();
+  subjectInput.value = 'Quantum Mechanics';
+
+  const generateBtn = createElement();
+
+  global.document = {
+    getElementById(id) {
+      if (id === 'subject') return subjectInput;
+      if (id === 'generateBtn') return generateBtn;
+      return null;
+    },
+    querySelector(selector) {
+      if (selector === '.decryptage-controls #generateBtn') return generateBtn;
+      return null;
+    },
+    querySelectorAll() { return []; }
+  };
+
+  global.configManager = {
+    getConfig() { return { style: 'storytelling', duration: 'long', intent: 'master' }; },
+    enableQuizCard() {}
+  };
+
+  global.courseManager = {
+    async generateCourse(subject, style, duration, intent) {
+      calledWith = { subject, style, duration, intent };
+      return {};
+    }
+  };
+
+  global.utils = { initializeLucide() {} };
+
+  async function handleGenerateCourse() {
+    const subject = document.getElementById('subject').value.trim();
+    const { style, duration, intent } = configManager.getConfig();
+    await courseManager.generateCourse(subject, style, duration, intent);
+    utils.initializeLucide();
+  }
+
+  const btn = document.querySelector('.decryptage-controls #generateBtn');
+  btn.addEventListener('click', handleGenerateCourse);
+  btn.dispatchEvent({ type: 'click' });
+
+  assert.deepStrictEqual(calledWith, {
+    subject: 'Quantum Mechanics',
+    style: 'storytelling',
+    duration: 'long',
+    intent: 'master'
+  });
+});

--- a/frontend/tests/modular-config-manager.test.js
+++ b/frontend/tests/modular-config-manager.test.js
@@ -40,16 +40,18 @@ test('preset selection updates advanced controls', async () => {
 
   global.document = {
     querySelectorAll(selector) {
-      if (selector === '.quick-config [data-preset]') return [presetDefault, presetExpert];
-      if (selector === '.selector-group button') return allButtons;
-      const typeMatch = selector.match(/\.selector-group button\[data-type="([^\"]+)"\]/);
+      const sel = selector.replace(/^\.decryptage-controls\s*/, '');
+      if (sel === '.quick-config [data-preset]') return [presetDefault, presetExpert];
+      if (sel === '.selector-group button') return allButtons;
+      const typeMatch = sel.match(/\.selector-group button\[data-type="([^\"]+)"\]/);
       if (typeMatch) return allButtons.filter(b => b.dataset.type === typeMatch[1]);
       return [];
     },
     querySelector(selector) {
-      if (selector === '[data-type="style"][data-value="storytelling"]') return styleStory;
-      if (selector === '[data-type="duration"][data-value="long"]') return durationLong;
-      if (selector === '[data-type="intent"][data-value="master"]') return intentMaster;
+      const sel = selector.replace(/^\.decryptage-controls\s*/, '');
+      if (sel === '[data-type="style"][data-value="storytelling"]') return styleStory;
+      if (sel === '[data-type="duration"][data-value="long"]') return durationLong;
+      if (sel === '[data-type="intent"][data-value="master"]') return intentMaster;
       return null;
     },
     getElementById() {


### PR DESCRIPTION
## Summary
- update modular-config-manager tests to support `.decryptage-controls`
- add integration test covering course generation from decryptage controls

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a48a0963548325a5ebeff3cb4e46fe