### PR TITLE
feat: add onboarding routes

### DIFF
--- a/backend/src/routes/index.js
+++ b/backend/src/routes/index.js
@@ -3,6 +3,7 @@ const express = require('express');
 const authRoutes = require('./auth');
 const coursesRoutes = require('./courses');
 const aiRoutes = require('./ai');
+const onboardingRoutes = require('./onboardingRoutes');
 
 const router = express.Router();
 
@@ -10,6 +11,7 @@ const router = express.Router();
 router.use('/auth', authRoutes);
 router.use('/courses', coursesRoutes);
 router.use('/ai', aiRoutes);
+router.use('/onboarding', onboardingRoutes);
 
 // Route de santé
 router.get('/health', (req, res) => {

--- a/backend/src/routes/onboardingRoutes.js
+++ b/backend/src/routes/onboardingRoutes.js
@@ -1,0 +1,19 @@
+// backend/src/routes/onboardingRoutes.js
+const express = require('express');
+const onboardingController = require('../controllers/onboardingController');
+const { authenticate } = require('../middleware/auth');
+const { asyncHandler } = require('../utils/helpers');
+
+const router = express.Router();
+
+// Toutes les routes nécessitent une authentification
+router.use(authenticate);
+
+// Routes d'onboarding
+router.get('/config', asyncHandler(onboardingController.getConfig));
+router.post('/complete', asyncHandler(onboardingController.complete));
+router.get('/profile', asyncHandler(onboardingController.getProfile));
+router.get('/status', asyncHandler(onboardingController.getStatus));
+router.post('/preference', asyncHandler(onboardingController.addPreference));
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- add onboarding router with config, completion, profile, status and preference endpoints
- register onboarding routes in main router

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5cbf885648325bef9dbf91d054145