### PR TITLE
test(domain): add use case unit tests

### DIFF
--- a/backend/tests/unit/domain/usecases/CreateCourseUseCase.test.js
+++ b/backend/tests/unit/domain/usecases/CreateCourseUseCase.test.js
@@ -1,0 +1,63 @@
+const test = require('node:test');
+const assert = require('node:assert');
+
+const { ValidationError } = require('../../../../src/domain/errors');
+const CreateCourseUseCase = require('../../../../src/domain/usecases/CreateCourseUseCase');
+
+test('throws ValidationError when userId is missing', async () => {
+  const useCase = new CreateCourseUseCase({}, {});
+  await assert.rejects(
+    () => useCase.execute({ subject: 'Math' }),
+    ValidationError
+  );
+});
+
+test('throws ValidationError when subject is missing', async () => {
+  const useCase = new CreateCourseUseCase({}, {});
+  await assert.rejects(
+    () => useCase.execute({ userId: 'user1' }),
+    ValidationError
+  );
+});
+
+test('generates content and saves course', async () => {
+  const generated = 'generated content';
+  const serviceCalls = [];
+  const repoCalls = [];
+
+  const courseGenerationService = {
+    generateCourse: async (subject, options) => {
+      serviceCalls.push({ subject, options });
+      return generated;
+    }
+  };
+
+  const courseRepository = {
+    create: async data => {
+      repoCalls.push(data);
+      return { id: 1, ...data };
+    }
+  };
+
+  const useCase = new CreateCourseUseCase(courseRepository, courseGenerationService);
+  const input = { userId: 'user1', subject: 'Physics', options: { level: 'easy' } };
+  const result = await useCase.execute(input);
+
+  assert.deepStrictEqual(serviceCalls, [{ subject: 'Physics', options: { level: 'easy' } }]);
+  assert.deepStrictEqual(repoCalls, [
+    {
+      subject: 'Physics',
+      content: generated,
+      userId: 'user1',
+      level: 'easy'
+    }
+  ]);
+  assert.deepStrictEqual(result, {
+    id: 1,
+    subject: 'Physics',
+    content: generated,
+    userId: 'user1',
+    level: 'easy'
+  });
+});
+

--- a/backend/tests/unit/domain/usecases/GenerateCourseUseCase.test.js
+++ b/backend/tests/unit/domain/usecases/GenerateCourseUseCase.test.js
@@ -1,0 +1,80 @@
+const test = require('node:test');
+const assert = require('node:assert');
+
+const { ValidationError } = require('../../../../src/domain/errors');
+const GenerateCourseUseCase = require('../../../../src/domain/usecases/GenerateCourseUseCase');
+
+test('throws ValidationError when userId is missing', async () => {
+  const useCase = new GenerateCourseUseCase({}, {});
+  await assert.rejects(
+    () => useCase.execute({ subject: 'Math' }),
+    ValidationError
+  );
+});
+
+test('throws ValidationError when subject is missing', async () => {
+  const useCase = new GenerateCourseUseCase({}, {});
+  await assert.rejects(
+    () => useCase.execute({ userId: 'user1' }),
+    ValidationError
+  );
+});
+
+test('generates and saves course with provided parameters', async () => {
+  const generated = 'generated content';
+  const serviceCalls = [];
+  const repoCalls = [];
+
+  const courseGenerationService = {
+    generateCourse: async (subject, vulgarization, duration, teacherType) => {
+      serviceCalls.push({ subject, vulgarization, duration, teacherType });
+      return generated;
+    }
+  };
+
+  const courseRepository = {
+    create: async data => {
+      repoCalls.push(data);
+      return { id: '1', ...data };
+    }
+  };
+
+  const useCase = new GenerateCourseUseCase(courseRepository, courseGenerationService);
+  const input = {
+    userId: 'user1',
+    subject: 'History',
+    teacherType: 'METHODICAL',
+    duration: 'SHORT',
+    vulgarization: 'GENERAL_PUBLIC'
+  };
+  const result = await useCase.execute(input);
+
+  assert.deepStrictEqual(serviceCalls, [
+    {
+      subject: 'History',
+      vulgarization: 'GENERAL_PUBLIC',
+      duration: 'SHORT',
+      teacherType: 'METHODICAL'
+    }
+  ]);
+  assert.deepStrictEqual(repoCalls, [
+    {
+      subject: 'History',
+      content: generated,
+      teacherType: 'METHODICAL',
+      duration: 'SHORT',
+      vulgarization: 'GENERAL_PUBLIC',
+      userId: 'user1'
+    }
+  ]);
+  assert.deepStrictEqual(result, {
+    id: '1',
+    subject: 'History',
+    content: generated,
+    teacherType: 'METHODICAL',
+    duration: 'SHORT',
+    vulgarization: 'GENERAL_PUBLIC',
+    userId: 'user1'
+  });
+});
+


### PR DESCRIPTION
## Summary
- add unit tests for CreateCourseUseCase and GenerateCourseUseCase
- verify validation and repository/service interactions with mocks

## Testing
- `node --test backend/tests/unit/domain/usecases/*.test.js`
- `node --test backend/tests/**/*.test.js` (fails: had to interrupt due to open handles)


------
https://chatgpt.com/codex/tasks/task_e_68a84812f5cc832584a5b84db387540b