### PR TITLE
chore: log onboarding config and globals

### DIFF
--- a/backend/src/controllers/onboardingController.js
+++ b/backend/src/controllers/onboardingController.js
@@ -11,6 +11,7 @@ class OnboardingController {
   getConfig(req, res) {
     try {
       const config = this.onboardingService.getQuestionConfig();
+      logger.info('Raw onboarding config', config);
       const questions = config.map((q) => ({
         id: q.key,
         question: q.question,
@@ -18,6 +19,7 @@ class OnboardingController {
         options: q.options || [],
         label: q.question
       }));
+      logger.info('Transformed onboarding questions', questions);
       const { response } = createResponse(true, { questions });
       res.json(response);
     } catch (error) {

--- a/frontend/app/onboarding.html
+++ b/frontend/app/onboarding.html
@@ -89,6 +89,12 @@
     document.addEventListener('DOMContentLoaded', async () => {
       const form = document.getElementById('onboardingForm');
 
+      console.log('Onboarding globals', {
+        API_BASE_URL: window.API_BASE_URL,
+        authManager: window.authManager,
+        utils: window.utils
+      });
+
       // Verify required globals
       if (!window.API_BASE_URL || !window.authManager || !window.utils) {
         console.error('Missing required globals', {


### PR DESCRIPTION
## Summary
- log raw onboarding config and transformed questions in controller
- log key onboarding globals on page load

## Testing
- `npm test` *(fails: PrismaClientConstructorValidationError for datasource "db")*

------
https://chatgpt.com/codex/tasks/task_e_68a60d54d1088325ac3332f59cedbd48