### PR TITLE
feat: harden Google login flow

### DIFF
--- a/frontend/app/assets/js/auth.js
+++ b/frontend/app/assets/js/auth.js
@@ -34,21 +34,25 @@ class AuthManager {
 
     // ⭐ NOUVELLE MÉTHODE : Authentification Google
     async handleGoogleLogin(googleResponse) {
-        try {
-            console.log('Traitement connexion Google...', googleResponse);
-            
-            if (!googleResponse.credential) {
-                throw new Error('Token Google manquant');
-            }
+        if (!googleResponse?.credential) {
+            utils.showNotification('Token Google manquant', 'error');
+            return { success: false, error: 'Token Google manquant' };
+        }
 
-            // Envoyer le token à notre API
-            const response = await fetch(`${API_BASE_URL}/auth/google`, {
+        try {
+            const response = await fetch(`${API_BASE_URL}/api/auth/google`, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ 
-                    credential: googleResponse.credential 
-                })
+                body: JSON.stringify({ credential: googleResponse.credential })
             });
+
+            if (!response.ok) {
+                const errorData = await response.json().catch(() => ({}));
+                const message = errorData.error || 'Erreur de connexion';
+                utils.showNotification(message, 'error');
+                utils.handleAuthError(message, true);
+                return { success: false, error: message };
+            }
 
             const data = await response.json();
             console.log('Réponse auth Google:', data);
@@ -60,8 +64,8 @@ class AuthManager {
                 localStorage.setItem('user', JSON.stringify(this.user));
                 this.updateUI();
 
-                showNotification('Connexion Google réussie !', 'success');
-                
+                utils.showNotification('Connexion Google réussie !', 'success');
+
                 // Charger les cours de l'utilisateur
                 if (typeof courseManager !== 'undefined' && courseManager.loadUserCourses) {
                     courseManager.loadUserCourses();
@@ -74,12 +78,17 @@ class AuthManager {
             } else if (data.code === 'QUOTA_EXCEEDED') {
                 this.showAction(data.error || 'Quota dépassé', 'Sauvegarder', () => this.savePendingAuth({ credential: googleResponse.credential }));
             } else {
-                throw new Error(data.error || 'Erreur connexion Google');
+                const msg = data.error || 'Erreur connexion Google';
+                utils.showNotification(msg, 'error');
+                utils.handleAuthError(msg, true);
+                return { success: false, error: msg };
             }
         } catch (error) {
             console.error('Erreur connexion Google:', error);
-                utils.handleAuthError('Erreur connexion Google: ' + error.message, true);
-            return { success: false, error: error.message };
+            const friendly = error.message.includes('Failed to fetch') ? 'Impossible de contacter le serveur' : error.message;
+            utils.showNotification(friendly, 'error');
+            utils.handleAuthError('Erreur connexion Google: ' + friendly, true);
+            return { success: false, error: friendly };
         }
     }
 


### PR DESCRIPTION
## Summary
- use `/api/auth/google` for Google login calls
- add credential checks, server response validation, and user-friendly error handling for Google OAuth

## Testing
- `npm test` *(fails: backend/tests/routes/config.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68a7216e874883258f55aa8ca633c110