### PR TITLE
refactor: iterate localStorage keys directly

### DIFF
--- a/frontend/app/assets/js/course-manager.js
+++ b/frontend/app/assets/js/course-manager.js
@@ -74,11 +74,12 @@ class CourseManager {
     if (courseId) {
       localStorage.removeItem(`noza-course-${courseId}`);
     }
-    Object.keys(localStorage).forEach(key => {
-      if (key.startsWith('noza-course-list')) {
+    for (let i = localStorage.length - 1; i >= 0; i--) {
+      const key = localStorage.key(i);
+      if (key && key.startsWith('noza-course-list')) {
         localStorage.removeItem(key);
       }
-    });
+    }
   }
 
   // Afficher un message d'erreur avec action


### PR DESCRIPTION
## Summary
- optimize cache invalidation by iterating localStorage keys without building an array

## Testing
- `npm test` *(fails: stylelint: not found)*
- `npm install` *(fails: 403 Forbidden for stylelint package)*

------
https://chatgpt.com/codex/tasks/task_e_68a9bf922a788325937e828824b41569