### PR TITLE
feat: async env checks with stronger JWT secret validation

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -44,7 +44,7 @@ process.on('SIGINT', () => gracefulShutdown('SIGINT'));
 const startServer = async () => {
   try {
     // Vérifier les variables d'environnement
-    checkEnv();
+    await checkEnv();
 
     // Vérifier et appliquer les migrations
     logger.info('Vérification des migrations de base de données...');


### PR DESCRIPTION
## Summary
- make git tracking check asynchronous using exec
- await env check and enforce high entropy JWT secrets
- await env validation when starting server

## Testing
- `npm install` *(fails: 403 Forbidden for stylelint)*
- `npm test` *(fails: stylelint: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9b77681e88325946f088762e9f014