### PR TITLE
refactor: use cors middleware

### DIFF
--- a/backend/src/config/index.js
+++ b/backend/src/config/index.js
@@ -29,8 +29,12 @@ const jwt = {
   expiresIn: requireEnv('JWT_EXPIRES_IN'),
 };
 
+const devOrigins = ['http://localhost:3000', 'http://localhost:3001'];
+const prodOrigins = ['https://app.noza.dev', 'https://api.noza.dev'];
+
 const cors = {
-  origins: requireEnv('CORS_ORIGINS').split(',').map((o) => o.trim()),
+  origins: nodeEnv === 'development' ? devOrigins : [...devOrigins, ...prodOrigins],
+  credentials: true,
 };
 
 const api = {


### PR DESCRIPTION
## Summary
- replace manual CORS headers with `cors` middleware
- centralize allowed origins in config and enable credentials only for whitelisted origins

## Testing
- `npm test` *(fails: Cannot find module 'sanitize-html', '@prisma/client')*
- `npm install --prefix backend` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a887a4bb888325a87476610d0a9e30