### PR TITLE
Ensure tab navigation spans full width

### DIFF
--- a/frontend/app/assets/css/app.css
+++ b/frontend/app/assets/css/app.css
@@ -1640,6 +1640,7 @@ body::before {
     border-radius: 12px 12px 0 0;
     padding: 5px;
     flex-shrink: 0;
+    width: 100%;
 }
 
 .tab {
@@ -1651,6 +1652,8 @@ body::before {
     font-weight: 600;
     position: relative;
     font-size: 0.95rem;
+    flex: 1;
+    text-align: center;
 }
 
 .tab-content {


### PR DESCRIPTION
## Summary
- Make `.tabs` container span full width
- Stretch each `.tab` evenly and center its content

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4913200808325b5e90b45a897d0ef