### PR TITLE
refactor: reorganize backend into layered architecture

### DIFF
--- a/backend/scripts/check-env.js
+++ b/backend/scripts/check-env.js
@@ -6,7 +6,7 @@ require('dotenv').config();
 const fs = require('fs');
 const path = require('path');
 const { execSync } = require('child_process');
-const { logger } = require('../src/utils/helpers');
+const { logger } = require('../src/infrastructure/utils/helpers');
 
 // Vérifie si un fichier est suivi par git
 function isTracked(file, cwd) {

--- a/backend/scripts/check-migrations.js
+++ b/backend/scripts/check-migrations.js
@@ -1,5 +1,5 @@
 const { exec } = require('child_process');
-const { logger } = require('../src/utils/helpers');
+const { logger } = require('../src/infrastructure/utils/helpers');
 
 function run(command) {
   return new Promise((resolve) => {

--- a/backend/server.js
+++ b/backend/server.js
@@ -3,9 +3,9 @@ require('dotenv').config();
 const fs = require('fs');
 const http = require('http');
 const https = require('https');
-const { app, initializeApp } = require('./src/app');
-const { logger } = require('./src/utils/helpers');
-const { disconnectDatabase } = require('./src/config/database');
+const { app, initializeApp } = require('./src/presentation/app');
+const { logger } = require('./src/infrastructure/utils/helpers');
+const { disconnectDatabase } = require('./src/infrastructure/database');
 const { checkEnv } = require('./scripts/check-env');
 // const { ensureMigrations } = require('./scripts/check-migrations');
 

--- a/backend/src/application/services/anthropicService.js
+++ b/backend/src/application/services/anthropicService.js
@@ -1,11 +1,11 @@
-// backend/src/services/anthropicService.js
+// backend/src/application/services/anthropicService.js
 const Anthropic = require('@anthropic-ai/sdk');
-const { logger } = require('../utils/helpers');
+const { logger } = require('../../infrastructure/utils/helpers');
 const {
   DURATIONS,
   TEACHER_TYPES,
   VULGARIZATION_LEVELS
-} = require('../utils/constants');
+} = require('../../infrastructure/utils/constants');
 
 const MAX_COURSE_LENGTH = 6000;
 const ERROR_CODES = {

--- a/backend/src/application/services/googleAuthService.js
+++ b/backend/src/application/services/googleAuthService.js
@@ -1,6 +1,6 @@
-// backend/src/services/googleAuthService.js
+// backend/src/application/services/googleAuthService.js
 const { OAuth2Client } = require('google-auth-library');
-const { logger } = require('../utils/helpers');
+const { logger } = require('../../infrastructure/utils/helpers');
 
 class GoogleAuthService {
   constructor() {

--- a/backend/src/application/services/onboardingService.js
+++ b/backend/src/application/services/onboardingService.js
@@ -1,11 +1,11 @@
-// backend/src/services/onboardingService.js
+// backend/src/application/services/onboardingService.js
 let defaultPrisma = null;
 try {
-  ({ prisma: defaultPrisma } = require('../config/database'));
+  ({ prisma: defaultPrisma } = require('../../infrastructure/database'));
 } catch (err) {
   defaultPrisma = null;
 }
-const { logger } = require('../utils/helpers');
+const { logger } = require('../../infrastructure/utils/helpers');
 
 // Configuration des questions d'onboarding
 const QUESTION_CONFIG = [

--- a/backend/src/infrastructure/database/index.js
+++ b/backend/src/infrastructure/database/index.js
@@ -1,4 +1,4 @@
-// backend/src/config/database.js
+// backend/src/infrastructure/database/index.js
 const { PrismaClient } = require('@prisma/client');
 const { logger } = require('../utils/helpers');
 

--- a/backend/src/infrastructure/middleware/auth.js
+++ b/backend/src/infrastructure/middleware/auth.js
@@ -1,6 +1,6 @@
-// backend/src/middleware/auth.js
+// backend/src/infrastructure/middleware/auth.js
 const { verifyToken } = require('../utils/auth');
-const { prisma } = require('../config/database');
+const { prisma } = require('../database');
 const { createResponse, logger } = require('../utils/helpers');
 const { ERROR_MESSAGES, HTTP_STATUS } = require('../utils/constants');
 

--- a/backend/src/infrastructure/middleware/blacklist.js
+++ b/backend/src/infrastructure/middleware/blacklist.js
@@ -1,4 +1,4 @@
-// backend/src/middleware/blacklist.js
+// backend/src/infrastructure/middleware/blacklist.js
 const { createResponse } = require('../utils/helpers');
 const { ERROR_MESSAGES, HTTP_STATUS } = require('../utils/constants');
 

--- a/backend/src/infrastructure/middleware/validation.js
+++ b/backend/src/infrastructure/middleware/validation.js
@@ -1,4 +1,4 @@
-// backend/src/middleware/validation.js
+// backend/src/infrastructure/middleware/validation.js
 const { body, validationResult } = require('express-validator');
 const { createResponse } = require('../utils/helpers');
 const { HTTP_STATUS, DURATIONS, TEACHER_TYPES, VULGARIZATION_LEVELS } = require('../utils/constants');

--- a/backend/src/infrastructure/utils/auth.js
+++ b/backend/src/infrastructure/utils/auth.js
@@ -1,4 +1,4 @@
-// backend/src/utils/auth.js (copier depuis backend/utils-old/auth.js)
+// backend/src/infrastructure/utils/auth.js (copier depuis backend/utils-old/auth.js)
 const jwt = require('jsonwebtoken');
 const bcrypt = require('bcryptjs');
 

--- a/backend/src/infrastructure/utils/constants.js
+++ b/backend/src/infrastructure/utils/constants.js
@@ -1,4 +1,4 @@
-// backend/src/utils/constants.js
+// backend/src/infrastructure/utils/constants.js
 
 // Niveaux de détail
 const DETAIL_LEVELS = {

--- a/backend/src/infrastructure/utils/helpers.js
+++ b/backend/src/infrastructure/utils/helpers.js
@@ -1,4 +1,4 @@
-// backend/src/utils/helpers.js
+// backend/src/infrastructure/utils/helpers.js
 const {
   ERROR_MESSAGES,
   HTTP_STATUS,

--- a/backend/src/presentation/app.js
+++ b/backend/src/presentation/app.js
@@ -1,12 +1,12 @@
-// backend/src/app.js
+// backend/src/presentation/app.js
 const express = require('express');
 const helmet = require('helmet');
 const rateLimit = require('express-rate-limit');
 const path = require('path');
 const cookieParser = require('cookie-parser');
-const { connectDatabase } = require('./config/database');
-const { logger } = require('./utils/helpers');
-const { LIMITS } = require('./utils/constants');
+const { connectDatabase } = require('../infrastructure/database');
+const { logger } = require('../infrastructure/utils/helpers');
+const { LIMITS } = require('../infrastructure/utils/constants');
 
 // Importer les routes
 const apiRoutes = require('./routes');
@@ -141,15 +141,15 @@ app.use((req, res, next) => {
 });
 
 // Servir les fichiers statiques pour l'application et le marketing
-app.use('/app', express.static(path.join(__dirname, '../../frontend/app')));
-app.use('/', express.static(path.join(__dirname, '../../frontend/marketing')));
+app.use('/app', express.static(path.join(__dirname, '../../../frontend/app')));
+app.use('/', express.static(path.join(__dirname, '../../../frontend/marketing')));
 
 // Routes pour les applications frontend
 app.get('/app*', (_, res) =>
-  res.sendFile(path.join(__dirname, '../../frontend/app/index.html'))
+  res.sendFile(path.join(__dirname, '../../../frontend/app/index.html'))
 );
 app.get('/', (_, res) =>
-  res.sendFile(path.join(__dirname, '../../frontend/marketing/index.html'))
+  res.sendFile(path.join(__dirname, '../../../frontend/marketing/index.html'))
 );
 
 // Routes API

--- a/backend/src/presentation/controllers/aiController.js
+++ b/backend/src/presentation/controllers/aiController.js
@@ -1,8 +1,8 @@
-// backend/src/controllers/aiController.js
-const { createResponse, sanitizeInput, logger } = require('../utils/helpers');
-const { HTTP_STATUS, ERROR_MESSAGES, ERROR_CODES, AI_ERROR_MESSAGES, LIMITS } = require('../utils/constants');
-const { prisma } = require('../config/database');
-const anthropicService = require('../services/anthropicService');
+// backend/src/presentation/controllers/aiController.js
+const { createResponse, sanitizeInput, logger } = require('../../infrastructure/utils/helpers');
+const { HTTP_STATUS, ERROR_MESSAGES, ERROR_CODES, AI_ERROR_MESSAGES, LIMITS } = require('../../infrastructure/utils/constants');
+const { prisma } = require('../../infrastructure/database');
+const anthropicService = require('../../application/services/anthropicService');
 
 class AiController {
   // Répondre à une question

--- a/backend/src/presentation/controllers/authController.js
+++ b/backend/src/presentation/controllers/authController.js
@@ -1,9 +1,9 @@
-// backend/src/controllers/authController.js
-const { prisma } = require('../config/database');
-const { hashPassword, comparePassword, generateToken } = require('../utils/auth');
-const { createResponse, sanitizeInput, logger } = require('../utils/helpers');
-const { HTTP_STATUS, ERROR_MESSAGES } = require('../utils/constants');
-const googleAuthService = require('../services/googleAuthService');
+// backend/src/presentation/controllers/authController.js
+const { prisma } = require('../../infrastructure/database');
+const { hashPassword, comparePassword, generateToken } = require('../../infrastructure/utils/auth');
+const { createResponse, sanitizeInput, logger } = require('../../infrastructure/utils/helpers');
+const { HTTP_STATUS, ERROR_MESSAGES } = require('../../infrastructure/utils/constants');
+const googleAuthService = require('../../application/services/googleAuthService');
 
 class AuthController {
   handleError(res, error, context) {

--- a/backend/src/presentation/controllers/courseController.js
+++ b/backend/src/presentation/controllers/courseController.js
@@ -1,8 +1,8 @@
-// backend/src/controllers/courseController.js
-const { prisma } = require('../config/database');
-const { createResponse, validateCourseParams, sanitizeInput, logger, mapLegacyParams } = require('../utils/helpers');
-const { HTTP_STATUS, ERROR_MESSAGES, LIMITS, ERROR_CODES } = require('../utils/constants');
-const anthropicService = require('../services/anthropicService');
+// backend/src/presentation/controllers/courseController.js
+const { prisma } = require('../../infrastructure/database');
+const { createResponse, validateCourseParams, sanitizeInput, logger, mapLegacyParams } = require('../../infrastructure/utils/helpers');
+const { HTTP_STATUS, ERROR_MESSAGES, LIMITS, ERROR_CODES } = require('../../infrastructure/utils/constants');
+const anthropicService = require('../../application/services/anthropicService');
 const crypto = require('crypto');
 
 class CourseController {

--- a/backend/src/presentation/controllers/onboardingController.js
+++ b/backend/src/presentation/controllers/onboardingController.js
@@ -1,7 +1,7 @@
-// backend/src/controllers/onboardingController.js
-const { createResponse, logger } = require('../utils/helpers');
-const { HTTP_STATUS, ERROR_MESSAGES } = require('../utils/constants');
-const OnboardingService = require('../services/onboardingService');
+// backend/src/presentation/controllers/onboardingController.js
+const { createResponse, logger } = require('../../infrastructure/utils/helpers');
+const { HTTP_STATUS, ERROR_MESSAGES } = require('../../infrastructure/utils/constants');
+const OnboardingService = require('../../application/services/onboardingService');
 
 class OnboardingController {
   constructor() {

--- a/backend/src/presentation/routes/ai.js
+++ b/backend/src/presentation/routes/ai.js
@@ -1,12 +1,12 @@
-// backend/src/routes/ai.js
+// backend/src/presentation/routes/ai.js
 const express = require('express');
 const aiController = require('../controllers/aiController');
-const { authenticate } = require('../middleware/auth');
-const { asyncHandler } = require('../utils/helpers');
-const { questionValidation } = require('../middleware/validation');
+const { authenticate } = require('../../infrastructure/middleware/auth');
+const { asyncHandler } = require('../../infrastructure/utils/helpers');
+const { questionValidation } = require('../../infrastructure/middleware/validation');
 const rateLimit = require('express-rate-limit');
-const { RATE_LIMITS, ERROR_MESSAGES } = require('../utils/constants');
-const { checkBlacklist } = require('../middleware/blacklist');
+const { RATE_LIMITS, ERROR_MESSAGES } = require('../../infrastructure/utils/constants');
+const { checkBlacklist } = require('../../infrastructure/middleware/blacklist');
 
 const router = express.Router();
 

--- a/backend/src/presentation/routes/auth.js
+++ b/backend/src/presentation/routes/auth.js
@@ -1,12 +1,12 @@
-// backend/src/routes/auth.js
+// backend/src/presentation/routes/auth.js
 const express = require('express');
 const authController = require('../controllers/authController');
-const { authenticate } = require('../middleware/auth');
-const { registerValidation, loginValidation } = require('../middleware/validation');
-const { asyncHandler } = require('../utils/helpers');
+const { authenticate } = require('../../infrastructure/middleware/auth');
+const { registerValidation, loginValidation } = require('../../infrastructure/middleware/validation');
+const { asyncHandler } = require('../../infrastructure/utils/helpers');
 const rateLimit = require('express-rate-limit');
-const { RATE_LIMITS, ERROR_MESSAGES } = require('../utils/constants');
-const { checkBlacklist } = require('../middleware/blacklist');
+const { RATE_LIMITS, ERROR_MESSAGES } = require('../../infrastructure/utils/constants');
+const { checkBlacklist } = require('../../infrastructure/middleware/blacklist');
 
 const router = express.Router();
 

--- a/backend/src/presentation/routes/courses.js
+++ b/backend/src/presentation/routes/courses.js
@@ -1,11 +1,11 @@
-// backend/src/routes/courses.js
+// backend/src/presentation/routes/courses.js
 const express = require('express');
 const courseController = require('../controllers/courseController');
-const { authenticate } = require('../middleware/auth');
-const { courseValidation, handleValidationErrors } = require('../middleware/validation');
-const { asyncHandler } = require('../utils/helpers');
+const { authenticate } = require('../../infrastructure/middleware/auth');
+const { courseValidation, handleValidationErrors } = require('../../infrastructure/middleware/validation');
+const { asyncHandler } = require('../../infrastructure/utils/helpers');
 const { query } = require('express-validator');
-const { LIMITS } = require('../utils/constants');
+const { LIMITS } = require('../../infrastructure/utils/constants');
 
 const router = express.Router();
 

--- a/backend/src/presentation/routes/index.js
+++ b/backend/src/presentation/routes/index.js
@@ -1,4 +1,4 @@
-// backend/src/routes/index.js
+// backend/src/presentation/routes/index.js
 const express = require('express');
 const authRoutes = require('./auth');
 const coursesRoutes = require('./courses');

--- a/backend/src/presentation/routes/onboardingRoutes.js
+++ b/backend/src/presentation/routes/onboardingRoutes.js
@@ -1,8 +1,8 @@
-// backend/src/routes/onboardingRoutes.js
+// backend/src/presentation/routes/onboardingRoutes.js
 const express = require('express');
 const onboardingController = require('../controllers/onboardingController');
-const { authenticate } = require('../middleware/auth');
-const { asyncHandler } = require('../utils/helpers');
+const { authenticate } = require('../../infrastructure/middleware/auth');
+const { asyncHandler } = require('../../infrastructure/utils/helpers');
 
 const router = express.Router();
 

--- a/backend/tests/controllers/courseController.test.js
+++ b/backend/tests/controllers/courseController.test.js
@@ -1,12 +1,12 @@
 const test = require('node:test');
 const assert = require('node:assert');
-const { mapLegacyParams } = require('../../src/utils/helpers');
+const { mapLegacyParams } = require('../../src/infrastructure/utils/helpers');
 const {
   DURATIONS,
   VULGARIZATION_LEVELS,
   LEGACY_VULGARIZATION_LEVELS,
   TEACHER_TYPES,
-} = require('../../src/utils/constants');
+} = require('../../src/infrastructure/utils/constants');
 
 test('detailLevel numeric values map to durations', () => {
   const mapping = {

--- a/backend/tests/middleware/auth.test.js
+++ b/backend/tests/middleware/auth.test.js
@@ -4,9 +4,9 @@ process.env.DATABASE_URL = 'postgresql://user:pass@localhost:5432/test';
 const test = require('node:test');
 const assert = require('node:assert');
 
-const { prisma } = require('../../src/config/database');
-const { generateToken } = require('../../src/utils/auth');
-const { authenticate } = require('../../src/middleware/auth');
+const { prisma } = require('../../src/infrastructure/database');
+const { generateToken } = require('../../src/infrastructure/utils/auth');
+const { authenticate } = require('../../src/infrastructure/middleware/auth');
 
 test('authenticate uses token from cookies when Authorization header missing', async () => {
   const fakeUser = { id: 1, email: 'user@example.com', name: 'Test User' };

--- a/backend/tests/onboarding/onboarding.test.js
+++ b/backend/tests/onboarding/onboarding.test.js
@@ -1,6 +1,6 @@
 const test = require('node:test');
 const assert = require('node:assert');
-const OnboardingService = require('../../src/services/onboardingService');
+const OnboardingService = require('../../src/application/services/onboardingService');
 
 test('calculateProfileConfidence computes fraction of answered questions', () => {
   const service = new OnboardingService();

--- a/backend/tests/routes/config.test.js
+++ b/backend/tests/routes/config.test.js
@@ -4,7 +4,7 @@ const request = require('supertest');
 process.env.JWT_SECRET = 'a'.repeat(32);
 process.env.DATABASE_URL = 'postgresql://user:pass@localhost:5432/test';
 process.env.GOOGLE_CLIENT_ID = 'dummy';
-const { app } = require('../../src/app');
+const { app } = require('../../src/presentation/app');
 
 test('GET /api/config/google returns client ID when configured', async () => {
   const originalClientId = process.env.GOOGLE_CLIENT_ID;

--- a/backend/tests/services/anthropicService.test.js
+++ b/backend/tests/services/anthropicService.test.js
@@ -16,9 +16,9 @@ Module._load = (request, parent, isMain) => {
   return originalLoad(request, parent, isMain);
 };
 
-const anthropicService = require('../../src/services/anthropicService');
+const anthropicService = require('../../src/application/services/anthropicService');
 Module._load = originalLoad;
-const { TEACHER_TYPES, DURATIONS, VULGARIZATION_LEVELS, ERROR_CODES } = require('../../src/utils/constants');
+const { TEACHER_TYPES, DURATIONS, VULGARIZATION_LEVELS, ERROR_CODES } = require('../../src/infrastructure/utils/constants');
 
 test('createPrompt creates flexible educational content', () => {
   const prompt = anthropicService.createPrompt(

--- a/backend/tests/services/googleAuthService.test.js
+++ b/backend/tests/services/googleAuthService.test.js
@@ -3,7 +3,7 @@ process.env.GOOGLE_CLIENT_ID = 'test-client-id';
 const test = require('node:test');
 const assert = require('node:assert');
 const { OAuth2Client } = require('google-auth-library');
-const googleAuthService = require('../../src/services/googleAuthService');
+const googleAuthService = require('../../src/application/services/googleAuthService');
 const { mock } = test;
 
 test.afterEach(() => {

--- a/backend/tests/utils/helpers.test.js
+++ b/backend/tests/utils/helpers.test.js
@@ -1,6 +1,6 @@
 const test = require('node:test');
 const assert = require('node:assert');
-const { sanitizeInput } = require('../../src/utils/helpers');
+const { sanitizeInput } = require('../../src/infrastructure/utils/helpers');
 
 test('sanitizeInput preserves accented letters', () => {
   const input = 'Café élève déjà naïve';

--- a/frontend/app/assets/js/shared/sanitize.js
+++ b/frontend/app/assets/js/shared/sanitize.js
@@ -1,6 +1,6 @@
 /**
  * Sanitize user-provided input while preserving Unicode letters and punctuation.
- * This logic is mirrored in backend/src/utils/helpers.js; update both places when
+ * This logic is mirrored in backend/src/infrastructure/utils/helpers.js; update both places when
  * changing the allowed character set or behavior.
  *
  * @param {string} input - The raw input string to clean.

--- a/frontend/marketing/assets/js/shared/sanitize.js
+++ b/frontend/marketing/assets/js/shared/sanitize.js
@@ -1,6 +1,6 @@
 /**
  * Sanitize user-provided input while preserving Unicode letters and punctuation.
- * This logic is mirrored in backend/src/utils/helpers.js; update both places when
+ * This logic is mirrored in backend/src/infrastructure/utils/helpers.js; update both places when
  * changing the allowed character set or behavior.
  *
  * @param {string} input - The raw input string to clean.


### PR DESCRIPTION
## Summary
- introduce domain, application, infrastructure, and presentation layers under `backend/src`
- move controllers, services, middleware, and utilities to their respective layers and update imports
- adjust scripts, tests, and frontend comments to new paths

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a823b16d648325ab8ca244c7c2350d