### PR TITLE
Load Inter font asynchronously with limited weights

### DIFF
--- a/frontend/app/index.html
+++ b/frontend/app/index.html
@@ -8,7 +8,19 @@
     <link rel="preconnect" href="https://accounts.google.com">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="dns-prefetch" href="https://fonts.googleapis.com">
+    <link rel="dns-prefetch" href="https://fonts.gstatic.com">
+    <script>
+      const inter = document.createElement('link');
+      inter.rel = 'stylesheet';
+      inter.href = 'https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap';
+      inter.media = 'print';
+      inter.onload = () => { inter.media = 'all'; };
+      document.head.appendChild(inter);
+    </script>
+    <noscript>
+      <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap">
+    </noscript>
     <link rel="stylesheet" href="assets/css/app.css">
 </head>
 <body>

--- a/frontend/app/onboarding.html
+++ b/frontend/app/onboarding.html
@@ -7,7 +7,19 @@
   <link rel="preconnect" href="https://accounts.google.com">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="dns-prefetch" href="https://fonts.googleapis.com">
+  <link rel="dns-prefetch" href="https://fonts.gstatic.com">
+  <script>
+    const inter = document.createElement('link');
+    inter.rel = 'stylesheet';
+    inter.href = 'https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap';
+    inter.media = 'print';
+    inter.onload = () => { inter.media = 'all'; };
+    document.head.appendChild(inter);
+  </script>
+  <noscript>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap">
+  </noscript>
   <link rel="stylesheet" href="assets/css/app.css">
     <style>.container{max-width:700px;margin:40px auto;background:#fff;padding:30px;border-radius:15px;box-shadow:0 6px 16px rgba(0,0,0,0.15)}.question-field{display:flex;flex-direction:column;gap:8px;margin-bottom:20px}.question-field label{font-weight:600;font-size:1rem;color:#2d3748}.question-field input,.question-field select,.question-field textarea{width:100%;padding:12px 16px;border:1px solid #cbd5e0;border-radius:8px;font-size:1rem;background:#fff;transition:border-color 0.3s ease,box-shadow 0.3s ease}.question-field input:focus,.question-field select:focus,.question-field textarea:focus{outline:none;border-color:#3182ce;box-shadow:0 0 0 3px rgba(66,153,225,0.5)}.submit-btn{width:100%;padding:14px;background:linear-gradient(135deg,#4299e1,#3182ce,#2c5282);color:#fff;border:none;border-radius:10px;font-size:1.1rem;font-weight:600;cursor:pointer;transition:background 0.3s ease,transform 0.3s ease,box-shadow 0.3s ease}.submit-btn:hover{background:linear-gradient(135deg,#3182ce,#2c5282,#2a4365);transform:translateY(-2px);box-shadow:0 8px 20px rgba(66,153,225,0.4)}.submit-btn:active{transform:translateY(0)}</style>
 </head>

--- a/frontend/marketing/auth.html
+++ b/frontend/marketing/auth.html
@@ -8,7 +8,19 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link rel="preconnect" href="https://unpkg.com">
     <link rel="preconnect" href="https://accounts.google.com">
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="dns-prefetch" href="https://fonts.googleapis.com">
+    <link rel="dns-prefetch" href="https://fonts.gstatic.com">
+    <script>
+      const inter = document.createElement('link');
+      inter.rel = 'stylesheet';
+      inter.href = 'https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap';
+      inter.media = 'print';
+      inter.onload = () => { inter.media = 'all'; };
+      document.head.appendChild(inter);
+    </script>
+    <noscript>
+      <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap">
+    </noscript>
     <link rel="stylesheet" href="assets/css/marketing.css">
 </head>
 <body>

--- a/frontend/marketing/contact.html
+++ b/frontend/marketing/contact.html
@@ -7,7 +7,19 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link rel="preconnect" href="https://unpkg.com">
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="dns-prefetch" href="https://fonts.googleapis.com">
+    <link rel="dns-prefetch" href="https://fonts.gstatic.com">
+    <script>
+      const inter = document.createElement('link');
+      inter.rel = 'stylesheet';
+      inter.href = 'https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap';
+      inter.media = 'print';
+      inter.onload = () => { inter.media = 'all'; };
+      document.head.appendChild(inter);
+    </script>
+    <noscript>
+      <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap">
+    </noscript>
     <link rel="stylesheet" href="assets/css/marketing.css">
 </head>
 <body>

--- a/frontend/marketing/index.html
+++ b/frontend/marketing/index.html
@@ -8,7 +8,19 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link rel="preconnect" href="https://unpkg.com">
     <link rel="preconnect" href="https://accounts.google.com">
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="dns-prefetch" href="https://fonts.googleapis.com">
+    <link rel="dns-prefetch" href="https://fonts.gstatic.com">
+    <script>
+      const inter = document.createElement('link');
+      inter.rel = 'stylesheet';
+      inter.href = 'https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap';
+      inter.media = 'print';
+      inter.onload = () => { inter.media = 'all'; };
+      document.head.appendChild(inter);
+    </script>
+    <noscript>
+      <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap">
+    </noscript>
     <link rel="stylesheet" href="assets/css/marketing.css">
 </head>
 <body>

--- a/frontend/marketing/solutions.html
+++ b/frontend/marketing/solutions.html
@@ -7,7 +7,19 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link rel="preconnect" href="https://unpkg.com">
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="dns-prefetch" href="https://fonts.googleapis.com">
+    <link rel="dns-prefetch" href="https://fonts.gstatic.com">
+    <script>
+      const inter = document.createElement('link');
+      inter.rel = 'stylesheet';
+      inter.href = 'https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap';
+      inter.media = 'print';
+      inter.onload = () => { inter.media = 'all'; };
+      document.head.appendChild(inter);
+    </script>
+    <noscript>
+      <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap">
+    </noscript>
     <link rel="stylesheet" href="assets/css/marketing.css">
 </head>
 <body>

--- a/frontend/marketing/tarifs.html
+++ b/frontend/marketing/tarifs.html
@@ -7,7 +7,19 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link rel="preconnect" href="https://unpkg.com">
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="dns-prefetch" href="https://fonts.googleapis.com">
+    <link rel="dns-prefetch" href="https://fonts.gstatic.com">
+    <script>
+      const inter = document.createElement('link');
+      inter.rel = 'stylesheet';
+      inter.href = 'https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap';
+      inter.media = 'print';
+      inter.onload = () => { inter.media = 'all'; };
+      document.head.appendChild(inter);
+    </script>
+    <noscript>
+      <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap">
+    </noscript>
     <link rel="stylesheet" href="assets/css/marketing.css">
 </head>
 <body>

--- a/frontend/tests/font-loading.test.js
+++ b/frontend/tests/font-loading.test.js
@@ -1,0 +1,27 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const frontendDir = path.join(__dirname, '..');
+
+const htmlFiles = fs.readdirSync(frontendDir, { withFileTypes: true })
+  .filter(dirent => dirent.isDirectory())
+  .flatMap(dirent =>
+    fs.readdirSync(path.join(frontendDir, dirent.name))
+      .filter(f => f.endsWith('.html'))
+      .map(f => path.join(frontendDir, dirent.name, f))
+  );
+
+test('Inter font loads only weights 400 and 600 with swap', () => {
+  const fontUrl = 'https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap';
+  htmlFiles.forEach(file => {
+    const html = fs.readFileSync(file, 'utf8');
+    assert.ok(html.includes(fontUrl), `${file} should reference Inter 400 & 600 with swap`);
+    assert.ok(!html.includes('wght@300'), `${file} should not request weight 300`);
+    assert.ok(!html.includes('wght@500'), `${file} should not request weight 500`);
+    assert.ok(!html.includes('wght@700'), `${file} should not request weight 700`);
+    assert.ok(html.includes('display=swap'), `${file} should use font-display swap`);
+  });
+});
+


### PR DESCRIPTION
## Summary
- load Inter font asynchronously via JS with weights 400 & 600 and dns-prefetch hints
- include noscript fallback and font-display swap in all frontend HTML files
- add tests ensuring only requested weights are referenced

## Testing
- `npm test` *(fails: Cannot find module 'sanitize-html')*
- `node --test frontend/tests/font-loading.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68a97f5536188325b3c080b7ae1cc50e