### PR TITLE
feat: update course parameter helpers for new API

### DIFF
--- a/backend/src/controllers/courseController.js
+++ b/backend/src/controllers/courseController.js
@@ -95,24 +95,49 @@ class CourseController {
   // Générer un nouveau cours
   async generateCourse(req, res) {
     try {
-      const { subject, detailLevel, legacyVulgarizationLevel, teacherType, duration, vulgarizationLevel } = req.body;
+      const {
+        subject,
+        detailLevel,
+        vulgarizationLevel,
+        teacherType,
+        duration,
+        style,
+        intent,
+        vulgarization,
+      } = req.body;
 
       const deprecatedFields = [];
       if (detailLevel != null) deprecatedFields.push('detailLevel');
-      if (legacyVulgarizationLevel != null) deprecatedFields.push('legacyVulgarizationLevel');
+      if (vulgarizationLevel != null) deprecatedFields.push('vulgarizationLevel');
+      if (style != null) deprecatedFields.push('style');
+      if (intent != null) deprecatedFields.push('intent');
       const hasDeprecatedParams = deprecatedFields.length > 0;
 
       if (hasDeprecatedParams) {
         logger.warn('Utilisation de paramètres dépréciés', { deprecatedFields });
       }
 
-      const isLegacyPayload = (teacherType == null && duration == null && vulgarizationLevel == null) && hasDeprecatedParams;
+      const isLegacyPayload =
+        teacherType == null && duration == null && vulgarization == null && hasDeprecatedParams;
 
       // Conversion et valeurs par défaut
-      const params = mapLegacyParams({ detailLevel, legacyVulgarizationLevel, teacherType, duration, vulgarizationLevel });
+      const params = mapLegacyParams({
+        detailLevel,
+        vulgarizationLevel,
+        teacherType,
+        duration,
+        style,
+        intent,
+        vulgarization,
+      });
 
       // Validation
-      const validationErrors = validateCourseParams(subject, params.teacherType, params.duration, params.vulgarizationLevel);
+      const validationErrors = validateCourseParams(
+        subject,
+        params.vulgarization,
+        params.duration,
+        params.teacherType
+      );
       if (validationErrors.length > 0) {
         const { response, statusCode } = createResponse(false, null, validationErrors.join(', '), HTTP_STATUS.BAD_REQUEST);
         return res.status(statusCode).json(response);
@@ -126,7 +151,7 @@ class CourseController {
         sanitizedSubject,
         params.teacherType,
         params.duration,
-        params.vulgarizationLevel
+        params.vulgarization
       );
 
       // Sauvegarde en base
@@ -135,10 +160,10 @@ class CourseController {
           subject: sanitizedSubject,
           content: courseContent,
           detailLevel: parseInt(params.detailLevel),
-          legacyVulgarizationLevel: parseInt(params.legacyVulgarizationLevel),
+          vulgarizationLevel: parseInt(params.vulgarizationLevel),
           teacherType: params.teacherType,
           duration: params.duration,
-          vulgarizationLevel: params.vulgarizationLevel,
+          vulgarization: params.vulgarization,
           userId: req.user.id
         }
       });
@@ -148,7 +173,7 @@ class CourseController {
         userId: req.user.id,
         teacherType: params.teacherType,
         duration: params.duration,
-        vulgarizationLevel: params.vulgarizationLevel,
+        vulgarization: params.vulgarization,
         isLegacyPayload
       });
 

--- a/backend/src/middleware/validation.js
+++ b/backend/src/middleware/validation.js
@@ -56,18 +56,26 @@ const courseValidation = [
     .optional()
     .isIn(Object.values(DURATIONS))
     .withMessage('Durée invalide'),
-  body('vulgarizationLevel')
+  body('vulgarization')
     .optional()
     .isIn(Object.values(VULGARIZATION_LEVELS))
     .withMessage('Niveau de vulgarisation invalide'),
+  body('vulgarizationLevel')
+    .optional()
+    .isInt({ min: 1, max: 4 })
+    .withMessage('Niveau de vulgarisation legacy invalide'),
   body('detailLevel')
     .optional()
     .isInt({ min: 1, max: 3 })
     .withMessage('Niveau de détail invalide'),
-  body('legacyVulgarizationLevel')
+  body('style')
     .optional()
-    .isInt({ min: 1, max: 4 })
-    .withMessage('Niveau de vulgarisation legacy invalide'),
+    .isString()
+    .withMessage('Style invalide'),
+  body('intent')
+    .optional()
+    .isString()
+    .withMessage('Intent invalide'),
   handleValidationErrors
 ];
 

--- a/backend/src/utils/helpers.js
+++ b/backend/src/utils/helpers.js
@@ -1,5 +1,12 @@
 // backend/src/utils/helpers.js
-const { ERROR_MESSAGES, HTTP_STATUS, DURATIONS, TEACHER_TYPES, VULGARIZATION_LEVELS, LEGACY_VULGARIZATION_LEVELS } = require('./constants');
+const {
+  ERROR_MESSAGES,
+  HTTP_STATUS,
+  DURATIONS,
+  TEACHER_TYPES,
+  VULGARIZATION_LEVELS,
+  LEGACY_VULGARIZATION_LEVELS,
+} = require('./constants');
 const sanitizeHtml = require('sanitize-html');
 
 // Formatage de réponse standardisé
@@ -27,51 +34,82 @@ const createResponse = (success, data = null, error = null, statusCode = HTTP_ST
 };
 
 // Validation des paramètres
-const validateCourseParams = (subject, teacherType, duration, vulgarizationLevel) => {
+const validateCourseParams = (subject, vulgarization, duration, teacherType) => {
   const errors = [];
 
   if (!subject || typeof subject !== 'string' || subject.trim().length === 0) {
     errors.push('Le sujet est requis');
   }
 
-  if (!teacherType || !Object.values(TEACHER_TYPES).includes(teacherType)) {
-    errors.push("Type d'enseignant invalide");
-  }
-
   if (!duration || !Object.values(DURATIONS).includes(duration)) {
     errors.push('Durée invalide');
   }
 
-  if (!vulgarizationLevel || !Object.values(VULGARIZATION_LEVELS).includes(vulgarizationLevel)) {
+  if (!vulgarization || !Object.values(VULGARIZATION_LEVELS).includes(vulgarization)) {
     errors.push('Niveau de vulgarisation invalide');
+  }
+
+  if (!teacherType || !Object.values(TEACHER_TYPES).includes(teacherType)) {
+    errors.push("Type d'enseignant invalide");
   }
 
   return errors;
 };
 
 // Conversion des anciens paramètres vers les nouveaux
-const mapLegacyParams = ({ detailLevel, legacyVulgarizationLevel, teacherType, duration, vulgarizationLevel }) => {
+const mapLegacyParams = ({
+  detailLevel,
+  vulgarizationLevel,
+  teacherType,
+  duration,
+  style,
+  intent,
+  vulgarization,
+}) => {
   const durationMap = { 1: DURATIONS.SHORT, 2: DURATIONS.MEDIUM, 3: DURATIONS.LONG };
   const vulgarizationMap = {
     [LEGACY_VULGARIZATION_LEVELS.GENERAL_PUBLIC]: VULGARIZATION_LEVELS.GENERAL_PUBLIC,
     [LEGACY_VULGARIZATION_LEVELS.ENLIGHTENED]: VULGARIZATION_LEVELS.ENLIGHTENED,
     [LEGACY_VULGARIZATION_LEVELS.KNOWLEDGEABLE]: VULGARIZATION_LEVELS.KNOWLEDGEABLE,
-    [LEGACY_VULGARIZATION_LEVELS.EXPERT]: VULGARIZATION_LEVELS.EXPERT
+    [LEGACY_VULGARIZATION_LEVELS.EXPERT]: VULGARIZATION_LEVELS.EXPERT,
   };
 
-  const finalTeacherType = teacherType || TEACHER_TYPES.METHODICAL;
-  const finalDuration = duration || durationMap[detailLevel] || DURATIONS.MEDIUM;
-  const finalVulgarization = vulgarizationLevel || vulgarizationMap[legacyVulgarizationLevel] || VULGARIZATION_LEVELS.ENLIGHTENED;
+  const styleMap = {
+    academic: TEACHER_TYPES.METHODICAL,
+    inspiring: TEACHER_TYPES.PASSIONATE,
+    pragmatic: TEACHER_TYPES.PRAGMATIC,
+  };
 
-  const finalDetail = detailLevel || parseInt(Object.keys(durationMap).find(key => durationMap[key] === finalDuration));
-  const finalLegacyVulgarization = legacyVulgarizationLevel || parseInt(Object.keys(vulgarizationMap).find(key => vulgarizationMap[key] === finalVulgarization));
+  const intentMap = {
+    discover: TEACHER_TYPES.ANALOGIST,
+    learn: TEACHER_TYPES.METHODICAL,
+    master: TEACHER_TYPES.PASSIONATE,
+    expert: TEACHER_TYPES.SYNTHETIC,
+  };
+
+  const finalTeacherType =
+    teacherType || styleMap[style] || intentMap[intent] || TEACHER_TYPES.METHODICAL;
+  const finalDuration = duration || durationMap[detailLevel] || DURATIONS.MEDIUM;
+  const finalVulgarization =
+    vulgarization || vulgarizationMap[vulgarizationLevel] || VULGARIZATION_LEVELS.ENLIGHTENED;
+
+  const finalDetail =
+    detailLevel ||
+    parseInt(Object.keys(durationMap).find((key) => durationMap[key] === finalDuration));
+  const finalLegacyVulgarization =
+    vulgarizationLevel ||
+    parseInt(
+      Object.keys(vulgarizationMap).find(
+        (key) => vulgarizationMap[key] === finalVulgarization
+      )
+    );
 
   return {
     teacherType: finalTeacherType,
     duration: finalDuration,
-    vulgarizationLevel: finalVulgarization,
+    vulgarization: finalVulgarization,
     detailLevel: finalDetail,
-    legacyVulgarizationLevel: finalLegacyVulgarization
+    vulgarizationLevel: finalLegacyVulgarization,
   };
 };
 

--- a/backend/tests/controllers/courseController.test.js
+++ b/backend/tests/controllers/courseController.test.js
@@ -1,7 +1,12 @@
 const test = require('node:test');
 const assert = require('node:assert');
 const { mapLegacyParams } = require('../../src/utils/helpers');
-const { DURATIONS, VULGARIZATION_LEVELS, LEGACY_VULGARIZATION_LEVELS } = require('../../src/utils/constants');
+const {
+  DURATIONS,
+  VULGARIZATION_LEVELS,
+  LEGACY_VULGARIZATION_LEVELS,
+  TEACHER_TYPES,
+} = require('../../src/utils/constants');
 
 test('detailLevel numeric values map to durations', () => {
   const mapping = {
@@ -15,7 +20,7 @@ test('detailLevel numeric values map to durations', () => {
   }
 });
 
-test('legacyVulgarizationLevel numeric values map to new vulgarization levels', () => {
+test('vulgarizationLevel numeric values map to new vulgarization levels', () => {
   const mapping = {
     [LEGACY_VULGARIZATION_LEVELS.GENERAL_PUBLIC]: VULGARIZATION_LEVELS.GENERAL_PUBLIC,
     [LEGACY_VULGARIZATION_LEVELS.ENLIGHTENED]: VULGARIZATION_LEVELS.ENLIGHTENED,
@@ -23,13 +28,20 @@ test('legacyVulgarizationLevel numeric values map to new vulgarization levels', 
     [LEGACY_VULGARIZATION_LEVELS.EXPERT]: VULGARIZATION_LEVELS.EXPERT
   };
   for (const [level, expected] of Object.entries(mapping)) {
-    const result = mapLegacyParams({ legacyVulgarizationLevel: Number(level) });
-    assert.strictEqual(result.vulgarizationLevel, expected);
+    const result = mapLegacyParams({ vulgarizationLevel: Number(level) });
+    assert.strictEqual(result.vulgarization, expected);
+    assert.strictEqual(result.vulgarizationLevel, Number(level));
   }
 });
 
-test('applies default duration and vulgarization level when none provided', () => {
+test('applies default duration and vulgarization when none provided', () => {
   const result = mapLegacyParams({});
   assert.strictEqual(result.duration, DURATIONS.MEDIUM);
-  assert.strictEqual(result.vulgarizationLevel, VULGARIZATION_LEVELS.ENLIGHTENED);
+  assert.strictEqual(result.vulgarization, VULGARIZATION_LEVELS.ENLIGHTENED);
+  assert.strictEqual(result.vulgarizationLevel, LEGACY_VULGARIZATION_LEVELS.ENLIGHTENED);
+});
+
+test('maps legacy style to teacherType', () => {
+  const result = mapLegacyParams({ style: 'inspiring' });
+  assert.strictEqual(result.teacherType, TEACHER_TYPES.PASSIONATE);
 });


### PR DESCRIPTION
## Summary
- refactor course param validation to use `vulgarization` and `teacherType`
- map legacy course params including style/intent to new teacher types
- adjust controllers, validation middleware, and tests for updated param names

## Testing
- `npm test`
- `GOOGLE_CLIENT_ID='test' DATABASE_URL='postgres://user:pass@localhost:5432/db' node --test backend/tests/controllers/courseController.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a4ceeb123083258121690d0bc58763