### PR TITLE
refactor: simplify adaptive instructions

### DIFF
--- a/backend/src/services/anthropicService.js
+++ b/backend/src/services/anthropicService.js
@@ -145,20 +145,7 @@ class AnthropicService {
 PHILOSOPHIE PÉDAGOGIQUE :
 ${adaptiveText}
 
-OUTILS DE MISE EN FORME DISPONIBLES :
-- Utilise librement les blocs HTML suivants :
-<div class='styled-block'>
-  <div class='block-title'>Titre de la section</div>
-  <p>Contenu…</p>
-</div>
-<div class='math-block'>Formule ou équation…</div>
-<div class='code-block'><pre><code>// Code ou pseudo-code</code></pre></div>
-<div class='quote-block'>“Citation exacte…” — Auteur</div>
-<div class='example-block'>Cas concret…</div>
-<div class='conclusion-block'>Conclusion…</div>
-
-LIBERTÉ CRÉATIVE :
-- Organise et combine les blocs comme tu le souhaites pour optimiser la compréhension.
+STRUCTURE :
 - Commence par une introduction et termine par une conclusion.
 - Après la conclusion, ajoute un bloc générique 'Pour aller plus loin' avec 2–3 questions de réflexion et 2–3 pistes de cours ou lectures.
 

--- a/backend/src/utils/constants.js
+++ b/backend/src/utils/constants.js
@@ -113,51 +113,6 @@ const HTTP_STATUS = {
   SERVICE_UNAVAILABLE: 503
 };
 
-// Mots-clés pour détecter le type de contenu
-const CONTENT_DETECTION_KEYWORDS = {
-  MATHEMATICAL: [
-    'math',
-    'mathématique',
-    'équation',
-    'formule',
-    'calcul',
-    'théorème'
-  ],
-  TECHNICAL: [
-    'code',
-    'programmation',
-    'algorithme',
-    'javascript',
-    'python'
-  ],
-  SCIENTIFIC: [
-    'science',
-    'expérience',
-    'biologie',
-    'chimie',
-    'physique'
-  ],
-  LITERARY: [
-    'citation',
-    'littérature',
-    'roman',
-    'poésie',
-    'auteur'
-  ]
-};
-
-// Consignes adaptatives pour chaque type de contenu
-const ADAPTIVE_FORMAT_INSTRUCTIONS = {
-  MATHEMATICAL:
-    'Si des formules sont nécessaires, utilise uniquement des blocs <div class="math-block"> et ajoute un bloc générique pour les interpréter.',
-  TECHNICAL:
-    'Si du code est pertinent, insère-le uniquement dans des blocs <div class="code-block">.',
-  SCIENTIFIC:
-    'Présente les informations scientifiques de manière structurée et cite les sources si nécessaire.',
-  LITERARY:
-    'Si une citation est utile, place-la dans un bloc <div class="quote-block">.',
-  GENERAL: ''
-};
 
 module.exports = {
   DETAIL_LEVELS,
@@ -171,7 +126,5 @@ module.exports = {
   HTTP_STATUS,
   ERROR_CODES,
   AI_ERROR_MESSAGES,
-  DURATIONS,
-  CONTENT_DETECTION_KEYWORDS,
-  ADAPTIVE_FORMAT_INSTRUCTIONS
+  DURATIONS
 };


### PR DESCRIPTION
## Summary
- drop adaptive format-specific instructions and constants
- streamline adaptive prompt building with teacher type, vulgarization and duration only

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a585d585d08325a90b42f5cbdad0ff