### PR TITLE
feat: enhance onboarding flow

### DIFF
--- a/frontend/app/onboarding.html
+++ b/frontend/app/onboarding.html
@@ -22,53 +22,85 @@
   <script>
     document.addEventListener('DOMContentLoaded', async () => {
       const form = document.getElementById('onboardingForm');
+
+      // Verify required globals
+      if (!window.API_BASE_URL || !window.authManager || !window.utils) {
+        console.error('Missing required globals', {
+          API_BASE_URL: window.API_BASE_URL,
+          authManager: window.authManager,
+          utils: window.utils
+        });
+        return;
+      }
+
       utils.showLoading();
+      const configUrl = `${API_BASE_URL}/onboarding/config`;
 
       try {
-        const response = await fetch(`${API_BASE_URL}/onboarding/config`, {
+        console.log('Fetching onboarding config:', configUrl);
+        const response = await fetch(configUrl, {
           headers: {
             'Content-Type': 'application/json',
-            ...(authManager?.getAuthHeaders ? authManager.getAuthHeaders() : {})
+            ...authManager.getAuthHeaders()
           }
         });
+        console.log('Config response status:', response.status);
         const data = await response.json();
-        if (data.questions && Array.isArray(data.questions)) {
-          data.questions.forEach(q => {
-            const field = document.createElement('div');
-            const label = document.createElement('label');
-            label.textContent = q.label || q.question || q.id;
-            label.setAttribute('for', `q_${q.id}`);
-            field.appendChild(label);
+        console.log('Config response data:', data);
 
-            let input;
-            if (q.type === 'textarea') {
+        if (!data.success || !Array.isArray(data.data?.questions)) {
+          throw new Error('Configuration onboarding invalide');
+        }
+
+        data.data.questions.forEach(q => {
+          const field = document.createElement('div');
+          const label = document.createElement('label');
+          label.textContent = q.label || q.question || q.id;
+          label.setAttribute('for', `q_${q.id}`);
+          field.appendChild(label);
+
+          let input;
+          switch (q.type) {
+            case 'select':
+              input = document.createElement('select');
+              if (Array.isArray(q.options)) {
+                q.options.forEach(opt => {
+                  const option = document.createElement('option');
+                  if (typeof opt === 'object') {
+                    option.value = opt.value ?? opt.id ?? '';
+                    option.textContent = opt.label ?? opt.value ?? opt.id ?? '';
+                  } else {
+                    option.value = opt;
+                    option.textContent = opt;
+                  }
+                  input.appendChild(option);
+                });
+              }
+              break;
+            case 'textarea':
               input = document.createElement('textarea');
-            } else {
+              break;
+            default:
               input = document.createElement('input');
               input.type = q.type || 'text';
-            }
-            input.id = `q_${q.id}`;
-            input.name = q.id;
-            field.appendChild(input);
+          }
+          input.id = `q_${q.id}`;
+          input.name = q.id;
+          field.appendChild(input);
 
-            form.appendChild(field);
-          });
+          form.appendChild(field);
+        });
 
-          const submit = document.createElement('button');
-          submit.type = 'submit';
-          submit.id = 'submitBtn';
-          submit.textContent = 'Envoyer';
-          form.appendChild(submit);
+        const submit = document.createElement('button');
+        submit.type = 'submit';
+        submit.id = 'submitBtn';
+        submit.textContent = 'Envoyer';
+        form.appendChild(submit);
 
-          form.style.display = 'block';
-        } else {
-          utils.handleAuthError('Configuration onboarding invalide');
-        }
+        form.style.display = 'block';
       } catch (err) {
         console.error('Erreur chargement configuration onboarding', err);
-        if (typeof utils !== 'undefined') {
-          utils.handleAuthError('Erreur chargement questions');
-        }
+        utils.handleAuthError('Erreur chargement questions');
       } finally {
         utils.hideLoading();
       }
@@ -79,16 +111,21 @@
         const formData = new FormData(form);
         const answers = Object.fromEntries(formData.entries());
 
+        const submitUrl = `${API_BASE_URL}/onboarding/complete`;
         try {
-          const resp = await fetch(`${API_BASE_URL}/onboarding/complete`, {
+          console.log('Submitting onboarding answers to:', submitUrl);
+          const resp = await fetch(submitUrl, {
             method: 'POST',
             headers: {
               'Content-Type': 'application/json',
-              ...(authManager?.getAuthHeaders ? authManager.getAuthHeaders() : {})
+              ...authManager.getAuthHeaders()
             },
             body: JSON.stringify({ answers })
           });
+          console.log('Submit response status:', resp.status);
           const result = await resp.json();
+          console.log('Submit response data:', result);
+
           if (result.success) {
             if (window.onboardingManager) {
               await window.onboardingManager.checkOnboardingStatus(true);


### PR DESCRIPTION
## Summary
- validate required global objects before running onboarding logic
- dynamically render onboarding questions with text, select, or textarea inputs
- add detailed console logging and submit handling for onboarding flow

## Testing
- `npm test` *(fails: 1 failing test, 34 passing)*

------
https://chatgpt.com/codex/tasks/task_e_68a60978f47c83258de966c6f3db2a4b