### PR TITLE
chore: load onboarding manager as module

### DIFF
--- a/frontend/app/index.html
+++ b/frontend/app/index.html
@@ -179,7 +179,7 @@
         </div>
     </div>
 
-    <script src="assets/js/onboarding-manager.js"></script>
+    <script type="module" src="assets/js/onboarding-manager.js"></script>
     <script src="assets/js/auth-check.js"></script>
     <script type="module" src="assets/js/app-init.js"></script>
     <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.js"></script>


### PR DESCRIPTION
## Summary
- load onboarding manager script as ES module

## Testing
- `npm test` *(fails: backend/tests/routes/config.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68a5e6e41d608325a60b16de28684a10