### PR TITLE
Improve auth error handling and environment checks

### DIFF
--- a/backend/.env
+++ b/backend/.env
@@ -1,4 +1,0 @@
-GOOGLE_CLIENT_ID=1053222527627-909m2i2bvrq752sk3p91a2m5jo6aj9n0.apps.googleusercontent.com
-JWT_SECRET=your_jwt_secret_here
-DATABASE_URL=your_database_url_here
-NODE_ENV=production

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,18 @@
+# Example environment configuration for Noza backend
+NODE_ENV=development
+PORT=3000
+HTTPS_PORT=3443
+
+DATABASE_URL="postgresql://USER:PASSWORD@HOST:5432/DATABASE"
+JWT_SECRET="replace_with_32_char_secret"
+JWT_EXPIRES_IN="7d"
+
+# Set to 'true' to allow HTTP in production (not recommended)
+# ALLOW_HTTP=true
+
+# Paths to TLS certificate and key (required in production without ALLOW_HTTP)
+# TLS_CERT_PATH=/path/to/cert.pem
+# TLS_KEY_PATH=/path/to/key.pem
+
+# Optional API keys
+# ANTHROPIC_API_KEY=

--- a/backend/scripts/check-env.js
+++ b/backend/scripts/check-env.js
@@ -49,6 +49,32 @@ function checkEnv() {
     process.exit(1);
   }
 
+  const malformed = [];
+  if (process.env.DATABASE_URL) {
+    try {
+      new URL(process.env.DATABASE_URL);
+    } catch {
+      malformed.push('DATABASE_URL');
+    }
+  }
+
+  if (process.env.JWT_SECRET && process.env.JWT_SECRET.length < 32) {
+    malformed.push('JWT_SECRET (32 chars min)');
+  }
+
+  if (required.includes('TLS_CERT_PATH') && !fs.existsSync(process.env.TLS_CERT_PATH)) {
+    malformed.push('TLS_CERT_PATH (fichier introuvable)');
+  }
+
+  if (required.includes('TLS_KEY_PATH') && !fs.existsSync(process.env.TLS_KEY_PATH)) {
+    malformed.push('TLS_KEY_PATH (fichier introuvable)');
+  }
+
+  if (malformed.length) {
+    logger.error(`Variables d'environnement invalides: ${malformed.join(', ')}`);
+    process.exit(1);
+  }
+
   if (!process.env.ANTHROPIC_API_KEY) {
     logger.warn('ANTHROPIC_API_KEY non défini. Fonctionnalités IA désactivées.');
   }

--- a/backend/tests/routes/config.test.js
+++ b/backend/tests/routes/config.test.js
@@ -1,6 +1,9 @@
 const test = require('node:test');
 const assert = require('node:assert');
 const request = require('supertest');
+process.env.JWT_SECRET = 'a'.repeat(32);
+process.env.DATABASE_URL = 'postgresql://user:pass@localhost:5432/test';
+process.env.GOOGLE_CLIENT_ID = 'dummy';
 const { app } = require('../../src/app');
 
 test('GET /api/config/google returns client ID when configured', async () => {

--- a/backend/tests/scripts/check-env.test.js
+++ b/backend/tests/scripts/check-env.test.js
@@ -10,7 +10,7 @@ test('allows startup without TLS when ALLOW_HTTP is set', () => {
       ...process.env,
       NODE_ENV: 'production',
       DATABASE_URL: 'postgres://user:pass@localhost:5432/db',
-      JWT_SECRET: 'secret',
+      JWT_SECRET: 'a'.repeat(32),
       ALLOW_HTTP: 'true',
       NODE_PATH: path.join(__dirname, '../../node_modules')
     },


### PR DESCRIPTION
## Summary
- add centralized auth error handler for Prisma and JWT issues
- validate required env vars and detect malformed values
- document backend environment variables in `.env.example`

## Testing
- `node --test backend/tests/**/*.js` *(fails: process did not exit cleanly but tests reported ok)*
- `DATABASE_URL="postgresql://user:pass@localhost:5432/db" JWT_SECRET="12345678901234567890123456789012" node backend/scripts/check-env.js`


------
https://chatgpt.com/codex/tasks/task_e_68a73701adfc8325a30050d23f08fd4e