### PR TITLE
fix: correct Google auth URL

### DIFF
--- a/frontend/app/assets/js/auth.js
+++ b/frontend/app/assets/js/auth.js
@@ -40,7 +40,7 @@ class AuthManager {
         }
 
         try {
-            const response = await fetch(`${API_BASE_URL}/api/auth/google`, {
+            const response = await fetch(`${API_BASE_URL}/auth/google`, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ credential: googleResponse.credential })

--- a/frontend/marketing/assets/js/auth.js
+++ b/frontend/marketing/assets/js/auth.js
@@ -40,7 +40,7 @@ class AuthManager {
         }
 
         try {
-            const response = await fetch(`${API_BASE_URL}/api/auth/google`, {
+            const response = await fetch(`${API_BASE_URL}/auth/google`, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ credential: googleResponse.credential })


### PR DESCRIPTION
## Summary
- fix Google login fetch URLs in app and marketing auth modules

## Testing
- `npm test` *(fails: PrismaClientConstructorValidationError: Invalid value undefined for datasource "db" provided to PrismaClient constructor)*

------
https://chatgpt.com/codex/tasks/task_e_68a731de724c83258592b2fc4f621d6c