### PR TITLE
Replace style and intention selectors

### DIFF
--- a/frontend/app/assets/js/main.js
+++ b/frontend/app/assets/js/main.js
@@ -2,7 +2,7 @@
 
 import { utils, API_BASE_URL } from './utils/utils.js';
 import { authManager } from './auth.js';
-import { courseManager, STYLE_LABELS, DURATION_LABELS, INTENT_LABELS } from './course-manager.js';
+import { courseManager, VULGARIZATION_LABELS, DURATION_LABELS, TEACHER_TYPE_LABELS } from './course-manager.js';
 
 // État global de l'application
 let currentCourse = null;
@@ -63,8 +63,8 @@ async function handleGenerateCourse() {
     const subject = document.getElementById('subject').value.trim();
     const subjectLength = subject.length;
     const cfg = typeof configManager !== 'undefined' ? configManager.getConfig() : {};
-    const { style, duration, intent } = cfg;
-    const isLegacyPayload = !style && !duration && !intent;
+    const { vulgarization, duration, teacher_type } = cfg;
+    const isLegacyPayload = !vulgarization && !duration && !teacher_type;
 
     if (!subject) {
         utils.handleAuthError('Veuillez entrer un sujet pour le décryptage');
@@ -75,25 +75,25 @@ async function handleGenerateCourse() {
         if (courseManager) {
             const course = await courseManager.generateCourse(
                 subject,
-                style,
+                vulgarization,
                 duration,
-                intent
+                teacher_type
             );
             if (course) {
                 currentCourse = course;
-                const styleLabel = STYLE_LABELS[course.style] || course.style;
+                const vulgarizationLabel = VULGARIZATION_LABELS[course.vulgarization] || course.vulgarization;
                 const durationLabel = DURATION_LABELS[course.duration] || course.duration;
-                const intentLabel = INTENT_LABELS[course.intent] || course.intent;
-                displayCourseMetadata(styleLabel, durationLabel, intentLabel);
+                const teacherTypeLabel = TEACHER_TYPE_LABELS[course.teacher_type] || course.teacher_type;
+                displayCourseMetadata(vulgarizationLabel, durationLabel, teacherTypeLabel);
                 if (typeof configManager !== 'undefined') {
                     configManager.enableQuizCard();
                 }
 
                 if (typeof gtag === 'function') {
                     gtag('event', 'course_generation', {
-                        style,
+                        vulgarization,
                         duration,
-                        intent,
+                        teacher_type,
                         isLegacyPayload,
                         subject_length: subjectLength
                     });
@@ -105,16 +105,16 @@ async function handleGenerateCourse() {
     }
 }
 
-function displayCourseMetadata(style, duration, intent) {
+function displayCourseMetadata(vulgarization, duration, teacherType) {
     const container = document.getElementById('generatedCourse');
     if (!container) return;
 
     const badgesContainer = document.createElement('div');
     badgesContainer.className = 'message-badges';
     badgesContainer.innerHTML = `
-        <span class="message-badge course-badge">${style}</span>
+        <span class="message-badge course-badge">${vulgarization}</span>
         <span class="message-badge general-badge">${duration}</span>
-        <span class="message-badge level-badge">${intent}</span>
+        <span class="message-badge level-badge">${teacherType}</span>
     `;
 
     const existing = container.querySelector('.message-badges');

--- a/frontend/app/assets/js/modular-config-manager.js
+++ b/frontend/app/assets/js/modular-config-manager.js
@@ -2,9 +2,9 @@ export class ModularConfigManager {
     constructor() {
         this.currentPreset = 'default';
         this.presets = {
-            default: { style: 'neutral', duration: 'short', intent: 'discover' },
-            balanced: { style: 'pedagogical', duration: 'medium', intent: 'learn' },
-            expert: { style: 'storytelling', duration: 'long', intent: 'master' }
+            default: { vulgarization: 'general_public', duration: 'short', teacher_type: 'methodical' },
+            balanced: { vulgarization: 'enlightened', duration: 'medium', teacher_type: 'pragmatic' },
+            expert: { vulgarization: 'expert', duration: 'long', teacher_type: 'synthetic' }
         };
         this.currentValues = { ...this.presets[this.currentPreset] };
     }
@@ -53,7 +53,7 @@ export class ModularConfigManager {
                 this.currentValues = { ...values };
 
                 // Update advanced controls
-                ['style', 'duration', 'intent'].forEach(type => {
+                ['vulgarization', 'duration', 'teacher_type'].forEach(type => {
                     const val = values[type];
                     document.querySelectorAll(`.selector-group button[data-type="${type}"]`).forEach(b => {
                         b.classList.toggle('active', b.dataset.value === val);

--- a/frontend/app/index.html
+++ b/frontend/app/index.html
@@ -53,11 +53,12 @@
                             <div id="advancedSettings" class="advanced-settings">
                                 <div class="new-selector-container">
                                     <div class="selector-group">
-                                        <div class="selector-title">🖋️ Style</div>
+                                        <div class="selector-title">📚 Niveau de vulgarisation</div>
                                         <div class="selector-buttons">
-                                            <button data-type="style" data-value="neutral" class="active">Neutre</button>
-                                            <button data-type="style" data-value="pedagogical">Pédagogique</button>
-                                            <button data-type="style" data-value="storytelling">Narratif</button>
+                                            <button data-type="vulgarization" data-value="general_public" class="active">Grand public</button>
+                                            <button data-type="vulgarization" data-value="enlightened">Éclairé</button>
+                                            <button data-type="vulgarization" data-value="knowledgeable">Connaisseur</button>
+                                            <button data-type="vulgarization" data-value="expert">Expert</button>
                                         </div>
                                     </div>
                                     <div class="selector-group">
@@ -69,12 +70,14 @@
                                         </div>
                                     </div>
                                     <div class="selector-group">
-                                        <div class="selector-title">🎯 Intention</div>
+                                        <div class="selector-title">👨‍🏫 Type de prof</div>
                                         <div class="selector-buttons">
-                                            <button data-type="intent" data-value="discover" class="active">Découvrir</button>
-                                            <button data-type="intent" data-value="learn">Apprendre</button>
-                                            <button data-type="intent" data-value="master">Maîtriser</button>
-                                            <button data-type="intent" data-value="expert">Expert</button>
+                                            <button data-type="teacher_type" data-value="methodical" class="active">Méthodique</button>
+                                            <button data-type="teacher_type" data-value="passionate">Passionné</button>
+                                            <button data-type="teacher_type" data-value="analogist">Analogiste</button>
+                                            <button data-type="teacher_type" data-value="pragmatic">Pragmatique</button>
+                                            <button data-type="teacher_type" data-value="benevolent">Bienveillant</button>
+                                            <button data-type="teacher_type" data-value="synthetic">Synthétique</button>
                                         </div>
                                     </div>
                                 </div>

--- a/frontend/tests/course-generation.integration.test.js
+++ b/frontend/tests/course-generation.integration.test.js
@@ -48,13 +48,13 @@ test('course generation triggered from decryptage controls', async () => {
   };
 
   global.configManager = {
-    getConfig() { return { style: 'storytelling', duration: 'long', intent: 'master' }; },
+    getConfig() { return { vulgarization: 'expert', duration: 'long', teacher_type: 'synthetic' }; },
     enableQuizCard() {}
   };
 
   global.courseManager = {
-    async generateCourse(subject, style, duration, intent) {
-      calledWith = { subject, style, duration, intent };
+    async generateCourse(subject, vulgarization, duration, teacher_type) {
+      calledWith = { subject, vulgarization, duration, teacher_type };
       return {};
     }
   };
@@ -62,10 +62,10 @@ test('course generation triggered from decryptage controls', async () => {
   global.utils = { initializeLucide() {} };
 
   async function handleGenerateCourse() {
-    const subject = document.getElementById('subject').value.trim();
-    const { style, duration, intent } = configManager.getConfig();
-    await courseManager.generateCourse(subject, style, duration, intent);
-    utils.initializeLucide();
+      const subject = document.getElementById('subject').value.trim();
+      const { vulgarization, duration, teacher_type } = configManager.getConfig();
+      await courseManager.generateCourse(subject, vulgarization, duration, teacher_type);
+      utils.initializeLucide();
   }
 
   const btn = document.querySelector('.decryptage-controls #generateBtn');
@@ -74,8 +74,8 @@ test('course generation triggered from decryptage controls', async () => {
 
   assert.deepStrictEqual(calledWith, {
     subject: 'Quantum Mechanics',
-    style: 'storytelling',
+    vulgarization: 'expert',
     duration: 'long',
-    intent: 'master'
+    teacher_type: 'synthetic'
   });
 });

--- a/frontend/tests/modular-config-manager.test.js
+++ b/frontend/tests/modular-config-manager.test.js
@@ -30,13 +30,13 @@ function createElement({ className = '', dataset = {} } = {}) {
 test('preset selection updates advanced controls', async () => {
   const presetDefault = createElement({ dataset: { preset: 'default' }, className: 'preset' });
   const presetExpert = createElement({ dataset: { preset: 'expert' }, className: 'preset' });
-  const styleNeutral = createElement({ dataset: { type: 'style', value: 'neutral' } });
-  const styleStory = createElement({ dataset: { type: 'style', value: 'storytelling' } });
+  const vulgarizationGeneral = createElement({ dataset: { type: 'vulgarization', value: 'general_public' } });
+  const vulgarizationExpert = createElement({ dataset: { type: 'vulgarization', value: 'expert' } });
   const durationShort = createElement({ dataset: { type: 'duration', value: 'short' } });
   const durationLong = createElement({ dataset: { type: 'duration', value: 'long' } });
-  const intentDiscover = createElement({ dataset: { type: 'intent', value: 'discover' } });
-  const intentMaster = createElement({ dataset: { type: 'intent', value: 'master' } });
-  const allButtons = [styleNeutral, styleStory, durationShort, durationLong, intentDiscover, intentMaster];
+  const teacherMethodical = createElement({ dataset: { type: 'teacher_type', value: 'methodical' } });
+  const teacherSynthetic = createElement({ dataset: { type: 'teacher_type', value: 'synthetic' } });
+  const allButtons = [vulgarizationGeneral, vulgarizationExpert, durationShort, durationLong, teacherMethodical, teacherSynthetic];
 
   global.document = {
     querySelectorAll(selector) {
@@ -49,9 +49,9 @@ test('preset selection updates advanced controls', async () => {
     },
     querySelector(selector) {
       const sel = selector.replace(/^\.decryptage-controls\s*/, '');
-      if (sel === '[data-type="style"][data-value="storytelling"]') return styleStory;
+      if (sel === '[data-type="vulgarization"][data-value="expert"]') return vulgarizationExpert;
       if (sel === '[data-type="duration"][data-value="long"]') return durationLong;
-      if (sel === '[data-type="intent"][data-value="master"]') return intentMaster;
+      if (sel === '[data-type="teacher_type"][data-value="synthetic"]') return teacherSynthetic;
       return null;
     },
     getElementById() {
@@ -68,12 +68,12 @@ test('preset selection updates advanced controls', async () => {
 
   assert.strictEqual(manager.currentPreset, 'expert');
   const cfg = manager.getConfig();
-  assert.strictEqual(cfg.style, 'storytelling');
+  assert.strictEqual(cfg.vulgarization, 'expert');
   assert.strictEqual(cfg.duration, 'long');
-  assert.strictEqual(cfg.intent, 'master');
-  assert.ok(styleStory.classList.contains('active'));
+  assert.strictEqual(cfg.teacher_type, 'synthetic');
+  assert.ok(vulgarizationExpert.classList.contains('active'));
   assert.ok(durationLong.classList.contains('active'));
-  assert.ok(intentMaster.classList.contains('active'));
+  assert.ok(teacherSynthetic.classList.contains('active'));
 });
 
 test('quiz button reflects quiz availability', async () => {


### PR DESCRIPTION
## Summary
- swap style and intention selectors for new vulgarization level and teacher type options
- adjust config and course generation to use `vulgarization` and `teacher_type`
- update tests for new configuration fields

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a4d5ca70348325a312078985bbb39a