### PR TITLE
Add profile details component and tests

### DIFF
--- a/frontend/src/components/profile/ProfileDetails.jsx
+++ b/frontend/src/components/profile/ProfileDetails.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+export default function ProfileDetails({ profile }) {
+  if (!profile) {
+    return <div>Chargement...</div>;
+  }
+
+  return (
+    <div className='space-y-4'>
+      <div className='flex items-center space-x-4'>
+        <img
+          src={profile.avatarUrl}
+          alt={`Avatar de ${profile.name}`}
+          className='w-24 h-24 rounded-full object-cover'
+        />
+        <div>
+          <h2 className='text-xl font-semibold'>{profile.name}</h2>
+          <p className='text-gray-600 dark:text-gray-400'>{profile.email}</p>
+        </div>
+      </div>
+      {profile.bio && (
+        <p className='text-gray-700 dark:text-gray-300'>{profile.bio}</p>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/Profile.jsx
+++ b/frontend/src/pages/Profile.jsx
@@ -3,6 +3,7 @@ import ProfileHeader from '../components/profile/ProfileHeader';
 import PreferencesForm from '../components/profile/PreferencesForm';
 import ActivityStats from '../components/profile/ActivityStats';
 import ProfileSettings from '../components/profile/ProfileSettings';
+import ProfileDetails from '../components/profile/ProfileDetails';
 
 const tabs = [
   { id: 'profil', label: 'Mon profil' },
@@ -41,7 +42,7 @@ export default function Profile() {
           ))}
         </nav>
         <div className='mt-4'>
-          {activeTab === 'profil' && <div>Bienvenue sur votre profil.</div>}
+          {activeTab === 'profil' && <ProfileDetails profile={profile} />}
           {activeTab === 'preferences' && (
             <PreferencesForm profile={profile} onUpdate={setProfile} />
           )}

--- a/frontend/tests/profile-details.test.js
+++ b/frontend/tests/profile-details.test.js
@@ -1,0 +1,15 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+test('Profile tab renders ProfileDetails component', () => {
+  const content = fs.readFileSync('frontend/src/pages/Profile.jsx', 'utf8');
+  assert.match(content, /<ProfileDetails profile={profile} \/>/);
+});
+
+test('ProfileDetails displays basic profile fields', () => {
+  const content = fs.readFileSync('frontend/src/components/profile/ProfileDetails.jsx', 'utf8');
+  assert.match(content, /profile\.name/);
+  assert.match(content, /profile\.email/);
+  assert.match(content, /profile\.avatarUrl/);
+});


### PR DESCRIPTION
## Summary
- show profile avatar, name, email, and bio using new `ProfileDetails` component
- display profile details in the profile tab
- verify profile tab uses the component and required fields via tests

## Testing
- `node --test frontend/tests/profile-details.test.js`
- `node --test frontend/tests/*.js backend/tests/**/*.js` *(fails: ReferenceError: require is not defined in ES module scope)*

------
https://chatgpt.com/codex/tasks/task_e_68a765bf5be0832591b556a1e8cb9305