### PR TITLE
feat: add default course configuration fallback

### DIFF
--- a/frontend/app/assets/js/main.js
+++ b/frontend/app/assets/js/main.js
@@ -62,9 +62,17 @@ function setupEventListeners() {
 async function handleGenerateCourse() {
     const subject = document.getElementById('subject').value.trim();
     const subjectLength = subject.length;
-    const cfg = typeof configManager !== 'undefined' ? configManager.getConfig() : {};
+    const cfg = (typeof configManager !== 'undefined' && configManager) ?
+        configManager.getConfig() : {
+          vulgarization: 'enlightened',
+          duration: 'medium',
+          teacher_type: 'methodical'
+        };
+    const isLegacyPayload = !cfg.vulgarization && !cfg.duration && !cfg.teacher_type;
+    cfg.vulgarization ??= 'enlightened';
+    cfg.duration ??= 'medium';
+    cfg.teacher_type ??= 'methodical';
     const { vulgarization, duration, teacher_type } = cfg;
-    const isLegacyPayload = !vulgarization && !duration && !teacher_type;
 
     if (!subject) {
         utils.handleAuthError('Veuillez entrer un sujet pour le décryptage');


### PR DESCRIPTION
## Summary
- ensure course generation uses default config when configManager is absent
- guarantee cfg always includes vulgarization, duration, and teacher_type

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a4e2c85e4483259be790d71da8ea8c