### PR TITLE
feat: render mermaid diagrams and charts

### DIFF
--- a/frontend/app/assets/css/app.css
+++ b/frontend/app/assets/css/app.css
@@ -2650,3 +2650,26 @@ body::before {
 .checkbox-item input[type="checkbox"] {
     margin-right: 6px;
 }
+
+/* ==========================================================================
+   Mermaid & Chart.js visuals
+   ========================================================================== */
+
+pre.mermaid {
+    background: #fff;
+    border: 2px solid #e2e8f0;
+    border-radius: 10px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+    margin: 20px 0;
+    padding: 20px;
+}
+
+canvas[data-chart] {
+    display: block;
+    width: 100% !important;
+    background: #fff;
+    border: 2px solid #e2e8f0;
+    border-radius: 10px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+    margin: 20px 0;
+}

--- a/frontend/app/assets/js/course-manager.js
+++ b/frontend/app/assets/js/course-manager.js
@@ -258,7 +258,9 @@ class CourseManager {
       ? utils.sanitizeHTML(course.content)
       : course.content;
     document.getElementById('generatedCourse').innerHTML = sanitizedContent;
-    
+
+    this.renderVisuals();
+
     // Réinitialiser le chat
     const chatMessages = document.getElementById('chatMessages');
     chatMessages.innerHTML = '';
@@ -269,6 +271,30 @@ class CourseManager {
     document.getElementById('quizSection').innerHTML = '';
     
     utils.initializeLucide();
+  }
+
+  renderVisuals() {
+    // Initialiser Mermaid si des balises <pre class="mermaid"> sont présentes
+    if (window.mermaid && document.querySelector('pre.mermaid')) {
+      try {
+        mermaid.initialize({ startOnLoad: false });
+        mermaid.init(undefined, document.querySelectorAll('pre.mermaid'));
+      } catch (error) {
+        console.error('Erreur Mermaid:', error);
+      }
+    }
+
+    // Initialiser Chart.js pour chaque canvas disposant de l'attribut data-chart
+    if (window.Chart) {
+      document.querySelectorAll('canvas[data-chart]').forEach(canvas => {
+        try {
+          const config = JSON.parse(canvas.dataset.chart || '{}');
+          new Chart(canvas.getContext('2d'), config);
+        } catch (error) {
+          console.error('Erreur Chart.js:', error);
+        }
+      });
+    }
   }
 
   // Charger l'historique utilisateur

--- a/frontend/app/index.html
+++ b/frontend/app/index.html
@@ -191,6 +191,8 @@
     <script src="assets/js/auth-check.js"></script>
     <script type="module" src="assets/js/app-init.js"></script>
     <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.js"></script>
+    <script src="https://unpkg.com/mermaid@10/dist/mermaid.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script type="module" src="assets/js/utils/utils.js"></script>
     <script src="assets/js/googleAuth.js"></script>
     <script type="module" src="assets/js/auth.js"></script>


### PR DESCRIPTION
## Summary
- load Mermaid and Chart.js in app index
- render Mermaid diagrams and Chart.js charts after course injection
- add themed styles for Mermaid and chart visuals

## Testing
- `npm test` *(fails: Cannot find module 'sanitize-html', '@prisma/client', 'supertest')*

------
https://chatgpt.com/codex/tasks/task_e_68ac70fe4e448325bcf8c6ee41817439