### PR TITLE
fix: remove unused font preload tags

### DIFF
--- a/frontend/marketing/auth.html
+++ b/frontend/marketing/auth.html
@@ -8,7 +8,6 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link rel="preconnect" href="https://unpkg.com">
     <link rel="preconnect" href="https://accounts.google.com">
-    <link rel="preload" as="font" href="https://fonts.gstatic.com/s/inter/v12/UcCO3FwrK1riP4H1q5xRhA.woff2" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="assets/css/marketing.css">
 </head>

--- a/frontend/marketing/contact.html
+++ b/frontend/marketing/contact.html
@@ -7,7 +7,6 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link rel="preconnect" href="https://unpkg.com">
-    <link rel="preload" as="font" href="https://fonts.gstatic.com/s/inter/v12/UcCO3FwrK1riP4H1q5xRhA.woff2" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="assets/css/marketing.css">
 </head>

--- a/frontend/marketing/index.html
+++ b/frontend/marketing/index.html
@@ -8,7 +8,6 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link rel="preconnect" href="https://unpkg.com">
     <link rel="preconnect" href="https://accounts.google.com">
-    <link rel="preload" as="font" href="https://fonts.gstatic.com/s/inter/v12/UcCO3FwrK1riP4H1q5xRhA.woff2" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="assets/css/marketing.css">
 </head>

--- a/frontend/marketing/solutions.html
+++ b/frontend/marketing/solutions.html
@@ -7,7 +7,6 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link rel="preconnect" href="https://unpkg.com">
-    <link rel="preload" as="font" href="https://fonts.gstatic.com/s/inter/v12/UcCO3FwrK1riP4H1q5xRhA.woff2" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="assets/css/marketing.css">
 </head>

--- a/frontend/marketing/tarifs.html
+++ b/frontend/marketing/tarifs.html
@@ -7,7 +7,6 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link rel="preconnect" href="https://unpkg.com">
-    <link rel="preload" as="font" href="https://fonts.gstatic.com/s/inter/v12/UcCO3FwrK1riP4H1q5xRhA.woff2" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="assets/css/marketing.css">
 </head>


### PR DESCRIPTION
## Summary
- remove unused font preload tag from marketing pages

## Testing
- `npm test` *(fails: Cannot find module 'sanitize-html')*
- `python3 -m http.server 8080 -d frontend/marketing >/tmp/pyserver.log 2>&1 &; SERVER_PID=$!; sleep 1; for page in index.html solutions.html auth.html contact.html tarifs.html; do echo "Checking $page"; curl -s http://localhost:8080/$page | grep 'preload' || echo 'No preload'; done; kill $SERVER_PID`

------
https://chatgpt.com/codex/tasks/task_e_68a8a413edc883258b75bbbc2542dc1e