### PR TITLE
feat: add random quiz subject button

### DIFF
--- a/frontend/app/index.html
+++ b/frontend/app/index.html
@@ -124,7 +124,14 @@
                     <div class="quiz-ondemand-section" id="quizOnDemandSection">
                         <div class="form-group">
                             <label for="quizSubject">Sujet du quiz</label>
-                            <input type="text" id="quizSubject" placeholder="Ex: La photosynthèse">
+                            <div class="quiz-subject-input-container">
+                                <input type="text" id="quizSubject" placeholder="Ex: La photosynthèse">
+                                <button type="button" class="random-quiz-subject-btn" id="randomQuizSubjectBtn">
+                                    <i data-lucide="sparkles" aria-hidden="true"></i>
+                                    Générer un sujet aléatoire
+                                    <i data-lucide="dice-6" aria-hidden="true"></i>
+                                </button>
+                            </div>
                         </div>
                         <div class="form-group">
                             <label for="quizLevel">Niveau</label>


### PR DESCRIPTION
## Summary
- wrap quiz subject input with container and randomize button for on-demand quizzes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4b9c76e748325975208c574f80c60