### PR TITLE
Handle nested profile data from API

### DIFF
--- a/frontend/src/pages/Profile.jsx
+++ b/frontend/src/pages/Profile.jsx
@@ -18,7 +18,10 @@ export default function Profile() {
   useEffect(() => {
     fetch('/api/profile')
       .then((r) => r.json())
-      .then(setProfile)
+      .then((data) => {
+        setProfile(data.profile);
+        // éventuellement setStats(data.stats); setActivity(data.activity);
+      })
       .catch(() => {});
   }, []);
 


### PR DESCRIPTION
## Summary
- adapt profile page to fetch nested `profile` data

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a76435a3588325ab769e1976e65e54