### PR TITLE
feat(domain): add core entities and use case

### DIFF
--- a/backend/src/domain/entities/Course.js
+++ b/backend/src/domain/entities/Course.js
@@ -1,0 +1,11 @@
+class Course {
+  constructor({ id, subject, content, userId, createdAt }) {
+    this.id = id;
+    this.subject = subject;
+    this.content = content;
+    this.userId = userId;
+    this.createdAt = createdAt;
+  }
+}
+
+module.exports = Course;

--- a/backend/src/domain/entities/User.js
+++ b/backend/src/domain/entities/User.js
@@ -1,0 +1,8 @@
+class User {
+  constructor({ id, email }) {
+    this.id = id;
+    this.email = email;
+  }
+}
+
+module.exports = User;

--- a/backend/src/domain/repositories/CourseRepository.js
+++ b/backend/src/domain/repositories/CourseRepository.js
@@ -1,0 +1,7 @@
+class CourseRepository {
+  async create(course) {
+    throw new Error('Method not implemented');
+  }
+}
+
+module.exports = CourseRepository;

--- a/backend/src/domain/services/CourseGenerationService.js
+++ b/backend/src/domain/services/CourseGenerationService.js
@@ -1,0 +1,7 @@
+class CourseGenerationService {
+  async generateCourse(subject, options) {
+    throw new Error('Method not implemented');
+  }
+}
+
+module.exports = CourseGenerationService;

--- a/backend/src/domain/usecases/CreateCourseUseCase.js
+++ b/backend/src/domain/usecases/CreateCourseUseCase.js
@@ -1,0 +1,19 @@
+class CreateCourseUseCase {
+  constructor(courseRepository, courseGenerationService) {
+    this.courseRepository = courseRepository;
+    this.courseGenerationService = courseGenerationService;
+  }
+
+  async execute({ userId, subject, options }) {
+    const content = await this.courseGenerationService.generateCourse(subject, options);
+    const course = await this.courseRepository.create({
+      subject,
+      content,
+      userId,
+      ...options,
+    });
+    return course;
+  }
+}
+
+module.exports = CreateCourseUseCase;


### PR DESCRIPTION
## Summary
- define User and Course domain entities
- add CourseRepository and CourseGenerationService interfaces
- implement CreateCourseUseCase encapsulating course creation logic

## Testing
- `npm test` *(fails: test run did not terminate; see logs)*

------
https://chatgpt.com/codex/tasks/task_e_68a82b375cc88325bbb3961fc545d356