### PR TITLE
feat: add React profile page with Tailwind support

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="fr" class="h-full">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Noza App</title>
+  </head>
+  <body class="h-full bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100">
+    <div id="root" class="h-full"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "noza-frontend",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "test": "echo \"No tests configured\""
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.22.1",
+    "recharts": "^2.7.2"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.0",
+    "autoprefixer": "^10.4.16",
+    "postcss": "^8.4.32",
+    "tailwindcss": "^3.4.1",
+    "vite": "^5.0.0"
+  }
+}

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,0 +1,34 @@
+import React, { useState, useEffect } from 'react';
+import { Routes, Route, Link } from 'react-router-dom';
+import Profile from './pages/Profile';
+
+const Home = () => <div className="p-4">Accueil</div>;
+
+export default function App() {
+  const [darkMode, setDarkMode] = useState(false);
+
+  useEffect(() => {
+    document.documentElement.classList.toggle('dark', darkMode);
+  }, [darkMode]);
+
+  return (
+    <div className="min-h-full bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100">
+      <nav className="flex items-center justify-between p-4 border-b border-gray-200 dark:border-gray-700">
+        <div className="flex space-x-4">
+          <Link to="/" className="hover:underline">Home</Link>
+          <Link to="/profile" className="hover:underline">Profil</Link>
+        </div>
+        <button
+          onClick={() => setDarkMode(!darkMode)}
+          className="p-2 rounded bg-gray-200 dark:bg-gray-700"
+        >
+          {darkMode ? 'Light' : 'Dark'}
+        </button>
+      </nav>
+      <Routes>
+        <Route path="/" element={<Home />} />
+        <Route path="/profile" element={<Profile />} />
+      </Routes>
+    </div>
+  );
+}

--- a/frontend/src/components/profile/ActivityStats.jsx
+++ b/frontend/src/components/profile/ActivityStats.jsx
@@ -1,0 +1,26 @@
+import React, { useEffect, useState } from 'react';
+import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer } from 'recharts';
+
+export default function ActivityStats() {
+  const [data, setData] = useState([]);
+
+  useEffect(() => {
+    fetch('/api/profile/stats')
+      .then((r) => r.json())
+      .then(setData)
+      .catch(() => {});
+  }, []);
+
+  return (
+    <div className='w-full h-64'>
+      <ResponsiveContainer width='100%' height='100%'>
+        <LineChart data={data}>
+          <XAxis dataKey='date' stroke='#8884d8' />
+          <YAxis />
+          <Tooltip />
+          <Line type='monotone' dataKey='value' stroke='#8884d8' strokeWidth={2} />
+        </LineChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/frontend/src/components/profile/AvatarUpload.jsx
+++ b/frontend/src/components/profile/AvatarUpload.jsx
@@ -1,0 +1,43 @@
+import React, { useRef, useState } from 'react';
+
+export default function AvatarUpload({ avatarUrl }) {
+  const inputRef = useRef();
+  const [preview, setPreview] = useState(avatarUrl);
+
+  const handleFileChange = async (e) => {
+    const file = e.target.files[0];
+    if (!file) return;
+
+    const formData = new FormData();
+    formData.append('avatar', file);
+    setPreview(URL.createObjectURL(file));
+
+    await fetch('/api/profile/avatar', {
+      method: 'POST',
+      body: formData,
+    });
+  };
+
+  return (
+    <div className='relative'>
+      <img
+        src={preview || 'https://placehold.co/80'}
+        alt='avatar'
+        className='w-20 h-20 rounded-full object-cover'
+      />
+      <button
+        className='absolute bottom-0 right-0 bg-blue-500 text-white text-xs px-2 py-1 rounded'
+        onClick={() => inputRef.current.click()}
+      >
+        Changer
+      </button>
+      <input
+        type='file'
+        ref={inputRef}
+        className='hidden'
+        onChange={handleFileChange}
+        accept='image/*'
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/profile/PreferencesForm.jsx
+++ b/frontend/src/components/profile/PreferencesForm.jsx
@@ -1,0 +1,54 @@
+import React, { useState } from 'react';
+
+export default function PreferencesForm({ profile, onUpdate }) {
+  const [form, setForm] = useState(profile?.preferences || {});
+
+  const handleChange = (e) => {
+    const { name, value, type, checked } = e.target;
+    setForm((f) => ({ ...f, [name]: type === 'checkbox' ? checked : value }));
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    const res = await fetch('/api/profile/preferences', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(form),
+    });
+    if (res.ok) {
+      const updated = await res.json();
+      onUpdate && onUpdate((p) => ({ ...p, preferences: updated }));
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className='space-y-4'>
+      <div>
+        <label className='block text-sm font-medium'>Langue</label>
+        <input
+          name='language'
+          value={form.language || ''}
+          onChange={handleChange}
+          className='mt-1 w-full p-2 border border-gray-300 dark:border-gray-600 rounded'
+        />
+      </div>
+      <div className='flex items-center'>
+        <input
+          id='newsletter'
+          type='checkbox'
+          name='newsletter'
+          checked={form.newsletter || false}
+          onChange={handleChange}
+          className='mr-2'
+        />
+        <label htmlFor='newsletter'>Recevoir la newsletter</label>
+      </div>
+      <button
+        type='submit'
+        className='px-4 py-2 bg-blue-600 text-white rounded'
+      >
+        Sauvegarder
+      </button>
+    </form>
+  );
+}

--- a/frontend/src/components/profile/ProfileHeader.jsx
+++ b/frontend/src/components/profile/ProfileHeader.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import AvatarUpload from './AvatarUpload';
+
+export default function ProfileHeader({ profile }) {
+  if (!profile) {
+    return <div>Chargement...</div>;
+  }
+
+  return (
+    <div className='flex items-center space-x-4'>
+      <AvatarUpload avatarUrl={profile.avatarUrl} />
+      <div>
+        <h1 className='text-2xl font-bold'>{profile.name}</h1>
+        <p className='text-gray-600 dark:text-gray-400'>{profile.email}</p>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/profile/ProfileSettings.jsx
+++ b/frontend/src/components/profile/ProfileSettings.jsx
@@ -1,0 +1,33 @@
+import React from 'react';
+
+export default function ProfileSettings({ profile }) {
+  const handleDelete = async () => {
+    await fetch('/api/profile', { method: 'DELETE' });
+    // Additional handling like redirecting could be here
+  };
+
+  const handleSave = async () => {
+    await fetch('/api/profile', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(profile),
+    });
+  };
+
+  return (
+    <div className='space-y-4'>
+      <button
+        onClick={handleSave}
+        className='px-4 py-2 bg-green-600 text-white rounded'
+      >
+        Enregistrer
+      </button>
+      <button
+        onClick={handleDelete}
+        className='px-4 py-2 bg-red-600 text-white rounded'
+      >
+        Supprimer le compte
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+html, body, #root {
+  height: 100%;
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </React.StrictMode>
+);

--- a/frontend/src/pages/Profile.jsx
+++ b/frontend/src/pages/Profile.jsx
@@ -1,0 +1,53 @@
+import React, { useState, useEffect } from 'react';
+import ProfileHeader from '../components/profile/ProfileHeader';
+import PreferencesForm from '../components/profile/PreferencesForm';
+import ActivityStats from '../components/profile/ActivityStats';
+import ProfileSettings from '../components/profile/ProfileSettings';
+
+const tabs = [
+  { id: 'profil', label: 'Mon profil' },
+  { id: 'preferences', label: 'Mes préférences' },
+  { id: 'activite', label: 'Mon activité' },
+  { id: 'parametres', label: 'Paramètres' },
+];
+
+export default function Profile() {
+  const [activeTab, setActiveTab] = useState('profil');
+  const [profile, setProfile] = useState(null);
+
+  useEffect(() => {
+    fetch('/api/profile')
+      .then((r) => r.json())
+      .then(setProfile)
+      .catch(() => {});
+  }, []);
+
+  return (
+    <div className='p-4 max-w-4xl mx-auto space-y-4'>
+      <ProfileHeader profile={profile} />
+      <div>
+        <nav className='flex border-b border-gray-200 dark:border-gray-700'>
+          {tabs.map((t) => (
+            <button
+              key={t.id}
+              className={`px-4 py-2 -mb-px border-b-2 ${activeTab === t.id ? 'border-blue-500 text-blue-600' : 'border-transparent'}`}
+              onClick={() => setActiveTab(t.id)}
+            >
+              {t.label}
+            </button>
+          ))}
+        </nav>
+        <div className='mt-4'>
+          {activeTab === 'profil' && <div>Bienvenue sur votre profil.</div>}
+          {activeTab === 'preferences' && (
+            <PreferencesForm profile={profile} onUpdate={setProfile} />
+          )}
+          {activeTab === 'activite' && <ActivityStats />}
+          {activeTab === 'parametres' && (
+            <ProfileSettings profile={profile} />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,0 +1,8 @@
+export default {
+  darkMode: 'class',
+  content: ['./index.html', './src/**/*.{js,jsx,ts,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- scaffold Vite + React frontend with Tailwind and dark mode
- build profile page with tabs, charts, and CRUD API hooks
- add navigation with dark mode toggle

## Testing
- `npm test`
- `npm install` (fails: 403 Forbidden for @vitejs/plugin-react)
- `npm run build` (fails: vite: not found)

------
https://chatgpt.com/codex/tasks/task_e_68a76117aa64832595e19eeab5d8dc0f