### PR TITLE
refactor: use descriptive dir variable names in font-loading test

### DIFF
--- a/frontend/tests/font-loading.test.js
+++ b/frontend/tests/font-loading.test.js
@@ -6,11 +6,11 @@ const path = require('node:path');
 const frontendDir = path.join(__dirname, '..');
 
 const htmlFiles = fs.readdirSync(frontendDir, { withFileTypes: true })
-  .filter(dirent => dirent.isDirectory())
-  .flatMap(dirent =>
-    fs.readdirSync(path.join(frontendDir, dirent.name))
+  .filter(directory => directory.isDirectory())
+  .flatMap(directory =>
+    fs.readdirSync(path.join(frontendDir, directory.name))
       .filter(f => f.endsWith('.html'))
-      .map(f => path.join(frontendDir, dirent.name, f))
+      .map(f => path.join(frontendDir, directory.name, f))
   );
 
 test('Inter font loads only weights 400 and 600 with swap', () => {


### PR DESCRIPTION
## Summary
- rename `dirent` parameter and references to `directory` in font-loading test for clarity

## Testing
- `npm test` *(fails: stylelint: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9ba8a50dc83258f8b9b5bda00dc03