### PR TITLE
feat: add build pipeline and manifest test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ backend/node_modules/*
 !backend/node_modules/compression/**
 .DS_Store
 *.log
+backend/public/

--- a/backend/src/presentation/app.js
+++ b/backend/src/presentation/app.js
@@ -165,38 +165,16 @@ app.use((_, res, next) => {
 app.use(compression);
 app.use(cacheControl);
 
-// Servir les fichiers statiques pour l'application et le marketing
-app.use(
-  '/app',
-  express.static(path.join(__dirname, '../../../frontend/app'), {
-    setHeaders: setStaticHeaders
-  })
-);
-app.use(
-  '/',
-  express.static(path.join(__dirname, '../../../frontend/marketing'), {
-    setHeaders: setStaticHeaders
-  })
-);
+// Servir les fichiers statiques construits
+const publicDir = path.join(__dirname, '../../public');
+app.use(express.static(publicDir, { setHeaders: setStaticHeaders }));
 
 // Routes pour les applications frontend
-app.get(
-  '/app*',
-  setHtmlCache,
-  (_, res) =>
-    res.sendFile(
-      path.join(__dirname, '../../../frontend/app/index.html'),
-      { cacheControl: false }
-    )
+app.get('/app*', setHtmlCache, (_, res) =>
+  res.sendFile(path.join(publicDir, 'app/index.html'), { cacheControl: false })
 );
-app.get(
-  '/',
-  setHtmlCache,
-  (_, res) =>
-    res.sendFile(
-      path.join(__dirname, '../../../frontend/marketing/index.html'),
-      { cacheControl: false }
-    )
+app.get('/', setHtmlCache, (_, res) =>
+  res.sendFile(path.join(publicDir, 'app/index.html'), { cacheControl: false })
 );
 
 // Routes API

--- a/backend/tests/integration/buildSmoke.test.js
+++ b/backend/tests/integration/buildSmoke.test.js
@@ -1,0 +1,20 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const request = require('supertest');
+
+const rootDir = path.join(__dirname, '../../..');
+const manifestPath = path.join(rootDir, 'backend/public/manifest.json');
+const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+const { app } = require('../../src/presentation/app');
+
+test('manifest has entries and built files are served', async () => {
+  assert.ok(Object.keys(manifest).length > 0, 'manifest should not be empty');
+  const [original, hashed] = Object.entries(manifest)[0];
+  const resAsset = await request(app).get(`/${hashed}`);
+  assert.strictEqual(resAsset.status, 200);
+  const htmlRes = await request(app).get('/app').set('Accept', 'text/html');
+  assert.strictEqual(htmlRes.status, 200);
+  assert.ok(htmlRes.text.includes(hashed));
+});

--- a/backend/tests/integration/cacheHeaders.test.js
+++ b/backend/tests/integration/cacheHeaders.test.js
@@ -9,16 +9,15 @@ process.env.DATABASE_URL = 'postgresql://user:pass@localhost:5432/test';
 process.env.GOOGLE_CLIENT_ID = 'test-client-id';
 
 const rootDir = path.join(__dirname, '../../..');
-const jsDir = path.join(rootDir, 'frontend/app/assets/js');
-const original = path.join(jsDir, 'main.js');
-const hashed = path.join(jsDir, 'main.12345678.js');
-
-fs.copyFileSync(original, hashed);
+const manifest = JSON.parse(
+  fs.readFileSync(path.join(rootDir, 'backend/public/manifest.json'), 'utf8')
+);
+const hashedJs = manifest['main.js'];
 
 const { app } = require('../../src/presentation/app');
 
 test('hashed static asset has long cache headers', async () => {
-  const res = await request(app).get('/app/assets/js/main.12345678.js');
+  const res = await request(app).get(`/${hashedJs}`);
   assert.strictEqual(res.status, 200);
   assert.strictEqual(res.headers['cache-control'], 'public, max-age=31536000, immutable');
   assert.ok(res.headers.etag);
@@ -31,8 +30,4 @@ test('HTML route has hour cache headers', async () => {
   assert.strictEqual(res.headers['cache-control'], 'public, max-age=3600');
   assert.ok(res.headers.etag);
   assert.ok(res.headers.vary.includes('Accept-Encoding'));
-});
-
-process.on('exit', () => {
-  try { fs.unlinkSync(hashed); } catch {}
 });

--- a/build.js
+++ b/build.js
@@ -1,0 +1,48 @@
+const { execSync } = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const rootDir = __dirname;
+const frontendDir = path.join(rootDir, 'frontend');
+const backendPublicDir = path.join(rootDir, 'backend', 'public');
+
+// Run Vite build in the frontend directory
+execSync('node scripts/generate-env.js', { cwd: frontendDir, stdio: 'inherit' });
+execSync('npx vite build', { cwd: frontendDir, stdio: 'inherit' });
+
+// Copy the dist output to the backend public directory
+const distDir = path.join(frontendDir, 'dist');
+fs.rmSync(backendPublicDir, { recursive: true, force: true });
+fs.mkdirSync(backendPublicDir, { recursive: true });
+fs.cpSync(distDir, backendPublicDir, { recursive: true });
+
+// Generate a simple manifest mapping original names to hashed files
+const assetsDir = path.join(backendPublicDir, 'assets');
+const manifest = {};
+if (fs.existsSync(assetsDir)) {
+  for (const file of fs.readdirSync(assetsDir)) {
+    const match = file.match(/^(.*?)-([A-Za-z0-9-]+)(\.[^.]+)$/);
+    if (match) {
+      const original = match[1] + match[3];
+      manifest[original] = `assets/${file}`;
+    }
+  }
+}
+fs.writeFileSync(path.join(backendPublicDir, 'manifest.json'), JSON.stringify(manifest, null, 2));
+
+// Update HTML files to reference hashed asset names
+const updateHtml = dir => {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      updateHtml(full);
+    } else if (entry.isFile() && entry.name.endsWith('.html')) {
+      let html = fs.readFileSync(full, 'utf8');
+      for (const [orig, hashed] of Object.entries(manifest)) {
+        html = html.replace(new RegExp(orig, 'g'), hashed);
+      }
+      fs.writeFileSync(full, html);
+    }
+  }
+};
+updateHtml(backendPublicDir);

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "private": true,
   "scripts": {
     "prebuild": "node frontend/scripts/generate-env.js",
-    "build": "npm --prefix frontend run build && npm install --prefix backend",
+    "build": "node build.js && npm install --prefix backend",
     "start": "npm start --prefix backend",
-    "test": "node --test frontend/tests/*.js backend/tests/**/*.js"
+    "test": "node build.js && node --test frontend/tests/*.js backend/tests/**/*.js"
   },
   "engines": {
     "node": ">=18"


### PR DESCRIPTION
## Summary
- add root build script to compile frontend, copy to backend public, and map hashed assets
- serve built assets from backend/public and update cache tests
- add smoke test verifying manifest entries and served files

## Testing
- `npm test` *(fails: Cannot find module 'sanitize-html')*

------
https://chatgpt.com/codex/tasks/task_e_68a983f9d1f88325b6bbf1957e727cc4