### PR TITLE
Handle GoogleAuth re-init when switching auth tabs

### DIFF
--- a/frontend/app/assets/js/auth.js
+++ b/frontend/app/assets/js/auth.js
@@ -268,10 +268,12 @@ function setupAuthListeners() {
 
             // Relancer GoogleAuth lors du changement de vue si déjà prêt
             if (window.GoogleAuth) {
-                if (GoogleAuth.state === GoogleAuth.STATES.FAILED) {
+                if (GoogleAuth.state === GoogleAuth.STATES.FAILED &&
+                    typeof GoogleAuth.reset === 'function') {
                     GoogleAuth.reset();
                 }
-                if (GoogleAuth.state === GoogleAuth.STATES.READY) {
+                if (GoogleAuth.state === GoogleAuth.STATES.READY &&
+                    typeof GoogleAuth.promptLogin === 'function') {
                     GoogleAuth.promptLogin();
                 }
             }

--- a/frontend/app/assets/js/googleAuth.js
+++ b/frontend/app/assets/js/googleAuth.js
@@ -214,6 +214,30 @@ const GoogleAuth = (() => {
         });
     }
 
+    function reset() {
+        isReady = false;
+        state = STATES.INIT;
+        initPromise = null;
+        widthCache.clear();
+        document.querySelectorAll('.google-auth-fallback').forEach(el => el.remove());
+        document.querySelectorAll('.google-auth-container').forEach(c => {
+            c.classList.remove('loading');
+            c.style.opacity = '';
+            const msg = c.querySelector('.google-auth-message');
+            if (msg) msg.remove();
+            const btn = c.querySelector('div[id]');
+            if (btn) btn.innerHTML = '';
+        });
+    }
+
+    function promptLogin() {
+        try {
+            google?.accounts?.id?.prompt();
+        } catch (err) {
+            console.error('GoogleAuth promptLogin error:', err);
+        }
+    }
+
     function init(callback = () => {}, timeout = 10000) {
         if (isReady) return Promise.resolve();
         if (initPromise) return initPromise;
@@ -279,6 +303,8 @@ const GoogleAuth = (() => {
 
     return {
         init,
+        reset,
+        promptLogin,
         showEmailFallback,
         get state() { return state; },
         STATES


### PR DESCRIPTION
## Summary
- Implement `reset` and `promptLogin` in GoogleAuth to allow reinitialization and show Google prompt
- Safely call optional GoogleAuth helpers in auth tab handlers

## Testing
- `npm test` *(fails: Prisma datasource undefined; check-env asserts)*
- `node --test frontend/tests/*.js`
- `node -e "/* simulated tab switch */"`

------
https://chatgpt.com/codex/tasks/task_e_68a7353be6348325b1842790fde05c52