### PR TITLE
feat: add LRU cache utility

### DIFF
--- a/frontend/app/assets/js/utils/cache.js
+++ b/frontend/app/assets/js/utils/cache.js
@@ -1,0 +1,89 @@
+// frontend/app/assets/js/utils/cache.js
+// Simple LRU cache with per-entry TTL and JSON serialization.
+//
+// Usage:
+//   import { LRUCache } from './cache.js';
+//   const cache = new LRUCache();
+//   cache.set('user', { name: 'Ada' }, { ttl: 1000 }); // ttl in milliseconds
+//   const user = cache.get('user'); // -> { name: 'Ada' }
+
+export class LRUCache {
+  constructor(maxEntries = 50) {
+    this.maxEntries = maxEntries;
+    this.map = new Map();
+  }
+
+  _isExpired(entry) {
+    return entry.expiresAt !== Infinity && Date.now() > entry.expiresAt;
+  }
+
+  _serialize(value) {
+    return JSON.stringify(value);
+  }
+
+  _deserialize(value) {
+    try {
+      return JSON.parse(value);
+    } catch {
+      return undefined;
+    }
+  }
+
+  set(key, value, { ttl } = {}) {
+    const expiresAt = typeof ttl === 'number' ? Date.now() + ttl : Infinity;
+    const serialized = this._serialize(value);
+
+    if (this.map.has(key)) {
+      this.map.delete(key); // maintain LRU order
+    }
+    this.map.set(key, { value: serialized, expiresAt });
+
+    this._evict();
+  }
+
+  get(key) {
+    const entry = this.map.get(key);
+    if (!entry) return undefined;
+
+    if (this._isExpired(entry)) {
+      this.map.delete(key);
+      return undefined;
+    }
+
+    // Move to end to mark as recently used
+    this.map.delete(key);
+    this.map.set(key, entry);
+
+    return this._deserialize(entry.value);
+  }
+
+  has(key) {
+    const entry = this.map.get(key);
+    if (!entry) return false;
+    if (this._isExpired(entry)) {
+      this.map.delete(key);
+      return false;
+    }
+    return true;
+  }
+
+  clear() {
+    this.map.clear();
+  }
+
+  _evict() {
+    // Remove expired entries first
+    for (const [key, entry] of this.map) {
+      if (this._isExpired(entry)) {
+        this.map.delete(key);
+      }
+    }
+    // Evict least-recently-used items when capacity exceeded
+    while (this.map.size > this.maxEntries) {
+      const oldestKey = this.map.keys().next().value;
+      this.map.delete(oldestKey);
+    }
+  }
+}
+
+export default LRUCache;

--- a/frontend/tests/cache.test.js
+++ b/frontend/tests/cache.test.js
@@ -1,0 +1,30 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const load = () => import('../app/assets/js/utils/cache.js');
+
+test('stores and retrieves serialized values', async () => {
+  const { LRUCache } = await load();
+  const cache = new LRUCache();
+  cache.set('a', { foo: 'bar' }, { ttl: 1000 });
+  assert.deepEqual(cache.get('a'), { foo: 'bar' });
+});
+
+test('evicts least recently used entries', async () => {
+  const { LRUCache } = await load();
+  const cache = new LRUCache(2);
+  cache.set('a', 1, { ttl: 1000 });
+  cache.set('b', 2, { ttl: 1000 });
+  cache.get('a'); // mark 'a' as recently used
+  cache.set('c', 3, { ttl: 1000 });
+  assert.strictEqual(cache.has('b'), false);
+  assert.strictEqual(cache.has('a'), true);
+});
+
+test('expires entries based on TTL', async () => {
+  const { LRUCache } = await load();
+  const cache = new LRUCache();
+  cache.set('a', 1, { ttl: 10 });
+  await new Promise(r => setTimeout(r, 20));
+  assert.strictEqual(cache.get('a'), undefined);
+});


### PR DESCRIPTION
## Summary
- add reusable LRU cache with per-entry TTL and JSON serialization
- test LRU cache behavior including expiration and eviction

## Testing
- `node --test frontend/tests/*.js`
- `npm test` *(fails: Cannot find module 'sanitize-html', '@prisma/client'; install attempt blocked with E403)*

------
https://chatgpt.com/codex/tasks/task_e_68a89a6ab8b48325b89ada9c5fd01dc2