### PR TITLE
feat: initialize app after auth check

### DIFF
--- a/frontend/app/index.html
+++ b/frontend/app/index.html
@@ -187,16 +187,20 @@
     <script type="module" src="assets/js/auth.js"></script>
     <script type="module">
       import { ModularConfigManager } from './assets/js/modular-config-manager.js';
+      import { authManager } from './assets/js/auth.js';
+
       document.addEventListener('DOMContentLoaded', () => {
         window.configManager = new ModularConfigManager();
         configManager.init();
 
-        const authManager = new AuthManager();
         if (!authManager.isAuthenticated()) {
           window.location.href = '/auth.html';
           return;
         }
-        initializeApp();
+
+        if (typeof window.initializeApp === 'function') {
+          window.initializeApp();
+        }
       });
     </script>
     <script type="module" src="assets/js/course-manager.js"></script>


### PR DESCRIPTION
## Summary
- replace inline module script to initialize config manager, verify authentication, and conditionally start app

## Testing
- `node /tmp/verify/run.mjs`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4df654e4883259b6de46af7af20af