### PR TITLE
test: add onboarding service tests

### DIFF
--- a/backend/src/services/onboardingService.js
+++ b/backend/src/services/onboardingService.js
@@ -151,6 +151,11 @@ class OnboardingService {
     return keys.every((k) => profile[k]);
   }
 
+  needsOnboarding(profile) {
+    if (!profile) return true;
+    return !this.isProfileComplete(profile);
+  }
+
   calculateProfileConfidence(profile) {
     const keys = ['pedagogicalProfile', 'learningGoal', 'preferredStyle'];
     const answered = keys.filter((k) => profile[k]).length;

--- a/backend/tests/onboarding/onboarding.test.js
+++ b/backend/tests/onboarding/onboarding.test.js
@@ -1,0 +1,40 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const OnboardingService = require('../../src/services/onboardingService');
+
+test('calculateProfileConfidence computes fraction of answered questions', () => {
+  const service = new OnboardingService();
+  const emptyProfile = {};
+  assert.strictEqual(service.calculateProfileConfidence(emptyProfile), 0);
+
+  const partialProfile = { pedagogicalProfile: 'methodical', learningGoal: 'decouvrir' };
+  assert.strictEqual(service.calculateProfileConfidence(partialProfile), 2 / 3);
+
+  const fullProfile = {
+    pedagogicalProfile: 'methodical',
+    learningGoal: 'decouvrir',
+    preferredStyle: 'analogies'
+  };
+  assert.strictEqual(service.calculateProfileConfidence(fullProfile), 1);
+});
+
+test('needsOnboarding returns true when profile is missing fields', () => {
+  const service = new OnboardingService();
+  const incompleteProfile = { pedagogicalProfile: 'methodical' };
+  assert.strictEqual(service.needsOnboarding(incompleteProfile), true);
+});
+
+test('needsOnboarding returns false when profile is complete', () => {
+  const service = new OnboardingService();
+  const fullProfile = {
+    pedagogicalProfile: 'methodical',
+    learningGoal: 'decouvrir',
+    preferredStyle: 'analogies'
+  };
+  assert.strictEqual(service.needsOnboarding(fullProfile), false);
+});
+
+test('needsOnboarding returns true when profile is null', () => {
+  const service = new OnboardingService();
+  assert.strictEqual(service.needsOnboarding(null), true);
+});


### PR DESCRIPTION
## Summary
- add `needsOnboarding` helper to OnboardingService
- test `calculateProfileConfidence` and `needsOnboarding`

## Testing
- `node --test backend/tests/onboarding/onboarding.test.js`
- `node --test backend/tests/**/*.test.js` *(fails: Invalid value undefined for datasource "db" provided to PrismaClient constructor)*

------
https://chatgpt.com/codex/tasks/task_e_68a5cccfb980832586d822c1eb4a1899