### PR TITLE
feat: add domain error handling

### DIFF
--- a/backend/src/domain/errors/BusinessRuleError.js
+++ b/backend/src/domain/errors/BusinessRuleError.js
@@ -1,0 +1,5 @@
+const DomainError = require('./DomainError');
+
+class BusinessRuleError extends DomainError {}
+
+module.exports = BusinessRuleError;

--- a/backend/src/domain/errors/DomainError.js
+++ b/backend/src/domain/errors/DomainError.js
@@ -1,0 +1,9 @@
+class DomainError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = this.constructor.name;
+    Error.captureStackTrace(this, this.constructor);
+  }
+}
+
+module.exports = DomainError;

--- a/backend/src/domain/errors/ValidationError.js
+++ b/backend/src/domain/errors/ValidationError.js
@@ -1,0 +1,5 @@
+const DomainError = require('./DomainError');
+
+class ValidationError extends DomainError {}
+
+module.exports = ValidationError;

--- a/backend/src/domain/errors/index.js
+++ b/backend/src/domain/errors/index.js
@@ -1,0 +1,5 @@
+module.exports = {
+  DomainError: require('./DomainError'),
+  ValidationError: require('./ValidationError'),
+  BusinessRuleError: require('./BusinessRuleError')
+};

--- a/backend/src/domain/repositories/ICourseRepository.js
+++ b/backend/src/domain/repositories/ICourseRepository.js
@@ -1,22 +1,24 @@
+const { DomainError } = require('../errors');
+
 class ICourseRepository {
   async create(courseData) {
-    throw new Error('Method not implemented');
+    throw new DomainError('Method not implemented');
   }
 
   async findById(id) {
-    throw new Error('Method not implemented');
+    throw new DomainError('Method not implemented');
   }
 
   async findAllByUserId(userId) {
-    throw new Error('Method not implemented');
+    throw new DomainError('Method not implemented');
   }
 
   async update(id, updateData) {
-    throw new Error('Method not implemented');
+    throw new DomainError('Method not implemented');
   }
 
   async delete(id) {
-    throw new Error('Method not implemented');
+    throw new DomainError('Method not implemented');
   }
 }
 

--- a/backend/src/domain/services/AnthropicAIService.js
+++ b/backend/src/domain/services/AnthropicAIService.js
@@ -7,6 +7,11 @@ const {
   LIMITS,
   ERROR_CODES
 } = require('../../infrastructure/utils/constants');
+const {
+  DomainError,
+  ValidationError,
+  BusinessRuleError
+} = require('../errors');
 
 const MAX_COURSE_LENGTH = LIMITS.MAX_COURSE_LENGTH;
 
@@ -140,12 +145,12 @@ RENDU ATTENDU :
       logger.error('Erreur génération cours', { code, error });
       if (code === ERROR_CODES.IA_ERROR) {
         this.aiService.setOffline(true);
-        const err = new Error(this.getOfflineMessage());
+        const err = new DomainError(this.getOfflineMessage());
         err.code = code;
         err.offline = true;
         throw err;
       }
-      const err = new Error('Erreur lors de la génération du cours');
+      const err = new DomainError('Erreur lors de la génération du cours');
       err.code = code;
       throw err;
     }
@@ -226,12 +231,12 @@ Réponse :`;
       logger.error('Erreur réponse question', { code, error });
       if (code === ERROR_CODES.IA_ERROR) {
         this.aiService.setOffline(true);
-        const err = new Error(this.getOfflineMessage());
+        const err = new DomainError(this.getOfflineMessage());
         err.code = code;
         err.offline = true;
         throw err;
       }
-      const err = new Error('Erreur lors de la génération de la réponse');
+      const err = new DomainError('Erreur lors de la génération de la réponse');
       err.code = code;
       throw err;
     }
@@ -343,19 +348,19 @@ Assure-toi que les questions couvrent les points clés du cours et que les répo
         const quizData = JSON.parse(jsonMatch[0]);
         return quizData;
       } else {
-        throw new Error('Format de réponse invalide');
+        throw new ValidationError('Format de réponse invalide');
       }
     } catch (error) {
       const code = this.aiService.categorizeError(error);
       logger.error('Erreur génération quiz', { code, error });
       if (code === ERROR_CODES.IA_ERROR) {
         this.aiService.setOffline(true);
-        const err = new Error(this.getOfflineMessage());
+        const err = new DomainError(this.getOfflineMessage());
         err.code = code;
         err.offline = true;
         throw err;
       }
-      const err = new Error('Erreur lors de la génération du quiz');
+      const err = new DomainError('Erreur lors de la génération du quiz');
       err.code = code;
       throw err;
     }
@@ -410,19 +415,19 @@ Assure-toi que les questions couvrent les points clés du sujet et que les répo
         const quizData = JSON.parse(jsonMatch[0]);
         return quizData.questions;
       } else {
-        throw new Error('Format de réponse invalide');
+        throw new ValidationError('Format de réponse invalide');
       }
     } catch (error) {
       const code = this.aiService.categorizeError(error);
       logger.error('Erreur génération quiz à la demande', { code, error });
       if (code === ERROR_CODES.IA_ERROR) {
         this.aiService.setOffline(true);
-        const err = new Error(this.getOfflineMessage());
+        const err = new DomainError(this.getOfflineMessage());
         err.code = code;
         err.offline = true;
         throw err;
       }
-      const err = new Error('Erreur lors de la génération du quiz à la demande');
+      const err = new DomainError('Erreur lors de la génération du quiz à la demande');
       err.code = code;
       throw err;
     }
@@ -467,7 +472,7 @@ Format JSON :
         const suggestionsData = JSON.parse(jsonMatch[0]);
         return suggestionsData.questions;
       } else {
-        throw new Error('Format de réponse invalide');
+        throw new ValidationError('Format de réponse invalide');
       }
 
     } catch (error) {
@@ -475,12 +480,12 @@ Format JSON :
       logger.error('Erreur suggestions questions', { code, error });
       if (code === ERROR_CODES.IA_ERROR) {
         this.aiService.setOffline(true);
-        const err = new Error(this.getOfflineMessage());
+        const err = new DomainError(this.getOfflineMessage());
         err.code = code;
         err.offline = true;
         throw err;
       }
-      const err = new Error('Erreur lors de la génération des suggestions');
+      const err = new DomainError('Erreur lors de la génération des suggestions');
       err.code = code;
       throw err;
     }
@@ -551,7 +556,7 @@ Format JSON :
 
     } catch (error) {
       logger.error('Erreur génération sujet aléatoire', error);
-      throw new Error('Erreur lors de la génération du sujet aléatoire');
+      throw new BusinessRuleError('Erreur lors de la génération du sujet aléatoire');
     }
   }
 
@@ -573,7 +578,7 @@ Format JSON :
 
     } catch (error) {
       logger.error('Erreur récupération catégories', error);
-      throw new Error('Erreur lors de la récupération des catégories');
+      throw new BusinessRuleError('Erreur lors de la récupération des catégories');
     }
   }
 

--- a/backend/src/domain/services/CourseGenerationService.js
+++ b/backend/src/domain/services/CourseGenerationService.js
@@ -1,6 +1,8 @@
+const { DomainError } = require('../errors');
+
 class CourseGenerationService {
   async generateCourse(subject, options) {
-    throw new Error('Method not implemented');
+    throw new DomainError('Method not implemented');
   }
 }
 

--- a/backend/src/domain/services/IAIService.js
+++ b/backend/src/domain/services/IAIService.js
@@ -1,26 +1,28 @@
+const { DomainError } = require('../errors');
+
 class IAIService {
   async sendWithTimeout(options, timeoutMs, retryDelays) {
-    throw new Error('Method not implemented');
+    throw new DomainError('Method not implemented');
   }
 
   isOffline() {
-    throw new Error('Method not implemented');
+    throw new DomainError('Method not implemented');
   }
 
   getOfflineMessage() {
-    throw new Error('Method not implemented');
+    throw new DomainError('Method not implemented');
   }
 
   async recoverIfOffline() {
-    throw new Error('Method not implemented');
+    throw new DomainError('Method not implemented');
   }
 
   categorizeError(error) {
-    throw new Error('Method not implemented');
+    throw new DomainError('Method not implemented');
   }
 
   setOffline(value) {
-    throw new Error('Method not implemented');
+    throw new DomainError('Method not implemented');
   }
 }
 

--- a/backend/src/domain/usecases/CreateCourseUseCase.js
+++ b/backend/src/domain/usecases/CreateCourseUseCase.js
@@ -1,3 +1,5 @@
+const { ValidationError } = require('../errors');
+
 class CreateCourseUseCase {
   constructor(courseRepository, courseGenerationService) {
     this.courseRepository = courseRepository;
@@ -5,6 +7,12 @@ class CreateCourseUseCase {
   }
 
   async execute({ userId, subject, options }) {
+    if (!userId) {
+      throw new ValidationError('userId est requis');
+    }
+    if (!subject) {
+      throw new ValidationError('Le sujet est requis');
+    }
     const content = await this.courseGenerationService.generateCourse(subject, options);
     const course = await this.courseRepository.create({
       subject,

--- a/backend/src/domain/usecases/GenerateCourseUseCase.js
+++ b/backend/src/domain/usecases/GenerateCourseUseCase.js
@@ -1,3 +1,5 @@
+const { ValidationError } = require('../errors');
+
 class GenerateCourseUseCase {
   constructor(courseRepository, courseGenerationService) {
     this.courseRepository = courseRepository;
@@ -5,6 +7,12 @@ class GenerateCourseUseCase {
   }
 
   async execute({ userId, subject, teacherType, duration, vulgarization }) {
+    if (!userId) {
+      throw new ValidationError('userId est requis');
+    }
+    if (!subject) {
+      throw new ValidationError('Le sujet est requis');
+    }
     const content = await this.courseGenerationService.generateCourse(
       subject,
       vulgarization,

--- a/backend/src/presentation/app.js
+++ b/backend/src/presentation/app.js
@@ -10,6 +10,7 @@ const { LIMITS } = require('../infrastructure/utils/constants');
 
 // Importer les routes
 const apiRoutes = require('./routes');
+const errorHandler = require('./middleware/errorHandler');
 
 const app = express();
 
@@ -180,14 +181,7 @@ app.post('/api/logs', (req, res) => {
 });
 
 // Middleware de gestion des erreurs globales
-app.use((err, req, res, next) => {
-  logger.error('Erreur serveur non gérée', err);
-  
-  res.status(500).json({
-    success: false,
-    error: process.env.NODE_ENV === 'development' ? err.message : 'Erreur serveur interne'
-  });
-});
+app.use(errorHandler);
 
 // Middleware pour les routes non trouvées
 app.use('*', (req, res) => {

--- a/backend/src/presentation/middleware/errorHandler.js
+++ b/backend/src/presentation/middleware/errorHandler.js
@@ -1,0 +1,25 @@
+const { ValidationError, BusinessRuleError, DomainError } = require('../../domain/errors');
+const { logger } = require('../../infrastructure/utils/helpers');
+
+module.exports = (err, req, res, next) => {
+  if (err instanceof ValidationError) {
+    return res.status(400).json({ success: false, error: err.message });
+  }
+
+  if (err instanceof BusinessRuleError) {
+    return res.status(409).json({ success: false, error: err.message });
+  }
+
+  if (err instanceof DomainError) {
+    return res.status(400).json({ success: false, error: err.message });
+  }
+
+  logger.error('Erreur serveur non gérée', err);
+  res.status(500).json({
+    success: false,
+    error:
+      process.env.NODE_ENV === 'development'
+        ? err.message
+        : 'Erreur serveur interne'
+  });
+};


### PR DESCRIPTION
## Summary
- add DomainError base class with ValidationError and BusinessRuleError
- centralize error mapping with presentation middleware
- update services and use cases to throw domain errors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a845eaed508325a8fe6dee35e7f9d8