### PR TITLE
refactor anthropic prompt parameters

### DIFF
--- a/backend/src/controllers/courseController.js
+++ b/backend/src/controllers/courseController.js
@@ -154,9 +154,9 @@ class CourseController {
       // Génération du cours
       const courseContent = await anthropicService.generateCourse(
         sanitizedSubject,
-        params.teacherType,
+        params.vulgarization,
         params.duration,
-        params.vulgarization
+        params.teacherType
       );
 
       // Sauvegarde en base

--- a/backend/tests/services/anthropicService.test.js
+++ b/backend/tests/services/anthropicService.test.js
@@ -27,14 +27,14 @@ test('createPrompt includes duration word counts', () => {
     [DURATIONS.LONG]: 4200
   };
   for (const [duration, count] of Object.entries(mapping)) {
-    const prompt = anthropicService.createPrompt('Sujet', TEACHER_TYPES.METHODICAL, duration, VULGARIZATION_LEVELS.ENLIGHTENED);
+    const prompt = anthropicService.createPrompt('Sujet', VULGARIZATION_LEVELS.ENLIGHTENED, duration, TEACHER_TYPES.METHODICAL);
     assert.match(prompt, new RegExp(`${count} mots`));
   }
 });
 
 test('createPrompt includes distinct teacher type instructions', () => {
-  const promptMethod = anthropicService.createPrompt('Sujet', TEACHER_TYPES.METHODICAL, DURATIONS.MEDIUM, VULGARIZATION_LEVELS.ENLIGHTENED);
-  const promptPassion = anthropicService.createPrompt('Sujet', TEACHER_TYPES.PASSIONATE, DURATIONS.MEDIUM, VULGARIZATION_LEVELS.ENLIGHTENED);
+  const promptMethod = anthropicService.createPrompt('Sujet', VULGARIZATION_LEVELS.ENLIGHTENED, DURATIONS.MEDIUM, TEACHER_TYPES.METHODICAL);
+  const promptPassion = anthropicService.createPrompt('Sujet', VULGARIZATION_LEVELS.ENLIGHTENED, DURATIONS.MEDIUM, TEACHER_TYPES.PASSIONATE);
 
   assert.match(promptMethod, /approche méthodique et structurée/);
   assert.match(promptPassion, /passion et enthousiasme/);
@@ -88,7 +88,7 @@ test('APIUserAbortError does not trigger offline mode', async () => {
   };
 
   try {
-    await anthropicService.generateCourse('Sujet', TEACHER_TYPES.METHODICAL, DURATIONS.SHORT, VULGARIZATION_LEVELS.ENLIGHTENED);
+    await anthropicService.generateCourse('Sujet', VULGARIZATION_LEVELS.ENLIGHTENED, DURATIONS.SHORT, TEACHER_TYPES.METHODICAL);
     assert.fail('generateCourse should throw');
   } catch (err) {
     assert.strictEqual(err.code, ERROR_CODES.IA_TIMEOUT);


### PR DESCRIPTION
## Summary
- align anthropic prompt creation with explicit teacher style and vulgarization instructions
- accept new prompt argument order and fallback to legacy ordering
- update controller and tests for revised generateCourse API

## Testing
- `node --test backend/tests/services/anthropicService.test.js backend/tests/controllers/courseController.test.js`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a4d2d87c688325ad7421485d12c98b