### PR TITLE
feat: support teacher type and vulgarization

### DIFF
--- a/backend/prisma/migrations/20240101000000_rename_course_fields/migration.sql
+++ b/backend/prisma/migrations/20240101000000_rename_course_fields/migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "courses" RENAME COLUMN "style" TO "vulgarization";
+ALTER TABLE "courses" RENAME COLUMN "intent" TO "teacherType";

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -32,13 +32,13 @@ model Course {
   id                 String   @id @default(cuid())
   subject            String
   content            String   @db.Text
-  /// @deprecated Use style, duration, and intent instead
+  /// @deprecated Use vulgarization, duration, and teacherType instead
   detailLevel        Int?
-  /// @deprecated Use style, duration, and intent instead
+  /// @deprecated Use vulgarization, duration, and teacherType instead
   vulgarizationLevel Int?
-  style              String
+  vulgarization      String
   duration           String
-  intent             String
+  teacherType        String
   createdAt          DateTime @default(now())
   
   userId             String

--- a/backend/src/controllers/courseController.js
+++ b/backend/src/controllers/courseController.js
@@ -24,9 +24,9 @@ class CourseController {
             subject: true,
             detailLevel: true,
             vulgarizationLevel: true,
-            style: true,
+            vulgarization: true,
             duration: true,
-            intent: true,
+            teacherType: true,
             createdAt: true
           }
         }),
@@ -100,6 +100,7 @@ class CourseController {
         detailLevel,
         vulgarizationLevel,
         teacherType,
+        teacher_type,
         duration,
         style,
         intent,
@@ -118,13 +119,17 @@ class CourseController {
       }
 
       const isLegacyPayload =
-        teacherType == null && duration == null && vulgarization == null && hasDeprecatedParams;
+        teacherType == null &&
+        teacher_type == null &&
+        duration == null &&
+        vulgarization == null &&
+        hasDeprecatedParams;
 
       // Conversion et valeurs par défaut
       const params = mapLegacyParams({
         detailLevel,
         vulgarizationLevel,
-        teacherType,
+        teacherType: teacher_type ?? teacherType,
         duration,
         style,
         intent,

--- a/backend/src/middleware/validation.js
+++ b/backend/src/middleware/validation.js
@@ -48,6 +48,10 @@ const courseValidation = [
     .trim()
     .isLength({ min: 1, max: 500 })
     .withMessage('Le sujet doit faire entre 1 et 500 caractères'),
+  body('teacher_type')
+    .optional()
+    .isIn(Object.values(TEACHER_TYPES))
+    .withMessage("Type d'enseignant invalide"),
   body('teacherType')
     .optional()
     .isIn(Object.values(TEACHER_TYPES))


### PR DESCRIPTION
## Summary
- read `teacher_type` and `vulgarization` in course controller and pass them to course generation
- expose `vulgarization` and `teacherType` fields when listing or storing courses
- rename Prisma `style` and `intent` columns to `vulgarization` and `teacherType`

## Testing
- `npx prisma migrate dev --name rename-course-fields` *(fails: Can't reach database server at `localhost:5432`)*
- `node --test` *(fails: GOOGLE_CLIENT_ID manquant dans les variables d'environnement)*

------
https://chatgpt.com/codex/tasks/task_e_68a4d1151ef88325a1af7dd00de8ec27