### PR TITLE
feat: support configurable API URL

### DIFF
--- a/frontend/app/assets/js/config.js
+++ b/frontend/app/assets/js/config.js
@@ -13,31 +13,32 @@ window.APP_CONFIG = {
 };
 
 // Configuration de l'API
-window.API_BASE_URL = 'https://noza-app-staging.up.railway.app/api';
+const API_URL = window.ENV?.API_URL || '/api';
+window.API_BASE_URL = API_URL;
 
 // Configuration des endpoints
 window.ENDPOINTS = {
   auth: {
-    login: '/auth/login',
-    register: '/auth/register',
-    logout: '/auth/logout',
-    profile: '/auth/profile',
-    google: '/auth/google'
+    login: `${API_URL}/auth/login`,
+    register: `${API_URL}/auth/register`,
+    logout: `${API_URL}/auth/logout`,
+    profile: `${API_URL}/auth/profile`,
+    google: `${API_URL}/auth/google`
   },
   onboarding: {
-    config: '/onboarding/config',
-    complete: '/onboarding/complete',
-    status: '/onboarding/status',
-    profile: '/onboarding/profile'
+    config: `${API_URL}/onboarding/config`,
+    complete: `${API_URL}/onboarding/complete`,
+    status: `${API_URL}/onboarding/status`,
+    profile: `${API_URL}/onboarding/profile`
   },
   courses: {
-    create: '/courses',
-    list: '/courses',
-    details: '/courses'
+    create: `${API_URL}/courses`,
+    list: `${API_URL}/courses`,
+    details: `${API_URL}/courses`
   },
   ai: {
-    generate: '/ai/generate',
-    quiz: '/ai/quiz'
+    generate: `${API_URL}/ai/generate`,
+    quiz: `${API_URL}/ai/quiz`
   }
 };
 

--- a/frontend/app/assets/js/utils/utils.js
+++ b/frontend/app/assets/js/utils/utils.js
@@ -3,7 +3,7 @@
 import { sanitizeInput, sanitizeHTML } from '../shared/sanitize.js'; // Shared sanitization logic
 
 // Configuration API
-const API_BASE_URL = window.location.origin + '/api';
+const API_BASE_URL = window.ENV?.API_URL || '/api';
 
 // Libellés conviviaux pour les codes d'erreur
 const ERROR_LABELS = {

--- a/frontend/public/env.js
+++ b/frontend/public/env.js
@@ -1,0 +1,3 @@
+window.ENV = {
+  API_URL: '/api'
+};

--- a/frontend/scripts/generate-env.js
+++ b/frontend/scripts/generate-env.js
@@ -1,0 +1,11 @@
+const fs = require('fs');
+const path = require('path');
+
+const apiUrl = process.env.API_URL || '/api';
+const content = `window.ENV = {\n  API_URL: '${apiUrl}'\n};\n`;
+
+const publicDir = path.join(__dirname, '..', 'public');
+fs.mkdirSync(publicDir, { recursive: true });
+fs.writeFileSync(path.join(publicDir, 'env.js'), content);
+
+console.log(`Generated env.js with API_URL=${apiUrl}`);

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
+    "prebuild": "node frontend/scripts/generate-env.js",
     "build": "npm install --prefix backend",
     "start": "npm start --prefix backend",
     "test": "node --test frontend/tests/*.js backend/tests/**/*.js"


### PR DESCRIPTION
## Summary
- derive API endpoints from configurable API_URL
- generate env.js from environment variables
- run env generation before build

## Testing
- `npm test` *(fails: Cannot find module 'sanitize-html', '@prisma/client', 'supertest')*


------
https://chatgpt.com/codex/tasks/task_e_68a88907b5d8832587fb3576518af220