### PR TITLE
test: update constants usage and prompts

### DIFF
--- a/backend/tests/controllers/courseController.test.js
+++ b/backend/tests/controllers/courseController.test.js
@@ -34,14 +34,15 @@ test('vulgarizationLevel numeric values map to new vulgarization levels', () => 
   }
 });
 
-test('applies default duration and vulgarization when none provided', () => {
+test('applies default duration, vulgarization and teacherType when none provided', () => {
   const result = mapLegacyParams({});
   assert.strictEqual(result.duration, DURATIONS.MEDIUM);
   assert.strictEqual(result.vulgarization, VULGARIZATION_LEVELS.ENLIGHTENED);
   assert.strictEqual(result.vulgarizationLevel, LEGACY_VULGARIZATION_LEVELS.ENLIGHTENED);
+  assert.strictEqual(result.teacherType, TEACHER_TYPES.METHODICAL);
 });
 
-test('maps legacy style to teacherType', () => {
-  const result = mapLegacyParams({ style: 'inspiring' });
+test('returns provided teacherType', () => {
+  const result = mapLegacyParams({ teacherType: TEACHER_TYPES.PASSIONATE });
   assert.strictEqual(result.teacherType, TEACHER_TYPES.PASSIONATE);
 });

--- a/backend/tests/services/anthropicService.test.js
+++ b/backend/tests/services/anthropicService.test.js
@@ -32,13 +32,26 @@ test('createPrompt includes duration word counts', () => {
   }
 });
 
-test('createPrompt includes distinct teacher type instructions', () => {
-  const promptMethod = anthropicService.createPrompt('Sujet', VULGARIZATION_LEVELS.ENLIGHTENED, DURATIONS.MEDIUM, TEACHER_TYPES.METHODICAL);
-  const promptPassion = anthropicService.createPrompt('Sujet', VULGARIZATION_LEVELS.ENLIGHTENED, DURATIONS.MEDIUM, TEACHER_TYPES.PASSIONATE);
+test('createPrompt includes teacher and vulgarization instructions', () => {
+  const promptMethod = anthropicService.createPrompt(
+    'Sujet',
+    VULGARIZATION_LEVELS.GENERAL_PUBLIC,
+    DURATIONS.MEDIUM,
+    TEACHER_TYPES.METHODICAL
+  );
+  const promptPassion = anthropicService.createPrompt(
+    'Sujet',
+    VULGARIZATION_LEVELS.KNOWLEDGEABLE,
+    DURATIONS.MEDIUM,
+    TEACHER_TYPES.PASSIONATE
+  );
 
   assert.match(promptMethod, /approche méthodique et structurée/);
   assert.match(promptPassion, /passion et enthousiasme/);
   assert.notStrictEqual(promptMethod, promptPassion);
+
+  assert.match(promptMethod, /grand public/);
+  assert.match(promptPassion, /bonnes connaissances de base/);
 });
 
 test('sendWithTimeout retries on overload errors', async () => {


### PR DESCRIPTION
## Summary
- update anthropicService tests for vulgarization and teacher-type instructions
- adjust courseController tests for new teacherType parameter and defaults

## Testing
- `node --test backend/tests/services/anthropicService.test.js backend/tests/controllers/courseController.test.js`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a4dbf313a88325a888755b5fa50c41