### PR TITLE
Add explicit security headers via Helmet

### DIFF
--- a/backend/src/presentation/app.js
+++ b/backend/src/presentation/app.js
@@ -93,7 +93,9 @@ app.use(
       }
     },
     crossOriginEmbedderPolicy: false,
-    crossOriginOpenerPolicy: false
+    crossOriginOpenerPolicy: false,
+    referrerPolicy: { policy: 'strict-origin-when-cross-origin' },
+    xContentTypeOptions: true
   })
 );
 

--- a/backend/tests/integration/securityHeaders.test.js
+++ b/backend/tests/integration/securityHeaders.test.js
@@ -1,0 +1,22 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const request = require('supertest');
+
+process.env.NODE_ENV = 'development';
+process.env.ALLOW_HTTP = 'true';
+process.env.PORT = '3000';
+process.env.JWT_SECRET = 'a'.repeat(32);
+process.env.JWT_EXPIRES_IN = '1h';
+process.env.DATABASE_URL = 'postgresql://user:pass@localhost:5432/test';
+process.env.GOOGLE_CLIENT_ID = 'test-client-id';
+process.env.ANTHROPIC_API_KEY = 'test';
+process.env.REDIS_URL = 'redis://localhost:6379';
+
+const { app } = require('../../src/presentation/app');
+
+test('helmet sets security headers', async () => {
+  const res = await request(app).get('/api/config/google');
+  assert.strictEqual(res.status, 200);
+  assert.strictEqual(res.headers['x-content-type-options'], 'nosniff');
+  assert.strictEqual(res.headers['referrer-policy'], 'strict-origin-when-cross-origin');
+});


### PR DESCRIPTION
## Summary
- Add explicit `Referrer-Policy` and `X-Content-Type-Options` headers via Helmet configuration
- Introduce integration test checking the presence of these headers

## Testing
- `node --test tests/integration/securityHeaders.test.js` *(fails: Cannot find module 'supertest')*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/awilix)*

------
https://chatgpt.com/codex/tasks/task_e_68a98e00493883258b1fc6b77eab3dc6