### PR TITLE
chore: optimize marketing and app HTML loading

### DIFF
--- a/frontend/app/index.html
+++ b/frontend/app/index.html
@@ -4,6 +4,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Skillence AI - Application</title>
+    <link rel="preconnect" href="https://unpkg.com">
+    <link rel="preconnect" href="https://accounts.google.com">
     <link rel="stylesheet" href="assets/css/app.css">
 </head>
 <body>
@@ -179,14 +181,14 @@
         </div>
     </div>
 
-    <script type="module" src="assets/js/onboarding-manager.js"></script>
-    <script src="assets/js/auth-check.js"></script>
-    <script type="module" src="assets/js/app-init.js"></script>
-    <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.js"></script>
-    <script type="module" src="assets/js/utils/utils.js"></script>
-    <script src="assets/js/googleAuth.js"></script>
-    <script type="module" src="assets/js/auth.js"></script>
-    <script type="module" src="assets/js/course-manager.js"></script>
-    <script type="module" src="assets/js/main.js"></script>
+    <script type="module" src="assets/js/onboarding-manager.js" defer></script>
+    <script src="assets/js/auth-check.js" defer></script>
+    <script type="module" src="assets/js/app-init.js" defer></script>
+    <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.js" defer></script>
+    <script type="module" src="assets/js/utils/utils.js" defer></script>
+    <script src="assets/js/googleAuth.js" defer></script>
+    <script type="module" src="assets/js/auth.js" defer></script>
+    <script type="module" src="assets/js/course-manager.js" defer></script>
+    <script type="module" src="assets/js/main.js" defer></script>
 </body>
 </html>

--- a/frontend/app/onboarding.html
+++ b/frontend/app/onboarding.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Onboarding</title>
+  <link rel="preconnect" href="https://accounts.google.com">
   <link rel="stylesheet" href="assets/css/app.css">
   <style>
     .container {
@@ -82,9 +83,9 @@
   </div>
 
   <script src="assets/js/config.js"></script>
-  <script type="module" src="assets/js/utils/utils.js"></script>
-  <script type="module" src="assets/js/auth.js"></script>
-  <script type="module" src="assets/js/onboarding-manager.js"></script>
+  <script type="module" src="assets/js/utils/utils.js" defer></script>
+  <script type="module" src="assets/js/auth.js" defer></script>
+  <script type="module" src="assets/js/onboarding-manager.js" defer></script>
 <script>
 document.addEventListener('DOMContentLoaded', async () => {
   // Vérifier l'authentification avant tout

--- a/frontend/marketing/auth.html
+++ b/frontend/marketing/auth.html
@@ -4,8 +4,12 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Skillence AI - Le savoir accessible à tous</title>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="preconnect" href="https://unpkg.com">
     <link rel="preconnect" href="https://accounts.google.com">
+    <link rel="preload" as="font" href="https://fonts.gstatic.com/s/inter/v12/UcCO3FwrK1riP4H1q5xRhA.woff2" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="assets/css/marketing.css">
 </head>
 <body>
@@ -105,14 +109,16 @@
     </div>
 
     <!-- Scripts - Dans l'ordre de dépendance -->
-    <script src="assets/js/auth-check.js"></script>
-    <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.js"></script>
-    <script type="module" src="assets/js/navigation.js"></script>
+    <script src="assets/js/auth-check.js" defer></script>
+    <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.js" defer></script>
+    <script type="module" src="assets/js/navigation.js" defer></script>
+    <script type="module" src="assets/js/utils.js" defer></script>
+    <script src="assets/js/googleAuth.js" defer></script>
+    <script type="module" src="assets/js/auth.js" defer></script>
     <script>
-        lucide.createIcons();
+        document.addEventListener('DOMContentLoaded', () => {
+            lucide.createIcons();
+        });
     </script>
-    <script type="module" src="assets/js/utils.js"></script>
-    <script src="assets/js/googleAuth.js"></script>
-    <script type="module" src="assets/js/auth.js"></script>
 </body>
 </html>

--- a/frontend/marketing/contact.html
+++ b/frontend/marketing/contact.html
@@ -4,6 +4,10 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Skillence AI - Contact</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="preconnect" href="https://unpkg.com">
+    <link rel="preload" as="font" href="https://fonts.gstatic.com/s/inter/v12/UcCO3FwrK1riP4H1q5xRhA.woff2" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="assets/css/marketing.css">
 </head>
@@ -35,13 +39,15 @@
         </main>
     </div>
 
-    <script src="assets/js/auth-check.js"></script>
-    <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.js"></script>
-    <script type="module" src="assets/js/navigation.js"></script>
+    <script src="assets/js/auth-check.js" defer></script>
+    <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.js" defer></script>
+    <script type="module" src="assets/js/navigation.js" defer></script>
+    <script type="module" src="assets/js/utils.js" defer></script>
     <script>
-        lucide.createIcons();
+        document.addEventListener('DOMContentLoaded', () => {
+            lucide.createIcons();
+        });
     </script>
-    <script type="module" src="assets/js/utils.js"></script>
 </body>
 </html>
 

--- a/frontend/marketing/index.html
+++ b/frontend/marketing/index.html
@@ -4,8 +4,12 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Skillence AI - Accueil</title>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="preconnect" href="https://unpkg.com">
     <link rel="preconnect" href="https://accounts.google.com">
+    <link rel="preload" as="font" href="https://fonts.gstatic.com/s/inter/v12/UcCO3FwrK1riP4H1q5xRhA.woff2" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="assets/css/marketing.css">
 </head>
 <body>
@@ -44,12 +48,14 @@
         </main>
     </div>
 
-    <script src="assets/js/auth-check.js"></script>
-    <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.js"></script>
-    <script type="module" src="assets/js/navigation.js"></script>
+    <script src="assets/js/auth-check.js" defer></script>
+    <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.js" defer></script>
+    <script type="module" src="assets/js/navigation.js" defer></script>
+    <script type="module" src="assets/js/utils.js" defer></script>
     <script>
-        lucide.createIcons();
+        document.addEventListener('DOMContentLoaded', () => {
+            lucide.createIcons();
+        });
     </script>
-    <script type="module" src="assets/js/utils.js"></script>
 </body>
 </html>

--- a/frontend/marketing/solutions.html
+++ b/frontend/marketing/solutions.html
@@ -4,6 +4,10 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Skillence AI - Solutions</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="preconnect" href="https://unpkg.com">
+    <link rel="preload" as="font" href="https://fonts.gstatic.com/s/inter/v12/UcCO3FwrK1riP4H1q5xRhA.woff2" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="assets/css/marketing.css">
 </head>
@@ -35,13 +39,15 @@
         </main>
     </div>
 
-    <script src="assets/js/auth-check.js"></script>
-    <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.js"></script>
-    <script type="module" src="assets/js/navigation.js"></script>
+    <script src="assets/js/auth-check.js" defer></script>
+    <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.js" defer></script>
+    <script type="module" src="assets/js/navigation.js" defer></script>
+    <script type="module" src="assets/js/utils.js" defer></script>
     <script>
-        lucide.createIcons();
+        document.addEventListener('DOMContentLoaded', () => {
+            lucide.createIcons();
+        });
     </script>
-    <script type="module" src="assets/js/utils.js"></script>
 </body>
 </html>
 

--- a/frontend/marketing/tarifs.html
+++ b/frontend/marketing/tarifs.html
@@ -4,6 +4,10 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Skillence AI - Tarifs</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="preconnect" href="https://unpkg.com">
+    <link rel="preload" as="font" href="https://fonts.gstatic.com/s/inter/v12/UcCO3FwrK1riP4H1q5xRhA.woff2" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="assets/css/marketing.css">
 </head>
@@ -35,13 +39,15 @@
         </main>
     </div>
 
-    <script src="assets/js/auth-check.js"></script>
-    <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.js"></script>
-    <script type="module" src="assets/js/navigation.js"></script>
+    <script src="assets/js/auth-check.js" defer></script>
+    <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.js" defer></script>
+    <script type="module" src="assets/js/navigation.js" defer></script>
+    <script type="module" src="assets/js/utils.js" defer></script>
     <script>
-        lucide.createIcons();
+        document.addEventListener('DOMContentLoaded', () => {
+            lucide.createIcons();
+        });
     </script>
-    <script type="module" src="assets/js/utils.js"></script>
 </body>
 </html>
 


### PR DESCRIPTION
## Summary
- defer script loading across app and marketing pages
- preconnect to external domains and preload Inter fonts
- preserve inline script execution order with DOMContentLoaded wrappers

## Testing
- `npm test` *(fails: Cannot find module 'sanitize-html')*


------
https://chatgpt.com/codex/tasks/task_e_68a8902690a883258c57abee8dd51178