### PR TITLE
Remove obsolete course empty state

### DIFF
--- a/frontend/app/assets/js/course-manager.js
+++ b/frontend/app/assets/js/course-manager.js
@@ -236,7 +236,6 @@ class CourseManager {
 
   // Afficher un cours
   displayCourse(course) {
-    document.getElementById('emptyState').style.display = 'none';
     document.getElementById('courseContent').style.display = 'block';
     const sanitizedContent = typeof utils.sanitizeHTML === 'function'
       ? utils.sanitizeHTML(course.content)

--- a/frontend/app/index.html
+++ b/frontend/app/index.html
@@ -34,11 +34,6 @@
             </div>
 
             <div class="tab-content" id="courseTab">
-                <div class="empty-state" id="emptyState">
-                    <i data-lucide="book-open" aria-hidden="true"></i>
-                    <h3>Prêt à comprendre ?</h3>
-                    <p>Configurez votre cours dans le panneau de gauche et utilisez les contrôles situés en haut de l’onglet pour commencer.</p>
-                </div>
                 <div class="decryptage-controls">
                     <div class="config-card primary-card">
                         <div class="form-group">


### PR DESCRIPTION
## Summary
- remove unused empty state block from course tab
- stop referencing removed empty state element in course renderer

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a49fd178648325a237181a66831d20