### PR TITLE
Specify radix for parseInt

### DIFF
--- a/backend/src/infrastructure/utils/helpers.js
+++ b/backend/src/infrastructure/utils/helpers.js
@@ -79,13 +79,17 @@ const mapLegacyParams = ({
 
   const finalDetail =
     detailLevel ||
-    parseInt(Object.keys(durationMap).find((key) => durationMap[key] === finalDuration));
+    parseInt(
+      Object.keys(durationMap).find((key) => durationMap[key] === finalDuration),
+      10
+    );
   const finalLegacyVulgarization =
     vulgarizationLevel ||
     parseInt(
       Object.keys(vulgarizationMap).find(
         (key) => vulgarizationMap[key] === finalVulgarization
-      )
+      ),
+      10
     );
 
   return {

--- a/frontend/app/assets/js/main.js
+++ b/frontend/app/assets/js/main.js
@@ -237,7 +237,7 @@ const combinations = {
 
 function updateDetailGauge() {
     const slider = document.getElementById('detailSlider');
-    const value = parseInt(slider.value);
+    const value = parseInt(slider.value, 10);
     const level = detailLevels[value];
     
     const valueEl = document.getElementById('detailValue');
@@ -256,7 +256,7 @@ function updateDetailGauge() {
 
 function updateVulgarizationGauge() {
     const slider = document.getElementById('vulgarizationSlider');
-    const value = parseInt(slider.value);
+    const value = parseInt(slider.value, 10);
     const level = vulgarizationLevels[value];
     
     const valueEl = document.getElementById('vulgarizationValue');
@@ -395,8 +395,8 @@ function displayQuiz(quiz, containerId = 'quizSection') {
 }
 
 function handleQuizAnswer(btn) {
-    const questionIndex = parseInt(btn.dataset.questionIndex);
-    const optionIndex = parseInt(btn.dataset.optionIndex);
+    const questionIndex = parseInt(btn.dataset.questionIndex, 10);
+    const optionIndex = parseInt(btn.dataset.optionIndex, 10);
     const question = currentQuiz.questions[questionIndex];
     const questionEl = btn.closest('.quiz-question');
 
@@ -404,7 +404,7 @@ function handleQuizAnswer(btn) {
 
     questionEl.querySelectorAll('.quiz-option').forEach(opt => {
         opt.style.pointerEvents = 'none';
-        if (parseInt(opt.dataset.optionIndex) === question.correct) {
+        if (parseInt(opt.dataset.optionIndex, 10) === question.correct) {
             opt.classList.add('correct');
         }
     });

--- a/frontend/marketing/assets/js/main.js
+++ b/frontend/marketing/assets/js/main.js
@@ -78,7 +78,7 @@ const combinations = {
 
 function updateDetailGauge() {
     const slider = document.getElementById('detailSlider');
-    const value = parseInt(slider.value);
+    const value = parseInt(slider.value, 10);
     const level = detailLevels[value];
     
     const valueEl = document.getElementById('detailValue');
@@ -97,7 +97,7 @@ function updateDetailGauge() {
 
 function updateVulgarizationGauge() {
     const slider = document.getElementById('vulgarizationSlider');
-    const value = parseInt(slider.value);
+    const value = parseInt(slider.value, 10);
     const level = vulgarizationLevels[value];
     
     const valueEl = document.getElementById('vulgarizationValue');


### PR DESCRIPTION
## Summary
- enforce explicit base 10 in helper utility parsing functions
- use radix 10 for dataset and slider value parsing on frontend
- specify radix 10 for marketing slider value parsing

## Testing
- `npm test` *(fails: stylelint not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9bed9097c83258a09ca840d031d2c