### PR TITLE
Validate pagination parameters

### DIFF
--- a/backend/src/presentation/controllers/courseController.js
+++ b/backend/src/presentation/controllers/courseController.js
@@ -8,8 +8,12 @@ const container = require('../../infrastructure/container');
 class CourseController {
   async getAllCourses(req, res) {
     try {
-      const page = req.query.page || 1;
-      const limit = req.query.limit || 10;
+      let page = parseInt(req.query.page, 10);
+      let limit = parseInt(req.query.limit, 10);
+
+      page = Number.isNaN(page) ? 1 : Math.max(page, 1);
+      limit = Number.isNaN(limit) ? 10 : Math.max(Math.min(limit, 50), 1);
+
       const skip = (page - 1) * limit;
       const repository = container.resolve('courseRepository');
       const courses = await repository.findAllByUserId(req.user.id, { skip, take: limit });


### PR DESCRIPTION
## Summary
- parse `page` and `limit` as integers in `getAllCourses`
- enforce minimum page of 1 and maximum limit of 50
- compute pagination using validated values

## Testing
- `npm test` *(fails: stylelint: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/stylelint)*

------
https://chatgpt.com/codex/tasks/task_e_68a9bd3625908325a059d15f5de165e4