### PR TITLE
feat: preload critical modules and lazy-load secondary scripts

### DIFF
--- a/frontend/app/index.html
+++ b/frontend/app/index.html
@@ -10,6 +10,8 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link rel="dns-prefetch" href="https://fonts.googleapis.com">
     <link rel="dns-prefetch" href="https://fonts.gstatic.com">
+    <link rel="modulepreload" href="assets/js/utils/utils.js">
+    <link rel="modulepreload" href="assets/js/auth.js">
     <script>
       const inter = document.createElement('link');
       inter.rel = 'stylesheet';

--- a/frontend/app/onboarding.html
+++ b/frontend/app/onboarding.html
@@ -9,6 +9,8 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="dns-prefetch" href="https://fonts.googleapis.com">
   <link rel="dns-prefetch" href="https://fonts.gstatic.com">
+  <link rel="modulepreload" href="assets/js/utils/utils.js">
+  <link rel="modulepreload" href="assets/js/auth.js">
   <script>
     const inter = document.createElement('link');
     inter.rel = 'stylesheet';

--- a/frontend/marketing/assets/js/auth.js
+++ b/frontend/marketing/assets/js/auth.js
@@ -1,6 +1,13 @@
 // frontend/assets/js/auth.js
 
-import { utils, API_BASE_URL } from './utils.js';
+let utils, API_BASE_URL;
+async function loadUtils() {
+    if (!utils) {
+        const module = await import('./utils.js');
+        utils = module.utils;
+        API_BASE_URL = module.API_BASE_URL;
+    }
+}
 
 class AuthManager {
     constructor() {
@@ -27,13 +34,15 @@ class AuthManager {
         document.body.appendChild(notification);
     }
 
-    savePendingAuth(payload) {
+    async savePendingAuth(payload) {
+        await loadUtils();
         localStorage.setItem('pending-auth', JSON.stringify(payload));
         utils.showNotification('Données sauvegardées pour réessai ultérieur', 'success');
     }
 
     // ⭐ NOUVELLE MÉTHODE : Authentification Google
     async handleGoogleLogin(googleResponse) {
+        await loadUtils();
         if (!googleResponse?.credential) {
             utils.showNotification('Token Google manquant', 'error');
             return { success: false, error: 'Token Google manquant' };
@@ -88,9 +97,10 @@ class AuthManager {
 
     // CONNEXION email (existant)
     async login(email, password) {
+        await loadUtils();
         try {
             console.log('Tentative de connexion pour:', email);
-            
+
             const response = await fetch(`${API_BASE_URL}/auth/login`, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
@@ -125,9 +135,10 @@ class AuthManager {
 
     // INSCRIPTION email (existant)
     async register(name, email, password) {
+        await loadUtils();
         try {
             console.log('Tentative d\'inscription pour:', { name, email });
-            
+
             const response = await fetch(`${API_BASE_URL}/auth/register`, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
@@ -276,8 +287,9 @@ function setupAuthListeners() {
     const loginBtn = document.getElementById('loginBtn');
     if (loginBtn) {
         loginBtn.addEventListener('click', async function() {
+            await loadUtils();
             console.log('Clic sur le bouton de connexion');
-            
+
             const email = document.getElementById('loginEmail').value.trim();
             const password = document.getElementById('loginPassword').value;
             if (!email || !password) {
@@ -299,9 +311,7 @@ function setupAuthListeners() {
             this.disabled = false;
             this.innerHTML = '<i data-lucide="log-in"></i>Se connecter';
             // Réinitialiser les icônes
-            if (typeof utils !== 'undefined') {
-                utils.initializeLucide();
-            }
+            utils.initializeLucide();
         });
     }
 
@@ -309,8 +319,9 @@ function setupAuthListeners() {
     const registerBtn = document.getElementById('registerBtn');
     if (registerBtn) {
         registerBtn.addEventListener('click', async function() {
+            await loadUtils();
             console.log('Clic sur le bouton d\'inscription');
-            
+
             const name = document.getElementById('registerName').value.trim();
             const email = document.getElementById('registerEmail').value.trim();
             const password = document.getElementById('registerPassword').value;
@@ -339,9 +350,7 @@ function setupAuthListeners() {
             this.disabled = false;
             this.innerHTML = '<i data-lucide="user-plus"></i>Créer mon compte';
             // Réinitialiser les icônes
-            if (typeof utils !== 'undefined') {
-                utils.initializeLucide();
-            }
+            utils.initializeLucide();
         });
     }
 
@@ -382,7 +391,8 @@ function setupAuthListeners() {
     });
 }
 
-function showNotification(message, type = 'success') {
+async function showNotification(message, type = 'success') {
+    await loadUtils();
     if (typeof utils !== 'undefined' && utils.showNotification) {
         utils.showNotification(message, type);
     } else {

--- a/frontend/marketing/assets/js/main.js
+++ b/frontend/marketing/assets/js/main.js
@@ -1,10 +1,13 @@
 // frontend/assets/js/main.js - Point d'entrée principal
 
-import { utils } from './utils.js';
+let utils;
 
 // Initialisation de l'application
-document.addEventListener('DOMContentLoaded', function() {
+document.addEventListener('DOMContentLoaded', async function() {
     console.log('🚀 Initialisation Hermès App');
+
+    const module = await import('./utils.js');
+    utils = module.utils;
 
     initializeApp();
     setupEventListeners();

--- a/frontend/marketing/auth.html
+++ b/frontend/marketing/auth.html
@@ -10,6 +10,9 @@
     <link rel="preconnect" href="https://accounts.google.com">
     <link rel="dns-prefetch" href="https://fonts.googleapis.com">
     <link rel="dns-prefetch" href="https://fonts.gstatic.com">
+    <link rel="modulepreload" href="assets/js/navigation.js">
+    <link rel="modulepreload" href="assets/js/utils.js">
+    <link rel="modulepreload" href="assets/js/auth.js">
     <script>
       const inter = document.createElement('link');
       inter.rel = 'stylesheet';

--- a/frontend/marketing/contact.html
+++ b/frontend/marketing/contact.html
@@ -9,6 +9,8 @@
     <link rel="preconnect" href="https://unpkg.com">
     <link rel="dns-prefetch" href="https://fonts.googleapis.com">
     <link rel="dns-prefetch" href="https://fonts.gstatic.com">
+    <link rel="modulepreload" href="assets/js/navigation.js">
+    <link rel="modulepreload" href="assets/js/utils.js">
     <script>
       const inter = document.createElement('link');
       inter.rel = 'stylesheet';

--- a/frontend/marketing/index.html
+++ b/frontend/marketing/index.html
@@ -10,6 +10,8 @@
     <link rel="preconnect" href="https://accounts.google.com">
     <link rel="dns-prefetch" href="https://fonts.googleapis.com">
     <link rel="dns-prefetch" href="https://fonts.gstatic.com">
+    <link rel="modulepreload" href="assets/js/navigation.js">
+    <link rel="modulepreload" href="assets/js/utils.js">
     <script>
       const inter = document.createElement('link');
       inter.rel = 'stylesheet';

--- a/frontend/marketing/solutions.html
+++ b/frontend/marketing/solutions.html
@@ -9,6 +9,8 @@
     <link rel="preconnect" href="https://unpkg.com">
     <link rel="dns-prefetch" href="https://fonts.googleapis.com">
     <link rel="dns-prefetch" href="https://fonts.gstatic.com">
+    <link rel="modulepreload" href="assets/js/navigation.js">
+    <link rel="modulepreload" href="assets/js/utils.js">
     <script>
       const inter = document.createElement('link');
       inter.rel = 'stylesheet';

--- a/frontend/marketing/tarifs.html
+++ b/frontend/marketing/tarifs.html
@@ -9,6 +9,8 @@
     <link rel="preconnect" href="https://unpkg.com">
     <link rel="dns-prefetch" href="https://fonts.googleapis.com">
     <link rel="dns-prefetch" href="https://fonts.gstatic.com">
+    <link rel="modulepreload" href="assets/js/navigation.js">
+    <link rel="modulepreload" href="assets/js/utils.js">
     <script>
       const inter = document.createElement('link');
       inter.rel = 'stylesheet';

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -3,7 +3,5 @@ import '../app/assets/js/onboarding-manager.js';
 import '../app/assets/js/auth-check.js';
 import '../app/assets/js/app-init.js';
 import '../app/assets/js/utils/utils.js';
-import '../app/assets/js/googleAuth.js';
 import '../app/assets/js/auth.js';
-import '../app/assets/js/course-manager.js';
 import '../app/assets/js/main.js';

--- a/frontend/tests/module-loading.test.js
+++ b/frontend/tests/module-loading.test.js
@@ -1,0 +1,42 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+function hasPreload(html, href) {
+  return html.includes(`<link rel="modulepreload" href="${href}">`);
+}
+
+test('app pages preload critical modules', () => {
+  const appIndex = readFileSync('frontend/app/index.html', 'utf-8');
+  assert.ok(hasPreload(appIndex, 'assets/js/utils/utils.js'));
+  assert.ok(hasPreload(appIndex, 'assets/js/auth.js'));
+
+  const onboarding = readFileSync('frontend/app/onboarding.html', 'utf-8');
+  assert.ok(hasPreload(onboarding, 'assets/js/utils/utils.js'));
+  assert.ok(hasPreload(onboarding, 'assets/js/auth.js'));
+});
+
+test('marketing pages preload critical modules', () => {
+  const pages = ['index', 'contact', 'solutions', 'tarifs'];
+  for (const page of pages) {
+    const html = readFileSync(`frontend/marketing/${page}.html`, 'utf-8');
+    assert.ok(hasPreload(html, 'assets/js/navigation.js'));
+    assert.ok(hasPreload(html, 'assets/js/utils.js'));
+  }
+  const authHtml = readFileSync('frontend/marketing/auth.html', 'utf-8');
+  assert.ok(hasPreload(authHtml, 'assets/js/navigation.js'));
+  assert.ok(hasPreload(authHtml, 'assets/js/utils.js'));
+  assert.ok(hasPreload(authHtml, 'assets/js/auth.js'));
+});
+
+test('app main lazily loads course-manager', () => {
+  const js = readFileSync('frontend/app/assets/js/main.js', 'utf-8');
+  assert.ok(js.includes("import('./course-manager.js')"));
+  assert.ok(!js.includes("from './course-manager.js'"));
+});
+
+test('marketing auth lazily loads utils', () => {
+  const js = readFileSync('frontend/marketing/assets/js/auth.js', 'utf-8');
+  assert.ok(js.includes("import('./utils.js')"));
+  assert.ok(!js.includes("from './utils.js'"));
+});


### PR DESCRIPTION
## Summary
- dynamically import secondary app and marketing modules
- preload critical scripts with `<link rel="modulepreload">`
- test module preloading and lazy loading

## Testing
- `npm test` *(fails: stylelint: not found)*
- `node --test frontend/tests/module-loading.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a98b4d54dc8325ac4ab80ae59915b3