### PR TITLE
feat: add course repository interfaces and prisma implementation

### DIFF
--- a/backend/src/domain/repositories/CourseRepository.js
+++ b/backend/src/domain/repositories/CourseRepository.js
@@ -1,7 +1,0 @@
-class CourseRepository {
-  async create(course) {
-    throw new Error('Method not implemented');
-  }
-}
-
-module.exports = CourseRepository;

--- a/backend/src/domain/repositories/ICourseRepository.js
+++ b/backend/src/domain/repositories/ICourseRepository.js
@@ -1,0 +1,23 @@
+class ICourseRepository {
+  async create(courseData) {
+    throw new Error('Method not implemented');
+  }
+
+  async findById(id) {
+    throw new Error('Method not implemented');
+  }
+
+  async findAllByUserId(userId) {
+    throw new Error('Method not implemented');
+  }
+
+  async update(id, updateData) {
+    throw new Error('Method not implemented');
+  }
+
+  async delete(id) {
+    throw new Error('Method not implemented');
+  }
+}
+
+module.exports = ICourseRepository;

--- a/backend/src/infrastructure/database/PrismaCourseRepository.js
+++ b/backend/src/infrastructure/database/PrismaCourseRepository.js
@@ -1,0 +1,36 @@
+const ICourseRepository = require('../../domain/repositories/ICourseRepository');
+const { prisma } = require('.');
+const { toDomain, toPersistence } = require('./mappers/courseMapper');
+
+class PrismaCourseRepository extends ICourseRepository {
+  async create(courseData) {
+    const data = toPersistence(courseData);
+    const created = await prisma.course.create({ data });
+    return toDomain(created);
+  }
+
+  async findById(id) {
+    const course = await prisma.course.findUnique({ where: { id } });
+    return toDomain(course);
+  }
+
+  async findAllByUserId(userId) {
+    const courses = await prisma.course.findMany({
+      where: { userId },
+      orderBy: { createdAt: 'desc' },
+    });
+    return courses.map(toDomain);
+  }
+
+  async update(id, updateData) {
+    const data = toPersistence(updateData);
+    const updated = await prisma.course.update({ where: { id }, data });
+    return toDomain(updated);
+  }
+
+  async delete(id) {
+    await prisma.course.delete({ where: { id } });
+  }
+}
+
+module.exports = PrismaCourseRepository;

--- a/backend/src/infrastructure/database/mappers/courseMapper.js
+++ b/backend/src/infrastructure/database/mappers/courseMapper.js
@@ -1,0 +1,36 @@
+const Course = require('../../../domain/entities/Course');
+
+function toDomain(persistenceCourse) {
+  if (!persistenceCourse) return null;
+  return new Course({
+    id: persistenceCourse.id,
+    subject: persistenceCourse.subject,
+    content: persistenceCourse.content,
+    userId: persistenceCourse.userId,
+    createdAt: persistenceCourse.createdAt,
+  });
+}
+
+function toPersistence(domainCourse) {
+  if (!domainCourse) return null;
+  const persistence = {
+    id: domainCourse.id,
+    subject: domainCourse.subject,
+    content: domainCourse.content,
+    userId: domainCourse.userId,
+    duration: domainCourse.duration,
+    detailLevel: domainCourse.detailLevel,
+    vulgarizationLevel: domainCourse.vulgarizationLevel,
+    style: domainCourse.style,
+    intent: domainCourse.intent,
+    vulgarization: domainCourse.vulgarization,
+    teacherType: domainCourse.teacherType,
+    createdAt: domainCourse.createdAt,
+  };
+  Object.keys(persistence).forEach(
+    (key) => persistence[key] === undefined && delete persistence[key]
+  );
+  return persistence;
+}
+
+module.exports = { toDomain, toPersistence };


### PR DESCRIPTION
## Summary
- define `ICourseRepository` with CRUD signatures for courses
- map course domain objects to prisma records and back
- implement `PrismaCourseRepository` using the new mapper

## Testing
- `timeout 5 npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a83b134c7c8325bf02f59c1545b068