### PR TITLE
Add cache control middleware with ETag support

### DIFF
--- a/backend/src/infrastructure/middleware/cacheControl.js
+++ b/backend/src/infrastructure/middleware/cacheControl.js
@@ -1,0 +1,36 @@
+// backend/src/infrastructure/middleware/cacheControl.js
+const { createHash } = require('crypto');
+
+const STATIC_ASSET_REGEX = /\.(?:js|css|png|jpe?g|gif|svg|ico|woff2?|ttf)$/i;
+
+module.exports = (req, res, next) => {
+  if (STATIC_ASSET_REGEX.test(req.url)) {
+    res.set('Cache-Control', 'public, max-age=31536000, immutable');
+    return next();
+  }
+
+  if (req.path.startsWith('/api')) {
+    res.set('Cache-Control', 'private, max-age=0, must-revalidate');
+  }
+
+  const originalJson = res.json.bind(res);
+
+  res.json = (body) => {
+    try {
+      const jsonString = JSON.stringify(body);
+      const etag = createHash('md5').update(jsonString).digest('hex');
+      res.set('ETag', etag);
+
+      if (req.headers['if-none-match'] === etag) {
+        return res.status(304).end();
+      }
+    } catch (err) {
+      // If hashing fails, continue without ETag
+    }
+
+    return originalJson(body);
+  };
+
+  next();
+};
+

--- a/backend/src/presentation/app.js
+++ b/backend/src/presentation/app.js
@@ -6,6 +6,7 @@ const path = require('path');
 const cookieParser = require('cookie-parser');
 const cors = require('cors');
 const compression = require('../infrastructure/middleware/compression');
+const cacheControl = require('../infrastructure/middleware/cacheControl');
 const { connectDatabase } = require('../infrastructure/database');
 const { logger } = require('../infrastructure/utils/helpers');
 const { LIMITS } = require('../infrastructure/utils/constants');
@@ -143,6 +144,7 @@ app.use((_, res, next) => {
 
 // Compression
 app.use(compression);
+app.use(cacheControl);
 
 // Servir les fichiers statiques pour l'application et le marketing
 app.use('/app', express.static(path.join(__dirname, '../../../frontend/app')));


### PR DESCRIPTION
## Summary
- add middleware to handle Cache-Control headers and ETag generation for JSON responses
- apply cache control middleware globally in express app

## Testing
- `npm test` *(fails: 8 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68a896e35f448325b6a7506456e8e708