### PR TITLE
Fix onboarding config parsing

### DIFF
--- a/frontend/app/onboarding.html
+++ b/frontend/app/onboarding.html
@@ -120,11 +120,11 @@
         const data = await response.json();
         console.log('Config response data:', data);
 
-        if (!data.success || !Array.isArray(data.data?.questions)) {
+        if (!data.success || !Array.isArray(data.questions)) {
           throw new Error('Configuration onboarding invalide');
         }
 
-        data.data.questions.forEach(q => {
+        data.questions.forEach(q => {
           const field = document.createElement('div');
           field.className = 'question-field';
           const label = document.createElement('label');


### PR DESCRIPTION
## Summary
- Fix onboarding config parsing to use top-level `questions` field

## Testing
- `npm test` *(fails: Invalid value undefined for datasource "db" provided to PrismaClient constructor)*
- Node manual fetch of onboarding config

------
https://chatgpt.com/codex/tasks/task_e_68a625863b508325a1f33688cbb48dfe