### PR TITLE
refactor: drop legacy style/intent fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,24 +5,24 @@
 The `POST /api/courses` endpoint now supports the following parameters:
 
 - `subject` (string, required): topic to generate a course about.
-- `style` (string, required): presentation style. Accepted values: `neutral`, `pedagogical`, `storytelling`.
+- `vulgarization` (string, required): target audience. Accepted values: `general_public`, `enlightened`, `knowledgeable`, `expert`.
 - `duration` (string, required): estimated course length. Accepted values: `short`, `medium`, `long`.
-- `intent` (string, required): learning intention. Accepted values: `discover`, `learn`, `master`, `expert`.
+- `teacher_type` (string, required): teaching persona. Accepted values: `methodical`, `passionate`, `analogist`, `pragmatic`, `benevolent`, `synthetic`.
 - `detailLevel` (number, deprecated): legacy field mapped to `duration`.
-- `vulgarizationLevel` (number, deprecated): legacy field mapped to `intent`.
+- `vulgarizationLevel` (number, deprecated): legacy field mapped to `vulgarization`.
 
 ### Sample payload
 
 ```json
 {
   "subject": "Introduction to Algebra",
-  "style": "pedagogical",
+  "vulgarization": "enlightened",
   "duration": "medium",
-  "intent": "learn"
+  "teacher_type": "methodical"
 }
 ```
 
-Legacy clients may continue to send `detailLevel` and `vulgarizationLevel`. These fields remain supported for backward compatibility but will be removed in a future release.
+Legacy clients may continue to send `detailLevel` and `vulgarizationLevel`. These fields remain supported for backward compatibility but will be removed in a future release. Former fields `style` and `intent` are no longer supported.
 
 ## Running the Server
 

--- a/backend/docs/api.md
+++ b/backend/docs/api.md
@@ -19,13 +19,15 @@ Authorization: Bearer <token>
 Creates a new course for the authenticated user.
 
 ### New fields
-- `style` (string, required): presentation style. Values: `neutral`, `pedagogical`, `storytelling`.
+- `vulgarization` (string, required): audience level. Values: `general_public`, `enlightened`, `knowledgeable`, `expert`.
 - `duration` (string, required): course length. Values: `short`, `medium`, `long`.
-- `intent` (string, required): learning intent. Values: `discover`, `learn`, `master`, `expert`.
+- `teacher_type` (string, required): teacher persona. Values: `methodical`, `passionate`, `analogist`, `pragmatic`, `benevolent`, `synthetic`.
 
 ### Deprecated fields
 - `detailLevel` (number): 1 `synthesis`, 2 `detailed`, 3 `exhaustive`. Replaced by `duration`.
-- `vulgarizationLevel` (number): 1 `general_public`, 2 `enlightened`, 3 `knowledgeable`, 4 `expert`. Replaced by `intent`.
+- `vulgarizationLevel` (number): 1 `general_public`, 2 `enlightened`, 3 `knowledgeable`, 4 `expert`. Replaced by `vulgarization`.
+- `style` (string): presentation style, replaced by `vulgarization`.
+- `intent` (string): learning intent, replaced by `teacher_type`.
 
 ### Example request
 
@@ -35,14 +37,14 @@ Content-Type: application/json
 
 {
   "subject": "Introduction to Algebra",
-  "style": "pedagogical",
+  "vulgarization": "enlightened",
   "duration": "medium",
-  "intent": "learn"
+  "teacher_type": "methodical"
 }
 ```
 
 ### Migration guidance
 - Map `detailLevel` to `duration`: 1→`short`, 2→`medium`, 3→`long`.
-- Map `vulgarizationLevel` to `intent`: 1→`discover`, 2→`learn`, 3→`master`, 4→`expert`.
+- Map `vulgarizationLevel` to `vulgarization`: 1→`general_public`, 2→`enlightened`, 3→`knowledgeable`, 4→`expert`.
 
 Legacy fields remain accepted for backward compatibility but will be removed in a future release.

--- a/backend/src/controllers/courseController.js
+++ b/backend/src/controllers/courseController.js
@@ -102,16 +102,12 @@ class CourseController {
         teacherType,
         teacher_type,
         duration,
-        style,
-        intent,
         vulgarization,
       } = req.body;
 
       const deprecatedFields = [];
       if (detailLevel != null) deprecatedFields.push('detailLevel');
       if (vulgarizationLevel != null) deprecatedFields.push('vulgarizationLevel');
-      if (style != null) deprecatedFields.push('style');
-      if (intent != null) deprecatedFields.push('intent');
       const hasDeprecatedParams = deprecatedFields.length > 0;
 
       if (hasDeprecatedParams) {
@@ -131,8 +127,6 @@ class CourseController {
         vulgarizationLevel,
         teacherType: teacher_type ?? teacherType,
         duration,
-        style,
-        intent,
         vulgarization,
       });
 

--- a/backend/src/utils/helpers.js
+++ b/backend/src/utils/helpers.js
@@ -62,8 +62,6 @@ const mapLegacyParams = ({
   vulgarizationLevel,
   teacherType,
   duration,
-  style,
-  intent,
   vulgarization,
 }) => {
   const durationMap = { 1: DURATIONS.SHORT, 2: DURATIONS.MEDIUM, 3: DURATIONS.LONG };
@@ -74,21 +72,7 @@ const mapLegacyParams = ({
     [LEGACY_VULGARIZATION_LEVELS.EXPERT]: VULGARIZATION_LEVELS.EXPERT,
   };
 
-  const styleMap = {
-    academic: TEACHER_TYPES.METHODICAL,
-    inspiring: TEACHER_TYPES.PASSIONATE,
-    pragmatic: TEACHER_TYPES.PRAGMATIC,
-  };
-
-  const intentMap = {
-    discover: TEACHER_TYPES.ANALOGIST,
-    learn: TEACHER_TYPES.METHODICAL,
-    master: TEACHER_TYPES.PASSIONATE,
-    expert: TEACHER_TYPES.SYNTHETIC,
-  };
-
-  const finalTeacherType =
-    teacherType || styleMap[style] || intentMap[intent] || TEACHER_TYPES.METHODICAL;
+  const finalTeacherType = teacherType || TEACHER_TYPES.METHODICAL;
   const finalDuration = duration || durationMap[detailLevel] || DURATIONS.MEDIUM;
   const finalVulgarization =
     vulgarization || vulgarizationMap[vulgarizationLevel] || VULGARIZATION_LEVELS.ENLIGHTENED;


### PR DESCRIPTION
## Summary
- remove deprecated style and intent fields from course generation controller
- simplify legacy parameter mapping utility
- document new vulgarization and teacher_type API fields

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a4d805bd988325b1977af1083eeee5