### PR TITLE
feat: add profile controller and routes

### DIFF
--- a/backend/src/controllers/profileController.js
+++ b/backend/src/controllers/profileController.js
@@ -1,0 +1,98 @@
+// backend/src/controllers/profileController.js
+const { createResponse, logger } = require('../utils/helpers');
+const { HTTP_STATUS, ERROR_MESSAGES } = require('../utils/constants');
+const ProfileService = require('../services/profileService');
+
+class ProfileController {
+  constructor() {
+    this.profileService = new ProfileService();
+  }
+
+  async getProfile(req, res) {
+    try {
+      const data = await this.profileService.getProfile(req.user.id);
+      const { response } = createResponse(true, data);
+      res.json(response);
+    } catch (error) {
+      logger.error('Erreur récupération profil', error);
+      const { response, statusCode } = createResponse(false, null, ERROR_MESSAGES.SERVER_ERROR, HTTP_STATUS.SERVER_ERROR);
+      res.status(statusCode).json(response);
+    }
+  }
+
+  async updatePreferences(req, res) {
+    try {
+      const profile = await this.profileService.updatePreferences(req.user.id, req.body || {});
+      const { response } = createResponse(true, { profile });
+      res.json(response);
+    } catch (error) {
+      logger.error('Erreur mise à jour préférences', error);
+      const { response, statusCode } = createResponse(false, null, ERROR_MESSAGES.SERVER_ERROR, HTTP_STATUS.SERVER_ERROR);
+      res.status(statusCode).json(response);
+    }
+  }
+
+  async updateInfo(req, res) {
+    try {
+      const user = await this.profileService.updateInfo(req.user.id, req.body || {});
+      const { response } = createResponse(true, { user });
+      res.json(response);
+    } catch (error) {
+      logger.error('Erreur mise à jour informations utilisateur', error);
+      const { response, statusCode } = createResponse(false, null, ERROR_MESSAGES.SERVER_ERROR, HTTP_STATUS.SERVER_ERROR);
+      res.status(statusCode).json(response);
+    }
+  }
+
+  async uploadAvatar(req, res) {
+    try {
+      const user = await this.profileService.uploadAvatar(req.user.id, req.file);
+      const { response } = createResponse(true, { user });
+      res.json(response);
+    } catch (error) {
+      logger.error('Erreur upload avatar', error);
+      const { response, statusCode } = createResponse(false, null, ERROR_MESSAGES.SERVER_ERROR, HTTP_STATUS.SERVER_ERROR);
+      res.status(statusCode).json(response);
+    }
+  }
+
+  async getStats(req, res) {
+    try {
+      const stats = await this.profileService.getUsageStats(req.user.id);
+      const { response } = createResponse(true, { stats });
+      res.json(response);
+    } catch (error) {
+      logger.error('Erreur récupération statistiques', error);
+      const { response, statusCode } = createResponse(false, null, ERROR_MESSAGES.SERVER_ERROR, HTTP_STATUS.SERVER_ERROR);
+      res.status(statusCode).json(response);
+    }
+  }
+
+  async getActivity(req, res) {
+    try {
+      const limit = parseInt(req.query.limit, 10) || 10;
+      const activity = await this.profileService.getActivity(req.user.id, limit);
+      const { response } = createResponse(true, { activity });
+      res.json(response);
+    } catch (error) {
+      logger.error('Erreur récupération activité', error);
+      const { response, statusCode } = createResponse(false, null, ERROR_MESSAGES.SERVER_ERROR, HTTP_STATUS.SERVER_ERROR);
+      res.status(statusCode).json(response);
+    }
+  }
+
+  async deleteData(req, res) {
+    try {
+      await this.profileService.deleteData(req.user.id);
+      const { response } = createResponse(true, { message: 'Données supprimées' });
+      res.json(response);
+    } catch (error) {
+      logger.error('Erreur suppression données utilisateur', error);
+      const { response, statusCode } = createResponse(false, null, ERROR_MESSAGES.SERVER_ERROR, HTTP_STATUS.SERVER_ERROR);
+      res.status(statusCode).json(response);
+    }
+  }
+}
+
+module.exports = new ProfileController();
+

--- a/backend/src/routes/index.js
+++ b/backend/src/routes/index.js
@@ -4,6 +4,8 @@ const authRoutes = require('./auth');
 const coursesRoutes = require('./courses');
 const aiRoutes = require('./ai');
 const onboardingRoutes = require('./onboardingRoutes');
+const profileRoutes = require('./profileRoutes');
+const { authenticate } = require('../middleware/auth');
 
 const router = express.Router();
 
@@ -12,6 +14,7 @@ router.use('/auth', authRoutes);
 router.use('/courses', coursesRoutes);
 router.use('/ai', aiRoutes);
 router.use('/onboarding', onboardingRoutes);
+router.use('/profile', authenticate, profileRoutes);
 
 // Route de santé
 router.get('/health', (req, res) => {

--- a/backend/src/routes/profileRoutes.js
+++ b/backend/src/routes/profileRoutes.js
@@ -1,0 +1,17 @@
+// backend/src/routes/profileRoutes.js
+const express = require('express');
+const profileController = require('../controllers/profileController');
+const { asyncHandler } = require('../utils/helpers');
+
+const router = express.Router();
+
+router.get('/', asyncHandler(profileController.getProfile.bind(profileController)));
+router.put('/preferences', asyncHandler(profileController.updatePreferences.bind(profileController)));
+router.put('/info', asyncHandler(profileController.updateInfo.bind(profileController)));
+router.post('/avatar', asyncHandler(profileController.uploadAvatar.bind(profileController)));
+router.get('/stats', asyncHandler(profileController.getStats.bind(profileController)));
+router.get('/activity', asyncHandler(profileController.getActivity.bind(profileController)));
+router.delete('/data', asyncHandler(profileController.deleteData.bind(profileController)));
+
+module.exports = router;
+


### PR DESCRIPTION
## Summary
- add profile controller using ProfileService
- expose profile routes for profile operations
- register profile router with authentication middleware

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a7600bdaec83258f699760a9c1b006