### PR TITLE
feat: add visual style option to course prompts

### DIFF
--- a/backend/src/domain/services/AnthropicAIService.js
+++ b/backend/src/domain/services/AnthropicAIService.js
@@ -114,7 +114,7 @@ class AnthropicAIService {
     ].concat([teacherTone[teacherType], vocab[vulgarization]].filter(Boolean));
   }
 
-  createPrompt(subject, vulgarization, duration, teacherType) {
+  createPrompt(subject, vulgarization, duration, teacherType, visualStyle) {
     const adaptive = this.getAdaptiveInstructions(
       teacherType,
       vulgarization,
@@ -139,6 +139,14 @@ class AnthropicAIService {
       .map(line => `- ${line}`)
       .join('\\n');
 
+    const visualInstructions = {
+      diagram: "Inclure des balises <figure> contenant du code Mermaid pour les schémas.",
+      chart: "Proposer des graphiques simplifiés sous forme de <canvas> (Chart.js).",
+      image: "Ajouter une <img> illustrative pertinente."
+    };
+
+    const visualText = visualInstructions[visualStyle];
+
     return `<h1>Titre du Cours</h1>
 
 PHILOSOPHIE PÉDAGOGIQUE :
@@ -156,12 +164,13 @@ STRUCTURE :
 Sujet : '${subject}'
 
 RENDU ATTENDU :
-- Retourne UNIQUEMENT le HTML final prêt à être injecté (aucun commentaire extérieur).`;
+- Retourne UNIQUEMENT le HTML final prêt à être injecté (aucun commentaire extérieur).
+${visualText ? '- ' + visualText : ''}`;
   }
 
 
 // Générer un cours
-  async generateCourse(subject, vulgarization, duration, teacherType) {
+  async generateCourse(subject, vulgarization, duration, teacherType, visualStyle) {
     if (this.isOffline()) {
       return this.getOfflineMessage();
     }
@@ -177,9 +186,21 @@ RENDU ATTENDU :
     teacherType = teacherType || TEACHER_TYPES.METHODICAL;
 
     try {
-      const prompt = this.createPrompt(subject, vulgarization, duration, teacherType);
+      const prompt = this.createPrompt(
+        subject,
+        vulgarization,
+        duration,
+        teacherType,
+        visualStyle
+      );
 
-      logger.info('Génération cours', { subject, vulgarization, duration, teacherType });
+      logger.info('Génération cours', {
+        subject,
+        vulgarization,
+        duration,
+        teacherType,
+        visualStyle
+      });
 
       const response = await this.aiService.sendWithTimeout({
         model: 'claude-3-5-sonnet-20241022',

--- a/backend/tests/services/anthropicService.test.js
+++ b/backend/tests/services/anthropicService.test.js
@@ -33,11 +33,13 @@ test('createPrompt creates flexible educational content', () => {
     'Sujet',
     VULGARIZATION_LEVELS.GENERAL_PUBLIC,
     DURATIONS.MEDIUM,
-    TEACHER_TYPES.METHODICAL
+    TEACHER_TYPES.METHODICAL,
+    'diagram'
   );
 
   assert.match(prompt, /PHILOSOPHIE PÉDAGOGIQUE/);
   assert.match(prompt, /Pour aller plus loin/);
+  assert.match(prompt, /Mermaid/);
 });
 
 test('createPrompt allows pedagogical freedom', () => {
@@ -45,7 +47,8 @@ test('createPrompt allows pedagogical freedom', () => {
     'Sujet',
     VULGARIZATION_LEVELS.GENERAL_PUBLIC,
     DURATIONS.MEDIUM,
-    TEACHER_TYPES.METHODICAL
+    TEACHER_TYPES.METHODICAL,
+    'diagram'
   );
 
   assert.doesNotMatch(prompt, /STRUCTURE REQUISE/);
@@ -56,12 +59,14 @@ test('createPrompt integrates personalization parameters', () => {
     'Sujet',
     VULGARIZATION_LEVELS.EXPERT,
     DURATIONS.LONG,
-    TEACHER_TYPES.PASSIONATE
+    TEACHER_TYPES.PASSIONATE,
+    'chart'
   );
 
   assert.match(prompt, /Transmets l'information avec passion et enthousiasme/);
   assert.match(prompt, /environ 4200 mots/);
   assert.match(prompt, /Conserve un registre technique mais reste créatif/);
+  assert.match(prompt, /Chart\.js/);
 });
 
 test('sendWithTimeout retries on overload errors', async () => {
@@ -113,7 +118,13 @@ test('APIUserAbortError does not trigger offline mode', async () => {
   };
 
   try {
-    await orchestrator.generateCourse('Sujet', VULGARIZATION_LEVELS.ENLIGHTENED, DURATIONS.SHORT, TEACHER_TYPES.METHODICAL);
+    await orchestrator.generateCourse(
+      'Sujet',
+      VULGARIZATION_LEVELS.ENLIGHTENED,
+      DURATIONS.SHORT,
+      TEACHER_TYPES.METHODICAL,
+      'diagram'
+    );
     assert.fail('generateCourse should throw');
   } catch (err) {
     assert.strictEqual(err.code, ERROR_CODES.IA_TIMEOUT);


### PR DESCRIPTION
## Summary
- allow specifying a visual style in course prompts
- describe expected Mermaid diagrams and Chart.js canvases in rendered HTML
- forward visual style from course generation service

## Testing
- `npm test` *(fails: Cannot find module 'sanitize-html')*

------
https://chatgpt.com/codex/tasks/task_e_68ac6648dc188325a8aca66bc7d01d26