### PR TITLE
Guard Google button observers

### DIFF
--- a/frontend/app/assets/js/googleAuth.js
+++ b/frontend/app/assets/js/googleAuth.js
@@ -201,8 +201,16 @@ const GoogleAuth = (() => {
                 requestAnimationFrame(() => enforceButtonDimensions(container, width));
             };
             schedule();
-            new ResizeObserver(schedule).observe(container);
-            new MutationObserver(schedule).observe(container, { childList: true, subtree: true });
+            try {
+                if (typeof ResizeObserver === 'function') {
+                    new ResizeObserver(schedule).observe(container);
+                }
+                if (typeof MutationObserver === 'function') {
+                    new MutationObserver(schedule).observe(container, { childList: true, subtree: true });
+                }
+            } catch (err) {
+                console.error('GoogleAuth observeButtons error:', err);
+            }
         });
     }
 

--- a/frontend/marketing/assets/js/googleAuth.js
+++ b/frontend/marketing/assets/js/googleAuth.js
@@ -201,8 +201,16 @@ const GoogleAuth = (() => {
                 requestAnimationFrame(() => enforceButtonDimensions(container, width));
             };
             schedule();
-            new ResizeObserver(schedule).observe(container);
-            new MutationObserver(schedule).observe(container, { childList: true, subtree: true });
+            try {
+                if (typeof ResizeObserver === 'function') {
+                    new ResizeObserver(schedule).observe(container);
+                }
+                if (typeof MutationObserver === 'function') {
+                    new MutationObserver(schedule).observe(container, { childList: true, subtree: true });
+                }
+            } catch (err) {
+                console.error('GoogleAuth observeButtons error:', err);
+            }
         });
     }
 


### PR DESCRIPTION
## Summary
- wrap Google sign-in button observers with safety checks

## Testing
- `npm test` *(fails: PrismaClientConstructorValidationError)*

------
https://chatgpt.com/codex/tasks/task_e_68a7239a80d48325818203b6e6c437f8