### PR TITLE
refactor: simplify auth error handling

### DIFF
--- a/frontend/app/assets/js/utils/utils.js
+++ b/frontend/app/assets/js/utils/utils.js
@@ -67,7 +67,7 @@ const utils = {
   },
 
   // Gestion unifiée des erreurs d'authentification
-  handleAuthError(error, critical = false) {
+  handleAuthError(error) {
     let message = 'Une erreur est survenue';
     if (typeof error === 'string') {
       message = error;
@@ -82,17 +82,17 @@ const utils = {
     }
 
     console.error(error);
-    this.showNotification(message, 'error');
 
-    if (critical) {
-      try {
-        fetch(`${API_BASE_URL}/logs`, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ level: 'error', message })
-        }).catch(err => console.error('Erreur lors de l\'envoi du log serveur', err));
-      } catch (err) {
-        console.error('Erreur lors de la préparation du log serveur', err);
+    try {
+      if (typeof this.showNotification === 'function') {
+        this.showNotification(message, 'error');
+      } else if (typeof alert === 'function') {
+        alert(message);
+      }
+    } catch (notifyErr) {
+      console.error('Notification failure', notifyErr);
+      if (typeof alert === 'function') {
+        alert(message);
       }
     }
   }

--- a/frontend/marketing/assets/js/utils.js
+++ b/frontend/marketing/assets/js/utils.js
@@ -67,7 +67,7 @@ const utils = {
   },
 
   // Gestion unifiée des erreurs d'authentification
-  handleAuthError(error, critical = false) {
+  handleAuthError(error) {
     let message = 'Une erreur est survenue';
     if (typeof error === 'string') {
       message = error;
@@ -82,17 +82,17 @@ const utils = {
     }
 
     console.error(error);
-    this.showNotification(message, 'error');
 
-    if (critical) {
-      try {
-        fetch(`${API_BASE_URL}/logs`, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ level: 'error', message })
-        }).catch(err => console.error('Erreur lors de l\'envoi du log serveur', err));
-      } catch (err) {
-        console.error('Erreur lors de la préparation du log serveur', err);
+    try {
+      if (typeof this.showNotification === 'function') {
+        this.showNotification(message, 'error');
+      } else if (typeof alert === 'function') {
+        alert(message);
+      }
+    } catch (notifyErr) {
+      console.error('Notification failure', notifyErr);
+      if (typeof alert === 'function') {
+        alert(message);
       }
     }
   }


### PR DESCRIPTION
## Summary
- remove server log requests from `handleAuthError`
- show auth errors via notifications with alert fallback
- log auth errors using `console.error`

## Testing
- `npm test` *(fails: PrismaClientConstructorValidationError: Invalid value undefined for datasource "db" provided to PrismaClient constructor.)*


------
https://chatgpt.com/codex/tasks/task_e_68a7228e95088325b8556540592f3d82