### PR TITLE
Add migration to flag incomplete onboarding profiles

### DIFF
--- a/backend/docs/onboarding-migration.md
+++ b/backend/docs/onboarding-migration.md
@@ -1,0 +1,7 @@
+# Onboarding Migration
+
+To harmonize onboarding fields, existing columns (`pedagogicalProfile`, `learningGoal`, `preferredStyle`) were removed in favor of new ones (`vulgarization`, `teacherType`, `duration`, `interests`, `learningContext`, `usageFrequency`).
+
+Because the old data could not be safely mapped to the new structure, we preserve user accounts and course data while requiring users to go through onboarding again. The migration script [`20240601000000_flag_users_for_reonboarding`](../prisma/migrations/20240601000000_flag_users_for_reonboarding/migration.sql) marks any user who lacks a value for one of the new fields as needing onboarding by setting `onboardingCompleted` to `false`.
+
+This approach keeps existing production data intact and avoids silent loss of information. Users will be prompted to re-onboard and provide the new profile information.

--- a/backend/prisma/migrations/20240601000000_flag_users_for_reonboarding/migration.sql
+++ b/backend/prisma/migrations/20240601000000_flag_users_for_reonboarding/migration.sql
@@ -1,0 +1,12 @@
+-- Flag users for re-onboarding if any of the new onboarding fields are missing.
+-- This preserves existing accounts while ensuring they complete the updated flow.
+UPDATE "users"
+SET "onboardingCompleted" = false
+WHERE "onboardingCompleted" = true AND (
+  "vulgarization" IS NULL OR
+  "teacherType" IS NULL OR
+  "duration" IS NULL OR
+  "interests" IS NULL OR
+  "learningContext" IS NULL OR
+  "usageFrequency" IS NULL
+);


### PR DESCRIPTION
## Summary
- flag users for re-onboarding if any new onboarding field is missing
- document onboarding migration strategy

## Testing
- `npm test` *(fails: Error: GOOGLE_CLIENT_ID manquant dans les variables d'environnement)*

------
https://chatgpt.com/codex/tasks/task_e_68a6db7f88348325adc6c01c048deb8f