### PR TITLE
fix: bind onboarding controller methods to preserve context

### DIFF
--- a/backend/src/routes/onboardingRoutes.js
+++ b/backend/src/routes/onboardingRoutes.js
@@ -10,10 +10,10 @@ const router = express.Router();
 router.use(authenticate);
 
 // Routes d'onboarding
-router.get('/config', asyncHandler(onboardingController.getConfig));
-router.post('/complete', asyncHandler(onboardingController.complete));
-router.get('/profile', asyncHandler(onboardingController.getProfile));
-router.get('/status', asyncHandler(onboardingController.getStatus));
-router.post('/preference', asyncHandler(onboardingController.addPreference));
+router.get('/config', asyncHandler(onboardingController.getConfig.bind(onboardingController)));
+router.post('/complete', asyncHandler(onboardingController.complete.bind(onboardingController)));
+router.get('/profile', asyncHandler(onboardingController.getProfile.bind(onboardingController)));
+router.get('/status', asyncHandler(onboardingController.getStatus.bind(onboardingController)));
+router.post('/preference', asyncHandler(onboardingController.addPreference.bind(onboardingController)));
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- bind onboarding controller methods in onboarding routes to preserve `this` context

## Testing
- `npm test` *(fail: 1 tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a62b2fcf18832584e55ee680ae9adb