### PR TITLE
test: switch to new config datasets

### DIFF
--- a/frontend/tests/course-generation.integration.test.js
+++ b/frontend/tests/course-generation.integration.test.js
@@ -44,8 +44,14 @@ test('course generation triggered from decryptage controls', async () => {
       if (selector === '.decryptage-controls #generateBtn') return generateBtn;
       return null;
     },
-    querySelectorAll() { return []; }
+    querySelectorAll() { return []; },
+    addEventListener() {},
+    body: { appendChild() {} }
   };
+  global.window = { location: { origin: '' } };
+  global.localStorage = { getItem() { return null; }, setItem() {}, removeItem() {} };
+
+  const { VULGARIZATION_LABELS, TEACHER_TYPE_LABELS } = await import('../app/assets/js/course-manager.js');
 
   global.configManager = {
     getConfig() { return { vulgarization: 'expert', duration: 'long', teacher_type: 'synthetic' }; },
@@ -78,4 +84,6 @@ test('course generation triggered from decryptage controls', async () => {
     duration: 'long',
     teacher_type: 'synthetic'
   });
+  assert.strictEqual(VULGARIZATION_LABELS[calledWith.vulgarization], 'Expert');
+  assert.strictEqual(TEACHER_TYPE_LABELS[calledWith.teacher_type], 'Synthétique');
 });

--- a/frontend/tests/modular-config-manager.test.js
+++ b/frontend/tests/modular-config-manager.test.js
@@ -43,7 +43,7 @@ test('preset selection updates advanced controls', async () => {
       const sel = selector.replace(/^\.decryptage-controls\s*/, '');
       if (sel === '.quick-config [data-preset]') return [presetDefault, presetExpert];
       if (sel === '.selector-group button') return allButtons;
-      const typeMatch = sel.match(/\.selector-group button\[data-type="([^\"]+)"\]/);
+      const typeMatch = sel.match(/\.selector-group button\[data-type="([^"]+)"\]/);
       if (typeMatch) return allButtons.filter(b => b.dataset.type === typeMatch[1]);
       return [];
     },
@@ -54,12 +54,14 @@ test('preset selection updates advanced controls', async () => {
       if (sel === '[data-type="teacher_type"][data-value="synthetic"]') return teacherSynthetic;
       return null;
     },
-    getElementById() {
-      return null;
-    }
+    getElementById() { return null; },
+    addEventListener() {},
+    body: { appendChild() {} }
   };
-  global.window = { Event: class { constructor(type) { this.type = type; } } };
+  global.window = { Event: class { constructor(type) { this.type = type; } }, location: { origin: '' } };
+  global.localStorage = { getItem() { return null; }, setItem() {}, removeItem() {} };
 
+  const { VULGARIZATION_LABELS, TEACHER_TYPE_LABELS } = await import('../app/assets/js/course-manager.js');
   const { ModularConfigManager } = await load();
   const manager = new ModularConfigManager();
   manager.init();
@@ -74,6 +76,8 @@ test('preset selection updates advanced controls', async () => {
   assert.ok(vulgarizationExpert.classList.contains('active'));
   assert.ok(durationLong.classList.contains('active'));
   assert.ok(teacherSynthetic.classList.contains('active'));
+  assert.strictEqual(VULGARIZATION_LABELS[cfg.vulgarization], 'Expert');
+  assert.strictEqual(TEACHER_TYPE_LABELS[cfg.teacher_type], 'Synthétique');
 });
 
 test('quiz button reflects quiz availability', async () => {


### PR DESCRIPTION
## Summary
- use `vulgarization` and `teacher_type` in modular config manager tests
- import label mappings and assert `VULGARIZATION_LABELS` and `TEACHER_TYPE_LABELS`
- update course generation integration test to match new datasets

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4d9e89e7c8325aa08deb4cb705031