### PR TITLE
chore: add Vite frontend build process

### DIFF
--- a/frontend/app/index.html
+++ b/frontend/app/index.html
@@ -184,14 +184,8 @@
         </div>
     </div>
 
-    <script type="module" src="assets/js/onboarding-manager.js" defer></script>
-    <script src="assets/js/auth-check.js" defer></script>
-    <script type="module" src="assets/js/app-init.js" defer></script>
+    <script src="/env.js"></script>
     <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.js" defer></script>
-    <script type="module" src="assets/js/utils/utils.js" defer></script>
-    <script src="assets/js/googleAuth.js" defer></script>
-    <script type="module" src="assets/js/auth.js" defer></script>
-    <script type="module" src="assets/js/course-manager.js" defer></script>
-    <script type="module" src="assets/js/main.js" defer></script>
+    <script type="module" src="/src/main.js"></script>
 </body>
 </html>

--- a/frontend/app/onboarding.html
+++ b/frontend/app/onboarding.html
@@ -20,10 +20,9 @@
     <form id="onboardingForm" class="onboarding-form" style="display:none;"></form>
   </div>
 
-  <script src="assets/js/config.js"></script>
-  <script type="module" src="assets/js/utils/utils.js" defer></script>
-  <script type="module" src="assets/js/auth.js" defer></script>
-  <script type="module" src="assets/js/onboarding-manager.js" defer></script>
+  <script src="/env.js"></script>
+  <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.js" defer></script>
+  <script type="module" src="/src/main.js"></script>
 <script>
 document.addEventListener('DOMContentLoaded', async () => {
   // Vérifier l'authentification avant tout

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "noza-frontend",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "devDependencies": {
+    "vite": "^5.0.0"
+  }
+}

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1,0 +1,9 @@
+import '../app/assets/js/config.js';
+import '../app/assets/js/onboarding-manager.js';
+import '../app/assets/js/auth-check.js';
+import '../app/assets/js/app-init.js';
+import '../app/assets/js/utils/utils.js';
+import '../app/assets/js/googleAuth.js';
+import '../app/assets/js/auth.js';
+import '../app/assets/js/course-manager.js';
+import '../app/assets/js/main.js';

--- a/frontend/tests/build-output.test.js
+++ b/frontend/tests/build-output.test.js
@@ -1,0 +1,28 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { execSync } = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+
+test('Vite build generates hashed asset references', () => {
+  execSync('node frontend/scripts/generate-env.js');
+  execSync('npm --prefix frontend run build', { stdio: 'ignore' });
+  const distDir = path.join(__dirname, '..', 'dist');
+  const indexPathCandidate1 = path.join(distDir, 'app', 'index.html');
+  const indexPath = fs.existsSync(indexPathCandidate1) ? indexPathCandidate1 : path.join(distDir, 'index.html');
+  const html = fs.readFileSync(indexPath, 'utf-8');
+
+  const scriptMatch = html.match(/src="(\.\/)?assets\/(.+?\.js)"/);
+  assert.ok(scriptMatch, 'index.html should reference a script asset');
+  const scriptRel = ((scriptMatch[1] || '') + 'assets/' + scriptMatch[2]).replace(/^\.\//, '');
+  const scriptFile = path.join(path.dirname(indexPath), scriptRel);
+  assert.ok(/-[a-f0-9]{8}\.js$/.test(scriptFile), 'script filename should contain hash');
+  assert.ok(fs.existsSync(scriptFile), 'script file should exist');
+
+  const cssMatch = html.match(/href="(\.\/)?assets\/(.+?\.css)"/);
+  assert.ok(cssMatch, 'index.html should reference a css asset');
+  const cssRel = ((cssMatch[1] || '') + 'assets/' + cssMatch[2]).replace(/^\.\//, '');
+  const cssFile = path.join(path.dirname(indexPath), cssRel);
+  assert.ok(/-[a-f0-9]{8}\.css$/.test(cssFile), 'css filename should contain hash');
+  assert.ok(fs.existsSync(cssFile), 'css file should exist');
+});

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,21 @@
+import { defineConfig } from 'vite';
+import { resolve } from 'path';
+
+export default defineConfig({
+  build: {
+    outDir: 'dist',
+    emptyOutDir: true,
+    rollupOptions: {
+      input: {
+        app: resolve(__dirname, 'app/index.html'),
+        onboarding: resolve(__dirname, 'app/onboarding.html')
+      },
+      output: {
+        entryFileNames: 'assets/[name]-[hash].js',
+        chunkFileNames: 'assets/[name]-[hash].js',
+        assetFileNames: 'assets/[name]-[hash][extname]'
+      }
+    },
+    minify: true
+  }
+});

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "prebuild": "node frontend/scripts/generate-env.js",
-    "build": "npm install --prefix backend",
+    "build": "npm --prefix frontend run build && npm install --prefix backend",
     "start": "npm start --prefix backend",
     "test": "node --test frontend/tests/*.js backend/tests/**/*.js"
   },


### PR DESCRIPTION
## Summary
- configure Vite for hashed builds and minification
- add frontend package with Vite scripts
- update HTML to load Vite assets via a single entry
- run frontend build during project build and test hashed output

## Testing
- `npm test` *(fails: Cannot find module 'sanitize-html')*


------
https://chatgpt.com/codex/tasks/task_e_68a97b7a74208325929ce171043a8cb0