### PR TITLE
feat: optimize prisma queries

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -75,14 +75,15 @@ model Course {
   
   duration           String
   createdAt          DateTime @default(now())
-  
+  deletedAt          DateTime?
+
   userId             String
   user               User     @relation(fields: [userId], references: [id], onDelete: Cascade)
   
   chatHistories      ChatHistory[]
   quizzes           Quiz[]
   @@map("courses")
-  @@index([userId, createdAt])
+  @@index([userId, createdAt, deletedAt])
 }
 
 model ChatHistory {

--- a/backend/src/domain/entities/Course.js
+++ b/backend/src/domain/entities/Course.js
@@ -1,10 +1,11 @@
 class Course {
-  constructor({ id, subject, content, userId, createdAt }) {
+  constructor({ id, subject, content, userId, createdAt, deletedAt = null }) {
     this.id = id;
     this.subject = subject;
     this.content = content;
     this.userId = userId;
     this.createdAt = createdAt;
+    this.deletedAt = deletedAt;
   }
 }
 

--- a/backend/src/infrastructure/database/PrismaCourseRepository.js
+++ b/backend/src/infrastructure/database/PrismaCourseRepository.js
@@ -5,31 +5,54 @@ const { toDomain, toPersistence } = require('./mappers/courseMapper');
 class PrismaCourseRepository extends ICourseRepository {
   async create(courseData) {
     const data = toPersistence(courseData);
-    const created = await prisma.course.create({ data });
+    const created = await prisma.course.create({
+      data,
+      select: { id: true, subject: true, createdAt: true },
+    });
     return toDomain(created);
   }
 
   async findById(id) {
-    const course = await prisma.course.findUnique({ where: { id } });
+    const course = await prisma.course.findUnique({
+      where: { id, deletedAt: null },
+      include: { quizzes: true },
+    });
     return toDomain(course);
   }
 
-  async findAllByUserId(userId) {
+  async findAllByUserId(userId, options = {}) {
+    const { cursor, limit = 20, include = {} } = options;
     const courses = await prisma.course.findMany({
-      where: { userId },
+      where: { userId, deletedAt: null },
+      select: {
+        id: true,
+        subject: true,
+        createdAt: true,
+        _count: { select: { quizzes: true } },
+        ...include,
+      },
       orderBy: { createdAt: 'desc' },
+      take: limit + 1,
+      ...(cursor && { cursor: { id: cursor } }),
     });
     return courses.map(toDomain);
   }
 
   async update(id, updateData) {
     const data = toPersistence(updateData);
-    const updated = await prisma.course.update({ where: { id }, data });
+    const updated = await prisma.course.update({
+      where: { id },
+      data,
+      select: { id: true, subject: true, createdAt: true },
+    });
     return toDomain(updated);
   }
 
   async delete(id) {
-    await prisma.course.delete({ where: { id } });
+    await prisma.course.update({
+      where: { id },
+      data: { deletedAt: new Date() },
+    });
   }
 }
 

--- a/backend/src/infrastructure/database/index.js
+++ b/backend/src/infrastructure/database/index.js
@@ -1,16 +1,23 @@
 // backend/src/infrastructure/database/index.js
 const { PrismaClient } = require('@prisma/client');
 const { logger } = require('../utils/helpers');
+const { attachQueryOptimizers } = require('./queryOptimizer');
 const { app: appConfig, database: dbConfig } = require('../../config');
+
+const dbUrl = new URL(dbConfig.url);
+dbUrl.searchParams.set('connection_limit', dbUrl.searchParams.get('connection_limit') || '10');
+dbUrl.searchParams.set('pool_timeout', dbUrl.searchParams.get('pool_timeout') || '30');
 
 const prisma = new PrismaClient({
   log: appConfig.env === 'development' ? ['query', 'info', 'warn', 'error'] : ['error'],
   datasources: {
     db: {
-      url: dbConfig.url,
+      url: dbUrl.toString(),
     },
   },
 });
+
+attachQueryOptimizers(prisma);
 
 // Test de connexion au démarrage
 async function connectDatabase() {

--- a/backend/src/infrastructure/database/mappers/courseMapper.js
+++ b/backend/src/infrastructure/database/mappers/courseMapper.js
@@ -8,6 +8,7 @@ function toDomain(persistenceCourse) {
     content: persistenceCourse.content,
     userId: persistenceCourse.userId,
     createdAt: persistenceCourse.createdAt,
+    deletedAt: persistenceCourse.deletedAt,
   });
 }
 
@@ -26,6 +27,7 @@ function toPersistence(domainCourse) {
     vulgarization: domainCourse.vulgarization,
     teacherType: domainCourse.teacherType,
     createdAt: domainCourse.createdAt,
+    deletedAt: domainCourse.deletedAt,
   };
   Object.keys(persistence).forEach(
     (key) => persistence[key] === undefined && delete persistence[key]

--- a/backend/src/infrastructure/database/queryOptimizer.js
+++ b/backend/src/infrastructure/database/queryOptimizer.js
@@ -1,0 +1,33 @@
+const { logger } = require('../utils/helpers');
+
+const MAX_RETRIES = 3;
+const SLOW_QUERY_THRESHOLD = 100; // ms
+
+function attachQueryOptimizers(prisma) {
+  prisma.$use(async (params, next) => {
+    const start = Date.now();
+    let attempt = 0;
+
+    while (true) {
+      try {
+        const result = await next(params);
+        const duration = Date.now() - start;
+        if (duration > SLOW_QUERY_THRESHOLD) {
+          logger.warn(`Slow query (${duration}ms) on ${params.model}.${params.action}`);
+        }
+        return result;
+      } catch (err) {
+        const isDeadlock = err.code === 'P2034' || (err.message && err.message.toLowerCase().includes('deadlock'));
+        if (isDeadlock && attempt < MAX_RETRIES) {
+          attempt += 1;
+          logger.warn(`Deadlock detected, retrying ${attempt}/${MAX_RETRIES}`);
+          await new Promise(res => setTimeout(res, 50 * attempt));
+          continue;
+        }
+        throw err;
+      }
+    }
+  });
+}
+
+module.exports = { attachQueryOptimizers };

--- a/backend/src/infrastructure/repositories/courseRepository.js
+++ b/backend/src/infrastructure/repositories/courseRepository.js
@@ -4,24 +4,45 @@ class CourseRepository {
   }
 
   async create(data) {
-    return this.prisma.course.create({ data });
+    return this.prisma.course.create({
+      data,
+      select: {
+        id: true,
+        subject: true,
+        createdAt: true,
+      },
+    });
   }
 
   async findById(id) {
-    return this.prisma.course.findUnique({ where: { id } });
+    return this.prisma.course.findUnique({
+      where: { id, deletedAt: null },
+      include: { quizzes: true },
+    });
   }
 
-  async findAllByUserId(userId, { skip = 0, take = 10 } = {}) {
+  async findAllByUserId(userId, options = {}) {
+    const { cursor, limit = 20, include = {} } = options;
     return this.prisma.course.findMany({
-      where: { userId },
+      where: { userId, deletedAt: null },
+      select: {
+        id: true,
+        subject: true,
+        createdAt: true,
+        _count: { select: { quizzes: true } },
+        ...include,
+      },
       orderBy: { createdAt: 'desc' },
-      skip,
-      take,
+      take: limit + 1,
+      ...(cursor && { cursor: { id: cursor } }),
     });
   }
 
   async delete(id) {
-    return this.prisma.course.delete({ where: { id } });
+    return this.prisma.course.update({
+      where: { id },
+      data: { deletedAt: new Date() },
+    });
   }
 }
 


### PR DESCRIPTION
## Summary
- optimize course repository with pagination, select/include and soft delete
- add prisma middleware for slow query logging and deadlock retry
- tune connection pooling and add deletedAt field to course schema

## Testing
- `npm test` *(fails: Cannot find module 'sanitize-html')*

------
https://chatgpt.com/codex/tasks/task_e_68a8a1b795388325a0a29c063102cc09