### PR TITLE
Configure trust proxy conditionally

### DIFF
--- a/backend/src/presentation/app.js
+++ b/backend/src/presentation/app.js
@@ -15,7 +15,11 @@ const errorHandler = require('./middleware/errorHandler');
 const app = express();
 
 // Permet de faire confiance aux en-têtes du proxy (utile pour HTTPS derrière un proxy)
-app.enable('trust proxy');
+if (process.env.NODE_ENV === 'production') {
+  app.set('trust proxy', 1); // trust first proxy only
+} else {
+  app.set('trust proxy', false); // disable trust proxy in dev
+}
 
 // Redirection HTTP -> HTTPS en production
 app.use((req, res, next) => {


### PR DESCRIPTION
## Summary
- Configure Express trust proxy based on environment, trusting only the first proxy in production and disabling it in development

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a85b9442848325b250b928184228fb