### PR TITLE
Use Terser plugin for Vite build

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,6 +7,7 @@
     "preview": "vite preview"
   },
   "devDependencies": {
-    "vite": "^5.0.0"
+    "vite": "^5.0.0",
+    "@rollup/plugin-terser": "^0.4.4"
   }
 }

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,5 +1,6 @@
 import { defineConfig } from 'vite';
 import { resolve } from 'path';
+import { terser } from '@rollup/plugin-terser';
 
 export default defineConfig({
   build: {
@@ -14,8 +15,15 @@ export default defineConfig({
         entryFileNames: 'assets/[name]-[hash].js',
         chunkFileNames: 'assets/[name]-[hash].js',
         assetFileNames: 'assets/[name]-[hash][extname]'
-      }
+      },
+      plugins: [terser({ compress: { drop_console: true, drop_debugger: true } })]
     },
-    minify: true
+    minify: 'terser',
+    terserOptions: {
+      compress: {
+        drop_console: true,
+        drop_debugger: true
+      }
+    }
   }
 });


### PR DESCRIPTION
## Summary
- import `@rollup/plugin-terser` and configure Vite to use Terser for minification
- enable `drop_console` and `drop_debugger` compression options
- add Terser plugin dependency for the frontend build

## Testing
- `npm install --prefix frontend` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@rollup%2fplugin-terser)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/stylelint)*
- `npm test` *(fails: stylelint: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9b9db16588325b82e09eb74b5fa5f