### PR TITLE
Expand onboarding profile fields

### DIFF
--- a/backend/tests/onboarding/onboarding.test.js
+++ b/backend/tests/onboarding/onboarding.test.js
@@ -38,3 +38,31 @@ test('needsOnboarding returns true when profile is null', () => {
   const service = new OnboardingService();
   assert.strictEqual(service.needsOnboarding(null), true);
 });
+
+test('saveAnswers rejects when mandatory fields are missing', async () => {
+  const prismaMock = {
+    user: {
+      findUnique: async () => ({
+        vulgarization: null,
+        teacherType: null,
+        duration: null,
+        interests: null,
+        learningContext: null,
+        usageFrequency: null,
+      }),
+      update: async () => {
+        throw new Error('should not update');
+      },
+    },
+    userData: {
+      upsert: async () => {
+        throw new Error('should not upsert');
+      },
+    },
+  };
+  const service = new OnboardingService(prismaMock);
+  await assert.rejects(
+    service.saveAnswers('u1', { teacherType: 'methodical' }),
+    /Champs obligatoires manquants/
+  );
+});


### PR DESCRIPTION
## Summary
- extend onboarding profile to cover vulgarization, teacher type, duration, interests, learning context, and usage frequency
- compute profile completion and confidence from only mandatory fields
- validate mandatory onboarding fields before saving answers

## Testing
- `DATABASE_URL="postgresql://user:pass@localhost:5432/db" GOOGLE_CLIENT_ID="dummy" node --test backend/tests/onboarding/onboarding.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68a6ce0026e08325ac8010391c71d50c