### PR TITLE
docs: add backend env example

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,18 +1,38 @@
-# Example environment configuration for Noza backend
-NODE_ENV=development
+# Server port
 PORT=3000
+
+# Node environment: development, production, test
+NODE_ENV=development
+
+# Port for HTTPS server
 HTTPS_PORT=3443
 
-DATABASE_URL="postgresql://USER:PASSWORD@HOST:5432/DATABASE"
-JWT_SECRET="replace_with_32_char_secret"
-JWT_EXPIRES_IN="7d"
+# Database connection URL
+DATABASE_URL=postgresql://user:pass@localhost:5432/noza
 
-# Set to 'true' to allow HTTP in production (not recommended)
-# ALLOW_HTTP=true
+# Secret used to sign JWT tokens
+JWT_SECRET=change-me
 
-# Paths to TLS certificate and key (required in production without ALLOW_HTTP)
-# TLS_CERT_PATH=/path/to/cert.pem
-# TLS_KEY_PATH=/path/to/key.pem
+# JWT expiration (e.g., 7d, 1h)
+JWT_EXPIRES_IN=7d
 
-# Optional API keys
-# ANTHROPIC_API_KEY=
+# Allowed CORS origins (comma separated)
+CORS_ORIGINS=http://localhost:3000,http://localhost:3001
+
+# Google OAuth client ID
+GOOGLE_CLIENT_ID=...
+
+# Anthropic API key
+ANTHROPIC_API_KEY=...
+
+# Path to TLS certificate (required in production when ALLOW_HTTP=false)
+TLS_CERT_PATH=./cert.pem
+
+# Path to TLS key (required in production when ALLOW_HTTP=false)
+TLS_KEY_PATH=./key.pem
+
+# Whether to allow HTTP (set false in production)
+ALLOW_HTTP=false
+
+# Redis connection URL
+REDIS_URL=redis://localhost:6379


### PR DESCRIPTION
## Summary
- document all backend environment variables with sample values in `.env.example`

## Testing
- `npm test` (fails: Missing script: "test")

------
https://chatgpt.com/codex/tasks/task_e_68a88bd913788325ad3cda06b07097af