### PR TITLE
Implement course retrieval and deletion

### DIFF
--- a/backend/src/infrastructure/repositories/courseRepository.js
+++ b/backend/src/infrastructure/repositories/courseRepository.js
@@ -6,6 +6,23 @@ class CourseRepository {
   async create(data) {
     return this.prisma.course.create({ data });
   }
+
+  async findById(id) {
+    return this.prisma.course.findUnique({ where: { id } });
+  }
+
+  async findAllByUserId(userId, { skip = 0, take = 10 } = {}) {
+    return this.prisma.course.findMany({
+      where: { userId },
+      orderBy: { createdAt: 'desc' },
+      skip,
+      take,
+    });
+  }
+
+  async delete(id) {
+    return this.prisma.course.delete({ where: { id } });
+  }
 }
 
 module.exports = CourseRepository;

--- a/backend/src/presentation/controllers/courseController.js
+++ b/backend/src/presentation/controllers/courseController.js
@@ -6,6 +6,59 @@ const { validateGenerateCourseDTO } = require('../../application/validators/cour
 const container = require('../../infrastructure/container');
 
 class CourseController {
+  async getAllCourses(req, res) {
+    try {
+      const page = req.query.page || 1;
+      const limit = req.query.limit || 10;
+      const skip = (page - 1) * limit;
+      const repository = container.resolve('courseRepository');
+      const courses = await repository.findAllByUserId(req.user.id, { skip, take: limit });
+      const { response, statusCode } = createResponse(true, { courses }, null, HTTP_STATUS.OK);
+      res.status(statusCode).json(response);
+    } catch (error) {
+      logger.error('Erreur récupération cours', error);
+      const { response, statusCode } = createResponse(false, null, ERROR_MESSAGES.SERVER_ERROR, HTTP_STATUS.SERVER_ERROR);
+      res.status(statusCode).json(response);
+    }
+  }
+
+  async getCourse(req, res) {
+    try {
+      const { id } = req.params;
+      const repository = container.resolve('courseRepository');
+      const course = await repository.findById(id);
+      if (!course || course.userId !== req.user.id) {
+        const { response, statusCode } = createResponse(false, null, ERROR_MESSAGES.COURSE_NOT_FOUND, HTTP_STATUS.NOT_FOUND);
+        return res.status(statusCode).json(response);
+      }
+      const { response, statusCode } = createResponse(true, { course }, null, HTTP_STATUS.OK);
+      res.status(statusCode).json(response);
+    } catch (error) {
+      logger.error('Erreur récupération cours', error);
+      const { response, statusCode } = createResponse(false, null, ERROR_MESSAGES.SERVER_ERROR, HTTP_STATUS.SERVER_ERROR);
+      res.status(statusCode).json(response);
+    }
+  }
+
+  async deleteCourse(req, res) {
+    try {
+      const { id } = req.params;
+      const repository = container.resolve('courseRepository');
+      const course = await repository.findById(id);
+      if (!course || course.userId !== req.user.id) {
+        const { response, statusCode } = createResponse(false, null, ERROR_MESSAGES.COURSE_NOT_FOUND, HTTP_STATUS.NOT_FOUND);
+        return res.status(statusCode).json(response);
+      }
+      await repository.delete(id);
+      const { response, statusCode } = createResponse(true, null, null, HTTP_STATUS.OK);
+      res.status(statusCode).json(response);
+    } catch (error) {
+      logger.error('Erreur suppression cours', error);
+      const { response, statusCode } = createResponse(false, null, ERROR_MESSAGES.SERVER_ERROR, HTTP_STATUS.SERVER_ERROR);
+      res.status(statusCode).json(response);
+    }
+  }
+
   async generateCourse(req, res) {
     try {
       const dto = new GenerateCourseDTO(req.body);
@@ -28,3 +81,4 @@ class CourseController {
 }
 
 module.exports = new CourseController();
+


### PR DESCRIPTION
## Summary
- add repository methods for fetching and deleting courses
- implement getAllCourses, getCourse, and deleteCourse controllers with createResponse-based error handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a86f6224008325b735dff1093ee022