### PR TITLE
feat: add intensity slider and update pedagogy logic

### DIFF
--- a/backend/src/middleware/validation.js
+++ b/backend/src/middleware/validation.js
@@ -1,7 +1,7 @@
 // backend/src/middleware/validation.js
 const { body, validationResult } = require('express-validator');
 const { createResponse } = require('../utils/helpers');
-const { HTTP_STATUS, DURATIONS, TEACHER_TYPES, VULGARIZATION_LEVELS } = require('../utils/constants');
+const { HTTP_STATUS, DURATIONS, TEACHER_TYPES, VULGARIZATION_LEVELS, INTENSITY_LEVELS } = require('../utils/constants');
 
 // Middleware pour gérer les erreurs de validation
 const handleValidationErrors = (req, res, next) => {
@@ -48,6 +48,10 @@ const courseValidation = [
     .trim()
     .isLength({ min: 1, max: 500 })
     .withMessage('Le sujet doit faire entre 1 et 500 caractères'),
+  body('intensity')
+    .optional()
+    .isIn(Object.values(INTENSITY_LEVELS))
+    .withMessage("Niveau d'intensité invalide"),
   body('teacher_type')
     .optional()
     .isIn(Object.values(TEACHER_TYPES))

--- a/backend/src/utils/constants.js
+++ b/backend/src/utils/constants.js
@@ -40,6 +40,29 @@ const DURATIONS = {
   LONG: 'long'
 };
 
+// Niveaux d'intensité pédagogique
+const INTENSITY_LEVELS = {
+  RAPID_SIMPLE: 'rapid_simple',
+  BALANCED: 'balanced',
+  DEEP_EXPERT: 'deep_expert'
+};
+
+// Mapping intensité vers vulgarisation/durée
+const INTENSITY_TO_CONFIG = {
+  [INTENSITY_LEVELS.RAPID_SIMPLE]: {
+    vulgarization: VULGARIZATION_LEVELS.GENERAL_PUBLIC,
+    duration: DURATIONS.SHORT
+  },
+  [INTENSITY_LEVELS.BALANCED]: {
+    vulgarization: VULGARIZATION_LEVELS.ENLIGHTENED,
+    duration: DURATIONS.MEDIUM
+  },
+  [INTENSITY_LEVELS.DEEP_EXPERT]: {
+    vulgarization: VULGARIZATION_LEVELS.EXPERT,
+    duration: DURATIONS.LONG
+  }
+};
+
 // Types de questions
 const QUESTION_TYPES = {
   COURSE_RELATED: 'course-related',
@@ -126,5 +149,7 @@ module.exports = {
   HTTP_STATUS,
   ERROR_CODES,
   AI_ERROR_MESSAGES,
-  DURATIONS
+  DURATIONS,
+  INTENSITY_LEVELS,
+  INTENSITY_TO_CONFIG
 };

--- a/backend/tests/services/anthropicService.test.js
+++ b/backend/tests/services/anthropicService.test.js
@@ -18,25 +18,23 @@ Module._load = (request, parent, isMain) => {
 
 const anthropicService = require('../../src/services/anthropicService');
 Module._load = originalLoad;
-const { TEACHER_TYPES, DURATIONS, VULGARIZATION_LEVELS, ERROR_CODES } = require('../../src/utils/constants');
+const { TEACHER_TYPES, INTENSITY_LEVELS, ERROR_CODES } = require('../../src/utils/constants');
 
 test('createPrompt creates flexible educational content', () => {
   const prompt = anthropicService.createPrompt(
     'Sujet',
-    VULGARIZATION_LEVELS.GENERAL_PUBLIC,
-    DURATIONS.MEDIUM,
+    INTENSITY_LEVELS.BALANCED,
     TEACHER_TYPES.METHODICAL
   );
 
-  assert.match(prompt, /PHILOSOPHIE PÉDAGOGIQUE/);
+  assert.match(prompt, /PROFIL PÉDAGOGIQUE/);
   assert.match(prompt, /Pour aller plus loin/);
 });
 
 test('createPrompt allows pedagogical freedom', () => {
   const prompt = anthropicService.createPrompt(
     'Sujet',
-    VULGARIZATION_LEVELS.GENERAL_PUBLIC,
-    DURATIONS.MEDIUM,
+    INTENSITY_LEVELS.BALANCED,
     TEACHER_TYPES.METHODICAL
   );
 
@@ -90,7 +88,7 @@ test('APIUserAbortError does not trigger offline mode', async () => {
   };
 
   try {
-    await anthropicService.generateCourse('Sujet', VULGARIZATION_LEVELS.ENLIGHTENED, DURATIONS.SHORT, TEACHER_TYPES.METHODICAL);
+    await anthropicService.generateCourse('Sujet', INTENSITY_LEVELS.RAPID_SIMPLE, TEACHER_TYPES.METHODICAL);
     assert.fail('generateCourse should throw');
   } catch (err) {
     assert.strictEqual(err.code, ERROR_CODES.IA_TIMEOUT);

--- a/frontend/app/assets/css/app.css
+++ b/frontend/app/assets/css/app.css
@@ -2650,3 +2650,75 @@ body::before {
 .checkbox-item input[type="checkbox"] {
     margin-right: 6px;
 }
+
+/* Slider d'intensité pédagogique */
+.intensity-slider-container {
+    padding: 20px 0;
+}
+
+.slider-wrapper {
+    position: relative;
+    margin: 20px 0;
+}
+
+.intensity-slider {
+    width: 100%;
+    height: 8px;
+    -webkit-appearance: none;
+    appearance: none;
+    background: #e2e8f0;
+    border-radius: 5px;
+    outline: none;
+    cursor: pointer;
+}
+
+.intensity-slider::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    appearance: none;
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+    background: linear-gradient(135deg, #4299e1, #3182ce);
+    cursor: pointer;
+    box-shadow: 0 3px 10px rgba(66, 153, 225, 0.3);
+}
+
+.intensity-slider::-moz-range-thumb {
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+    background: linear-gradient(135deg, #4299e1, #3182ce);
+    cursor: pointer;
+    border: none;
+    box-shadow: 0 3px 10px rgba(66, 153, 225, 0.3);
+}
+
+.slider-labels {
+    display: flex;
+    justify-content: space-between;
+    margin: 10px 0;
+    font-size: 0.9rem;
+    font-weight: 600;
+}
+
+.slider-label {
+    flex: 1;
+    text-align: center;
+    color: #64748b;
+    transition: all 0.3s ease;
+}
+
+.slider-label.active {
+    color: #3182ce;
+    transform: scale(1.1);
+}
+
+.intensity-description {
+    text-align: center;
+    margin-top: 15px;
+    padding: 12px;
+    background: #f7fafc;
+    border-radius: 8px;
+    font-size: 0.9rem;
+    color: #4a5568;
+}

--- a/frontend/app/assets/js/course-manager.js
+++ b/frontend/app/assets/js/course-manager.js
@@ -106,7 +106,7 @@ class CourseManager {
   }
 
   // Générer un cours
-  async generateCourse(subject, vulgarization, duration, teacher_type) {
+  async generateCourse(subject, vulgarization, duration, teacher_type, intensity) {
     if (!this.checkRateLimit()) {
       return null;
     }
@@ -127,6 +127,9 @@ class CourseManager {
       }
       if (teacher_type && TEACHER_TYPE_LABELS[teacher_type]) {
         payload.teacher_type = utils.sanitizeInput(teacher_type);
+      }
+      if (intensity) {
+        payload.intensity = utils.sanitizeInput(intensity);
       }
 
       const response = await fetch(`${API_BASE_URL}/courses`, {

--- a/frontend/app/assets/js/main.js
+++ b/frontend/app/assets/js/main.js
@@ -33,6 +33,7 @@ document.addEventListener('DOMContentLoaded', function() {
 function initializeApp() {
     // Configuration initiale de l'interface
     setupFormControls();
+    initializeGauges();
 }
 
 function setupEventListeners() {
@@ -62,17 +63,7 @@ function setupEventListeners() {
 async function handleGenerateCourse() {
     const subject = document.getElementById('subject').value.trim();
     const subjectLength = subject.length;
-    const cfg = (typeof configManager !== 'undefined' && configManager) ?
-        configManager.getConfig() : {
-          vulgarization: 'enlightened',
-          duration: 'medium',
-          teacher_type: 'methodical'
-        };
-    const isLegacyPayload = !cfg.vulgarization && !cfg.duration && !cfg.teacher_type;
-    cfg.vulgarization ??= 'enlightened';
-    cfg.duration ??= 'medium';
-    cfg.teacher_type ??= 'methodical';
-    const { vulgarization, duration, teacher_type } = cfg;
+    const { teacher_type, intensity, vulgarization, duration } = collectFormParameters();
 
     if (!subject) {
         utils.handleAuthError('Veuillez entrer un sujet pour le décryptage');
@@ -85,7 +76,8 @@ async function handleGenerateCourse() {
                 subject,
                 vulgarization,
                 duration,
-                teacher_type
+                teacher_type,
+                intensity
             );
             if (course) {
                 currentCourse = course;
@@ -99,10 +91,10 @@ async function handleGenerateCourse() {
 
                 if (typeof gtag === 'function') {
                     gtag('event', 'course_generation', {
+                        intensity,
                         vulgarization,
                         duration,
                         teacher_type,
-                        isLegacyPayload,
                         subject_length: subjectLength
                     });
                 }
@@ -206,102 +198,78 @@ async function askQuestion() {
 }
 
 // Jauges et contrôles (copiés de votre ancien script)
-const detailLevels = {
-    1: { name: 'Synthèse', description: 'Cours concis avec les points essentiels.' },
-    2: { name: 'Détaillé', description: 'Cours complet avec explications approfondies.' },
-    3: { name: 'Exhaustif', description: 'Analyse très complète avec références.' }
-};
-
-const vulgarizationLevels = {
-    1: { name: 'Grand Public', description: 'Comme expliquer à votre grand-mère' },
-    2: { name: 'Éclairé', description: 'Niveau bac scientifique' },
-    3: { name: 'Connaisseur', description: 'Niveau université' },
-    4: { name: 'Expert', description: 'Vocabulaire technique assumé' }
-};
-
-const combinations = {
-    '1-1': { icon: '🎯', text: 'Synthèse grand public - Vue d\'ensemble accessible' },
-    '1-4': { icon: '⚡', text: 'Synthèse expert - Résumé technique' },
-    '2-1': { icon: '📚', text: 'Guide détaillé grand public' },
-    '2-2': { icon: '🎯', text: 'Cours détaillé et accessible' },
-    '2-3': { icon: '🔧', text: 'Cours technique détaillé' },
-    '3-1': { icon: '📖', text: 'Manuel complet grand public' },
-    '3-4': { icon: '🎓', text: 'Analyse exhaustive expert' }
-};
-
-function updateDetailGauge() {
-    const slider = document.getElementById('detailSlider');
-    const value = parseInt(slider.value);
-    const level = detailLevels[value];
-    
-    const valueEl = document.getElementById('detailValue');
-    const descEl = document.getElementById('detailDescription');
-    const trackEl = document.getElementById('detailTrack');
-    
-    if (valueEl) valueEl.textContent = level.name;
-    if (descEl) descEl.innerHTML = `<strong>${level.name} :</strong> ${level.description}`;
-    if (trackEl) {
-        const percentage = ((value - 1) / 2) * 100;
-        trackEl.style.width = `${percentage}%`;
+const intensityLevels = {
+    1: {
+        name: 'Rapide & Simple',
+        description: 'Cours concis et accessible, synthèse des points essentiels',
+        vulgarization: 'general_public',
+        duration: 'short'
+    },
+    2: {
+        name: 'Équilibré',
+        description: 'Cours complet avec bon équilibre accessibilité/profondeur',
+        vulgarization: 'enlightened',
+        duration: 'medium'
+    },
+    3: {
+        name: 'Approfondi & Expert',
+        description: 'Analyse détaillée avec vocabulaire technique et références',
+        vulgarization: 'expert',
+        duration: 'long'
     }
-    
-    updateCombination();
-}
+};
 
-function updateVulgarizationGauge() {
-    const slider = document.getElementById('vulgarizationSlider');
+function updateIntensitySlider() {
+    const slider = document.getElementById('intensitySlider');
     const value = parseInt(slider.value);
-    const level = vulgarizationLevels[value];
-    
-    const valueEl = document.getElementById('vulgarizationValue');
-    const descEl = document.getElementById('vulgarizationDescription');
-    const trackEl = document.getElementById('vulgarizationTrack');
-    
-    if (valueEl) valueEl.textContent = level.name;
-    if (descEl) descEl.innerHTML = `<strong>${level.name} :</strong> ${level.description}`;
-    if (trackEl) {
-        const percentage = ((value - 1) / 3) * 100;
-        trackEl.style.width = `${percentage}%`;
-    }
-    
-    updateCombination();
-}
+    const level = intensityLevels[value];
 
-function updateCombination() {
-    const detailSlider = document.getElementById('detailSlider');
-    const vulgarSlider = document.getElementById('vulgarizationSlider');
-    
-    if (!detailSlider || !vulgarSlider) return;
-    
-    const detailVal = detailSlider.value;
-    const vulgarVal = vulgarSlider.value;
-    const key = `${detailVal}-${vulgarVal}`;
-    
-    const combination = combinations[key] || { 
-        icon: '⚙️', 
-        text: `Configuration personnalisée (Détail: ${detailLevels[detailVal]?.name}, Vulgarisation: ${vulgarizationLevels[vulgarVal]?.name})` 
+    const descEl = document.getElementById('intensityDescription');
+
+    if (descEl) {
+        descEl.innerHTML = `<strong>${level.name} :</strong> ${level.description}`;
+    }
+
+    document.querySelectorAll('.slider-label').forEach(label => {
+        label.classList.remove('active');
+    });
+
+    const labels = document.querySelectorAll('.slider-label');
+    if (labels[value - 1]) {
+        labels[value - 1].classList.add('active');
+    }
+
+    window.currentIntensity = {
+        vulgarization: level.vulgarization,
+        duration: level.duration,
+        level: value
     };
-    
-    const iconEl = document.querySelector('.combination-icon');
-    const textEl = document.getElementById('combinationText');
-    
-    if (iconEl) iconEl.textContent = combination.icon;
-    if (textEl) textEl.textContent = combination.text;
+}
+
+function initializeIntensitySlider() {
+    const slider = document.getElementById('intensitySlider');
+
+    if (slider) {
+        slider.addEventListener('input', updateIntensitySlider);
+        updateIntensitySlider();
+    }
 }
 
 function initializeGauges() {
-    const detailSlider = document.getElementById('detailSlider');
-    const vulgarizationSlider = document.getElementById('vulgarizationSlider');
-    
-    if (detailSlider) {
-        detailSlider.addEventListener('input', updateDetailGauge);
-        updateDetailGauge();
-    }
-    
-    if (vulgarizationSlider) {
-        vulgarizationSlider.addEventListener('input', updateVulgarizationGauge);
-        updateVulgarizationGauge();
-    }
+    initializeIntensitySlider();
+}
+
+function collectFormParameters() {
+    const teacherType = document.querySelector('[data-type="teacher_type"].active')?.dataset.value || 'methodical';
+    const intensity = window.currentIntensity || intensityLevels[2];
+
+    return {
+        teacher_type: teacherType,
+        intensity: intensity.level === 1 ? 'rapid_simple' : intensity.level === 2 ? 'balanced' : 'deep_expert',
+        // Conserver rétrocompatibilité
+        vulgarization: intensity.vulgarization,
+        duration: intensity.duration
+    };
 }
 
 function setupFormControls() {

--- a/frontend/app/index.html
+++ b/frontend/app/index.html
@@ -53,20 +53,27 @@
                             <div id="advancedSettings" class="advanced-settings">
                                 <div class="new-selector-container">
                                     <div class="selector-group">
-                                        <div class="selector-title">📚 Niveau de vulgarisation</div>
-                                        <div class="selector-buttons">
-                                            <button data-type="vulgarization" data-value="general_public" class="active">Grand public</button>
-                                            <button data-type="vulgarization" data-value="enlightened">Éclairé</button>
-                                            <button data-type="vulgarization" data-value="knowledgeable">Connaisseur</button>
-                                            <button data-type="vulgarization" data-value="expert">Expert</button>
-                                        </div>
-                                    </div>
-                                    <div class="selector-group">
-                                        <div class="selector-title">⏱️ Durée</div>
-                                        <div class="selector-buttons">
-                                            <button data-type="duration" data-value="short" class="active">Courte</button>
-                                            <button data-type="duration" data-value="medium">Moyenne</button>
-                                            <button data-type="duration" data-value="long">Longue</button>
+                                        <div class="selector-title">🎓 Intensité Pédagogique</div>
+                                        <div class="intensity-slider-container">
+                                            <div class="slider-wrapper">
+                                                <input type="range"
+                                                       id="intensitySlider"
+                                                       min="1"
+                                                       max="3"
+                                                       value="2"
+                                                       class="intensity-slider">
+                                                <div class="slider-track">
+                                                    <div class="slider-fill" id="intensityTrack"></div>
+                                                </div>
+                                            </div>
+                                            <div class="slider-labels">
+                                                <span class="slider-label left">⚡ Rapide & Simple</span>
+                                                <span class="slider-label center">⚖️ Équilibré</span>
+                                                <span class="slider-label right">🎓 Approfondi & Expert</span>
+                                            </div>
+                                            <div class="intensity-description" id="intensityDescription">
+                                                <strong>Équilibré :</strong> Cours complet avec bon équilibre accessibilité/profondeur
+                                            </div>
                                         </div>
                                     </div>
                                     <div class="selector-group">

--- a/frontend/marketing/assets/css/marketing.css
+++ b/frontend/marketing/assets/css/marketing.css
@@ -2527,3 +2527,75 @@ body {
     margin-right: 10px;
 }
 
+/* Slider d'intensité pédagogique */
+.intensity-slider-container {
+    padding: 20px 0;
+}
+
+.slider-wrapper {
+    position: relative;
+    margin: 20px 0;
+}
+
+.intensity-slider {
+    width: 100%;
+    height: 8px;
+    -webkit-appearance: none;
+    appearance: none;
+    background: #e2e8f0;
+    border-radius: 5px;
+    outline: none;
+    cursor: pointer;
+}
+
+.intensity-slider::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    appearance: none;
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+    background: linear-gradient(135deg, #4299e1, #3182ce);
+    cursor: pointer;
+    box-shadow: 0 3px 10px rgba(66, 153, 225, 0.3);
+}
+
+.intensity-slider::-moz-range-thumb {
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+    background: linear-gradient(135deg, #4299e1, #3182ce);
+    cursor: pointer;
+    border: none;
+    box-shadow: 0 3px 10px rgba(66, 153, 225, 0.3);
+}
+
+.slider-labels {
+    display: flex;
+    justify-content: space-between;
+    margin: 10px 0;
+    font-size: 0.9rem;
+    font-weight: 600;
+}
+
+.slider-label {
+    flex: 1;
+    text-align: center;
+    color: #64748b;
+    transition: all 0.3s ease;
+}
+
+.slider-label.active {
+    color: #3182ce;
+    transform: scale(1.1);
+}
+
+.intensity-description {
+    text-align: center;
+    margin-top: 15px;
+    padding: 12px;
+    background: #f7fafc;
+    border-radius: 8px;
+    font-size: 0.9rem;
+    color: #4a5568;
+}
+

--- a/frontend/marketing/assets/js/main.js
+++ b/frontend/marketing/assets/js/main.js
@@ -49,103 +49,75 @@ function setupEventListeners() {
     }
 }
 
-// Jauges et contrôles (copiés de votre ancien script)
-const detailLevels = {
-    1: { name: 'Synthèse', description: 'Cours concis avec les points essentiels.' },
-    2: { name: 'Détaillé', description: 'Cours complet avec explications approfondies.' },
-    3: { name: 'Exhaustif', description: 'Analyse très complète avec références.' }
-};
-
-const vulgarizationLevels = {
-    1: { name: 'Grand Public', description: 'Comme expliquer à votre grand-mère' },
-    2: { name: 'Éclairé', description: 'Niveau bac scientifique' },
-    3: { name: 'Connaisseur', description: 'Niveau université' },
-    4: { name: 'Expert', description: 'Vocabulaire technique assumé' }
-};
-
-const combinations = {
-    '1-1': { icon: '🎯', text: 'Synthèse grand public - Vue d\'ensemble accessible' },
-    '1-4': { icon: '⚡', text: 'Synthèse expert - Résumé technique' },
-    '2-1': { icon: '📚', text: 'Guide détaillé grand public' },
-    '2-2': { icon: '🎯', text: 'Cours détaillé et accessible' },
-    '2-3': { icon: '🔧', text: 'Cours technique détaillé' },
-    '3-1': { icon: '📖', text: 'Manuel complet grand public' },
-    '3-4': { icon: '🎓', text: 'Analyse exhaustive expert' }
-};
-
-function updateDetailGauge() {
-    const slider = document.getElementById('detailSlider');
-    const value = parseInt(slider.value);
-    const level = detailLevels[value];
-    
-    const valueEl = document.getElementById('detailValue');
-    const descEl = document.getElementById('detailDescription');
-    const trackEl = document.getElementById('detailTrack');
-    
-    if (valueEl) valueEl.textContent = level.name;
-    if (descEl) descEl.innerHTML = `<strong>${level.name} :</strong> ${level.description}`;
-    if (trackEl) {
-        const percentage = ((value - 1) / 2) * 100;
-        trackEl.style.width = `${percentage}%`;
+// Contrôle d'intensité pédagogique
+const intensityLevels = {
+    1: {
+        name: 'Rapide & Simple',
+        description: 'Cours concis et accessible, synthèse des points essentiels',
+        vulgarization: 'general_public',
+        duration: 'short'
+    },
+    2: {
+        name: 'Équilibré',
+        description: 'Cours complet avec bon équilibre accessibilité/profondeur',
+        vulgarization: 'enlightened',
+        duration: 'medium'
+    },
+    3: {
+        name: 'Approfondi & Expert',
+        description: 'Analyse détaillée avec vocabulaire technique et références',
+        vulgarization: 'expert',
+        duration: 'long'
     }
-    
-    updateCombination();
-}
+};
 
-function updateVulgarizationGauge() {
-    const slider = document.getElementById('vulgarizationSlider');
+function updateIntensitySlider() {
+    const slider = document.getElementById('intensitySlider');
     const value = parseInt(slider.value);
-    const level = vulgarizationLevels[value];
-    
-    const valueEl = document.getElementById('vulgarizationValue');
-    const descEl = document.getElementById('vulgarizationDescription');
-    const trackEl = document.getElementById('vulgarizationTrack');
-    
-    if (valueEl) valueEl.textContent = level.name;
-    if (descEl) descEl.innerHTML = `<strong>${level.name} :</strong> ${level.description}`;
-    if (trackEl) {
-        const percentage = ((value - 1) / 3) * 100;
-        trackEl.style.width = `${percentage}%`;
-    }
-    
-    updateCombination();
-}
+    const level = intensityLevels[value];
 
-function updateCombination() {
-    const detailSlider = document.getElementById('detailSlider');
-    const vulgarSlider = document.getElementById('vulgarizationSlider');
-    
-    if (!detailSlider || !vulgarSlider) return;
-    
-    const detailVal = detailSlider.value;
-    const vulgarVal = vulgarSlider.value;
-    const key = `${detailVal}-${vulgarVal}`;
-    
-    const combination = combinations[key] || { 
-        icon: '⚙️', 
-        text: `Configuration personnalisée (Détail: ${detailLevels[detailVal]?.name}, Vulgarisation: ${vulgarizationLevels[vulgarVal]?.name})` 
+    const descEl = document.getElementById('intensityDescription');
+    if (descEl) {
+        descEl.innerHTML = `<strong>${level.name} :</strong> ${level.description}`;
+    }
+
+    document.querySelectorAll('.slider-label').forEach(label => {
+        label.classList.remove('active');
+    });
+    const labels = document.querySelectorAll('.slider-label');
+    if (labels[value - 1]) {
+        labels[value - 1].classList.add('active');
+    }
+
+    window.currentIntensity = {
+        vulgarization: level.vulgarization,
+        duration: level.duration,
+        level: value
     };
-    
-    const iconEl = document.querySelector('.combination-icon');
-    const textEl = document.getElementById('combinationText');
-    
-    if (iconEl) iconEl.textContent = combination.icon;
-    if (textEl) textEl.textContent = combination.text;
+}
+
+function initializeIntensitySlider() {
+    const slider = document.getElementById('intensitySlider');
+    if (slider) {
+        slider.addEventListener('input', updateIntensitySlider);
+        updateIntensitySlider();
+    }
 }
 
 function initializeGauges() {
-    const detailSlider = document.getElementById('detailSlider');
-    const vulgarizationSlider = document.getElementById('vulgarizationSlider');
-    
-    if (detailSlider) {
-        detailSlider.addEventListener('input', updateDetailGauge);
-        updateDetailGauge();
-    }
-    
-    if (vulgarizationSlider) {
-        vulgarizationSlider.addEventListener('input', updateVulgarizationGauge);
-        updateVulgarizationGauge();
-    }
+    initializeIntensitySlider();
+}
+
+function collectFormParameters() {
+    const teacherType = document.querySelector('[data-type="teacher_type"].active')?.dataset.value || 'methodical';
+    const intensity = window.currentIntensity || intensityLevels[2];
+
+    return {
+        teacher_type: teacherType,
+        intensity: intensity.level === 1 ? 'rapid_simple' : intensity.level === 2 ? 'balanced' : 'deep_expert',
+        vulgarization: intensity.vulgarization,
+        duration: intensity.duration
+    };
 }
 
 function setupFormControls() {

--- a/frontend/marketing/index.html
+++ b/frontend/marketing/index.html
@@ -41,6 +41,33 @@
                 <h2>Tarifs</h2>
                 <p>Choisissez le plan qui vous convient, de l'accès gratuit aux fonctionnalités avancées pour les apprenants passionnés.</p>
             </section>
+
+            <section class="marketing-section">
+                <div class="selector-group">
+                    <div class="selector-title">🎓 Intensité Pédagogique</div>
+                    <div class="intensity-slider-container">
+                        <div class="slider-wrapper">
+                            <input type="range"
+                                   id="intensitySlider"
+                                   min="1"
+                                   max="3"
+                                   value="2"
+                                   class="intensity-slider">
+                            <div class="slider-track">
+                                <div class="slider-fill" id="intensityTrack"></div>
+                            </div>
+                        </div>
+                        <div class="slider-labels">
+                            <span class="slider-label left">⚡ Rapide & Simple</span>
+                            <span class="slider-label center">⚖️ Équilibré</span>
+                            <span class="slider-label right">🎓 Approfondi & Expert</span>
+                        </div>
+                        <div class="intensity-description" id="intensityDescription">
+                            <strong>Équilibré :</strong> Cours complet avec bon équilibre accessibilité/profondeur
+                        </div>
+                    </div>
+                </div>
+            </section>
         </main>
     </div>
 
@@ -51,5 +78,6 @@
         lucide.createIcons();
     </script>
     <script type="module" src="assets/js/utils.js"></script>
+    <script type="module" src="assets/js/main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replace separate duration and vulgarization controls with unified intensity slider
- refine teacher style and intensity prompts for course generation
- validate and process new intensity parameter across backend

## Testing
- `node --test frontend/tests/*.js`
- `node --test backend/tests/controllers/courseController.test.js`
- `node --test backend/tests/services/anthropicService.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68adc4bc928c832599f0f259f7643d82