### PR TITLE
Validate course params with new teacher and vulgarization fields

### DIFF
--- a/backend/src/middleware/validation.js
+++ b/backend/src/middleware/validation.js
@@ -52,18 +52,20 @@ const courseValidation = [
     .optional()
     .isIn(Object.values(TEACHER_TYPES))
     .withMessage("Type d'enseignant invalide"),
-  body('teacherType')
-    .optional()
-    .isIn(Object.values(TEACHER_TYPES))
-    .withMessage("Type d'enseignant invalide"),
-  body('duration')
-    .optional()
-    .isIn(Object.values(DURATIONS))
-    .withMessage('Durée invalide'),
   body('vulgarization')
     .optional()
     .isIn(Object.values(VULGARIZATION_LEVELS))
     .withMessage('Niveau de vulgarisation invalide'),
+  body('duration')
+    .optional()
+    .isIn(Object.values(DURATIONS))
+    .withMessage('Durée invalide'),
+
+  // Alias de compatibilité
+  body('teacherType')
+    .optional()
+    .isIn(Object.values(TEACHER_TYPES))
+    .withMessage("Type d'enseignant invalide"),
   body('vulgarizationLevel')
     .optional()
     .isInt({ min: 1, max: 4 })
@@ -72,14 +74,6 @@ const courseValidation = [
     .optional()
     .isInt({ min: 1, max: 3 })
     .withMessage('Niveau de détail invalide'),
-  body('style')
-    .optional()
-    .isString()
-    .withMessage('Style invalide'),
-  body('intent')
-    .optional()
-    .isString()
-    .withMessage('Intent invalide'),
   handleValidationErrors
 ];
 

--- a/backend/src/routes/courses.js
+++ b/backend/src/routes/courses.js
@@ -23,7 +23,18 @@ router.get(
   asyncHandler(courseController.getAllCourses)
 );
 router.get('/:id', asyncHandler(courseController.getCourse));
-router.post('/', courseValidation, asyncHandler(courseController.generateCourse));
+router.post(
+  '/',
+  courseValidation,
+  (req, res, next) => {
+    // Compatibilité : accepter encore teacherType (camelCase)
+    if (req.body.teacherType && !req.body.teacher_type) {
+      req.body.teacher_type = req.body.teacherType;
+    }
+    next();
+  },
+  asyncHandler(courseController.generateCourse)
+);
 router.delete('/:id', asyncHandler(courseController.deleteCourse));
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- validate `teacher_type` and `vulgarization` in course requests
- drop `style` and `intent` rules while still accepting legacy fields
- accept camelCase `teacherType` in course route for backward compatibility

## Testing
- `npm test`
- `node --test backend/tests/**/*.js` *(fails: Invalid value undefined for datasource "db" provided to PrismaClient constructor)*

------
https://chatgpt.com/codex/tasks/task_e_68a4d44ce40c832587142ff2b7616079