### PR TITLE
feat: add onboarding-aware app init

### DIFF
--- a/frontend/app/assets/js/app-init.js
+++ b/frontend/app/assets/js/app-init.js
@@ -1,0 +1,27 @@
+import { ModularConfigManager } from './modular-config-manager.js';
+import { authManager } from './auth.js';
+
+document.addEventListener('DOMContentLoaded', async () => {
+  if (!window.isLoggedIn || !window.isLoggedIn()) {
+    window.location.href = '/auth.html';
+    return;
+  }
+
+  await window.onboardingManager.redirectToOnboardingIfNeeded();
+  const status = await window.onboardingManager.checkOnboardingStatus();
+  if (!status.onboardingCompleted) {
+    return;
+  }
+
+  window.configManager = new ModularConfigManager();
+  window.configManager.init();
+
+  if (!authManager.isAuthenticated()) {
+    window.location.href = '/auth.html';
+    return;
+  }
+
+  if (typeof window.initializeApp === 'function') {
+    window.initializeApp();
+  }
+});

--- a/frontend/app/index.html
+++ b/frontend/app/index.html
@@ -179,30 +179,13 @@
         </div>
     </div>
 
+    <script src="assets/js/onboarding-manager.js"></script>
     <script src="assets/js/auth-check.js"></script>
-    <script src="assets/js/app-auth-check.js"></script>
+    <script type="module" src="assets/js/app-init.js"></script>
     <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.js"></script>
     <script type="module" src="assets/js/utils/utils.js"></script>
     <script src="assets/js/googleAuth.js"></script>
     <script type="module" src="assets/js/auth.js"></script>
-    <script type="module">
-      import { ModularConfigManager } from './assets/js/modular-config-manager.js';
-      import { authManager } from './assets/js/auth.js';
-
-      document.addEventListener('DOMContentLoaded', () => {
-        window.configManager = new ModularConfigManager();
-        configManager.init();
-
-        if (!authManager.isAuthenticated()) {
-          window.location.href = '/auth.html';
-          return;
-        }
-
-        if (typeof window.initializeApp === 'function') {
-          window.initializeApp();
-        }
-      });
-    </script>
     <script type="module" src="assets/js/course-manager.js"></script>
     <script type="module" src="assets/js/main.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- load onboarding manager before all scripts
- add app init script gating onboarding and login

## Testing
- `npm test` *(fails: npm not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5e15ac0e883258eefc8030d8026e6