### PR TITLE
feat: revamp teacher personas

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The `POST /api/courses` endpoint now supports the following parameters:
 - `subject` (string, required): topic to generate a course about.
 - `vulgarization` (string, required): target audience. Accepted values: `general_public`, `enlightened`, `knowledgeable`, `expert`.
 - `duration` (string, required): estimated course length. Accepted values: `short`, `medium`, `long`.
-- `teacher_type` (string, required): teaching persona. Accepted values: `methodical`, `passionate`, `analogist`, `pragmatic`, `benevolent`, `synthetic`.
+- `teacher_type` (string, required): teaching persona. Accepted values: `spark`, `builder`, `storyteller`, `lightning`.
 - `detailLevel` (number, deprecated): legacy field mapped to `duration`.
 - `vulgarizationLevel` (number, deprecated): legacy field mapped to `vulgarization`.
 - `style` (string, deprecated): maps to `vulgarization`.
@@ -20,7 +20,7 @@ The `POST /api/courses` endpoint now supports the following parameters:
   "subject": "Introduction to Algebra",
   "vulgarization": "enlightened",
   "duration": "medium",
-  "teacher_type": "methodical"
+  "teacher_type": "builder"
 }
 ```
 
@@ -36,7 +36,7 @@ The `POST /api/courses` endpoint now supports the following parameters:
     "vulgarizationLevel": 2,
     "vulgarization": "enlightened",
     "duration": "medium",
-    "teacherType": "methodical",
+    "teacherType": "builder",
     "createdAt": "2024-01-01T00:00:00.000Z"
   }
 }

--- a/backend/docs/api.md
+++ b/backend/docs/api.md
@@ -21,7 +21,7 @@ Creates a new course for the authenticated user.
 ### New fields
 - `vulgarization` (string, required): audience level. Values: `general_public`, `enlightened`, `knowledgeable`, `expert`.
 - `duration` (string, required): course length. Values: `short`, `medium`, `long`.
-- `teacher_type` (string, required): teacher persona. Values: `methodical`, `passionate`, `analogist`, `pragmatic`, `benevolent`, `synthetic`.
+- `teacher_type` (string, required): teacher persona. Values: `spark`, `builder`, `storyteller`, `lightning`.
 
 ### Deprecated fields
 - `detailLevel` (number): 1 `synthesis`, 2 `detailed`, 3 `exhaustive`. Replaced by `duration`.
@@ -39,7 +39,7 @@ Content-Type: application/json
   "subject": "Introduction to Algebra",
   "vulgarization": "enlightened",
   "duration": "medium",
-  "teacher_type": "methodical"
+  "teacher_type": "builder"
 }
 ```
 

--- a/backend/src/middleware/validation.js
+++ b/backend/src/middleware/validation.js
@@ -1,7 +1,7 @@
 // backend/src/middleware/validation.js
 const { body, validationResult } = require('express-validator');
 const { createResponse } = require('../utils/helpers');
-const { HTTP_STATUS, DURATIONS, TEACHER_TYPES, VULGARIZATION_LEVELS, INTENSITY_LEVELS } = require('../utils/constants');
+const { HTTP_STATUS, DURATIONS, VULGARIZATION_LEVELS, INTENSITY_LEVELS } = require('../utils/constants');
 
 // Middleware pour gérer les erreurs de validation
 const handleValidationErrors = (req, res, next) => {
@@ -54,7 +54,7 @@ const courseValidation = [
     .withMessage("Niveau d'intensité invalide"),
   body('teacher_type')
     .optional()
-    .isIn(Object.values(TEACHER_TYPES))
+    .isIn(['spark', 'builder', 'storyteller', 'lightning'])
     .withMessage("Type d'enseignant invalide"),
   body('vulgarization')
     .optional()
@@ -68,7 +68,7 @@ const courseValidation = [
   // Alias de compatibilité
   body('teacherType')
     .optional()
-    .isIn(Object.values(TEACHER_TYPES))
+    .isIn(['spark', 'builder', 'storyteller', 'lightning'])
     .withMessage("Type d'enseignant invalide"),
   body('vulgarizationLevel')
     .optional()

--- a/backend/src/services/anthropicService.js
+++ b/backend/src/services/anthropicService.js
@@ -27,41 +27,29 @@ const DURATION_TO_WORDS = {
 
 // Instructions détaillées selon le type de prof
 const TEACHER_STYLE_INSTRUCTIONS = {
-  [TEACHER_TYPES.METHODICAL]: {
-    approach: "Adopte une approche méthodique et structurée avec des étapes claires.",
-    structure: "Organise le contenu en sections numérotées avec des sous-parties logiques.",
-    language: "Utilise un vocabulaire précis et des transitions explicites entre les idées.",
-    examples: "Propose des exemples concrets suivant une progression logique."
+  [TEACHER_TYPES.SPARK]: {
+    approach: "Transmets l'information avec passion explosive et enthousiasme contagieux.",
+    structure: "Commence par captiver avec une anecdote épique, transforme chaque point en découverte fascinante.",
+    language: "Emploie un ton dynamique avec exclamations, vocabulaire vivant et métaphores enflammées.",
+    examples: "Raconte des histoires inspirantes, utilise des découvertes révolutionnaires comme exemples."
   },
-  [TEACHER_TYPES.PASSIONATE]: {
-    approach: "Transmets l'information avec passion, enthousiasme et émotion.",
-    structure: "Commence par captiver l'attention avec des anecdotes ou faits marquants.",
-    language: "Emploie un ton dynamique, des exclamations et un vocabulaire vivant.",
-    examples: "Raconte des histoires inspirantes et des découvertes fascinantes."
+  [TEACHER_TYPES.BUILDER]: {
+    approach: "Décompose la connaissance étape par étape comme un guide de construction.",
+    structure: "Organise en phases claires : fondations → construction → assemblage final.",
+    language: "Utilise un vocabulaire de construction : 'construisons', 'assemblons', 'posons les bases'.",
+    examples: "Donne des analogies de construction, compare aux projets DIY, explique l'utilité pratique."
   },
-  [TEACHER_TYPES.ANALOGIST]: {
-    approach: "Explique chaque concept complexe par des analogies du quotidien.",
-    structure: "Alterne systématiquement entre concept théorique et analogie concrète.",
-    language: "Utilise des comparaisons : 'C'est comme...', 'Imagine que...', 'À l'image de...'",
-    examples: "Transforme les notions abstraites en situations familières et visuelles."
+  [TEACHER_TYPES.STORYTELLER]: {
+    approach: "Transforme chaque concept en conte merveilleux avec des analogies magiques.",
+    structure: "Structure comme un récit : situation initiale → transformation → résolution.",
+    language: "Adopte un ton bienveillant de conteur : 'Il était une fois...', 'Imagine un royaume où...'",
+    examples: "Utilise des métaphores fantastiques, des personnages, des univers imaginaires."
   },
-  [TEACHER_TYPES.PRAGMATIC]: {
-    approach: "Mets l'accent sur les applications pratiques et l'utilité concrète.",
-    structure: "Présente d'abord l'utilité pratique avant la théorie.",
-    language: "Privilégie les termes concrets et les bénéfices tangibles.",
-    examples: "Donne des cas d'usage réels, des outils pratiques et des conseils applicables."
-  },
-  [TEACHER_TYPES.BENEVOLENT]: {
-    approach: "Adopte un ton bienveillant, encourageant et rassurant.",
-    structure: "Progresse graduellement, en rassurant sur la difficulté.",
-    language: "Utilise des formulations positives et encourageantes.",
-    examples: "Propose des exercices progressifs et valorise chaque étape d'apprentissage."
-  },
-  [TEACHER_TYPES.SYNTHETIC]: {
-    approach: "Propose des synthèses claires, concises et structurées.",
-    structure: "Présente les informations sous forme de listes, tableaux, schémas.",
-    language: "Privilégie la clarté et la concision, évite les digressions.",
-    examples: "Résume en points clés, fait des comparaisons synthétiques."
+  [TEACHER_TYPES.LIGHTNING]: {
+    approach: "Synthétise avec une efficacité redoutable, va à l'essentiel avec impact.",
+    structure: "Structure ultra-claire : points clés → schémas → synthèse percutante.",
+    language: "Style direct et percutant, phrases courtes et mémorables.",
+    examples: "Résumés en bullet points, comparaisons synthétiques, tableaux visuels."
   }
 };
 
@@ -165,7 +153,7 @@ class AnthropicService {
   getAdaptiveInstructions(teacherType, intensity = 'balanced') {
     const teacher =
       TEACHER_STYLE_INSTRUCTIONS[teacherType] ||
-      TEACHER_STYLE_INSTRUCTIONS[TEACHER_TYPES.METHODICAL];
+      TEACHER_STYLE_INSTRUCTIONS[TEACHER_TYPES.BUILDER];
     const intensityConfig =
       INTENSITY_INSTRUCTIONS[intensity] || INTENSITY_INSTRUCTIONS['balanced'];
 
@@ -213,7 +201,7 @@ Sujet à traiter : ${subject}`;
       return this.getOfflineMessage();
     }
 
-    teacherType = teacherType || TEACHER_TYPES.METHODICAL;
+    teacherType = teacherType || TEACHER_TYPES.BUILDER;
 
     try {
       const prompt = this.createPrompt(subject, intensity, teacherType);

--- a/backend/src/services/onboardingService.js
+++ b/backend/src/services/onboardingService.js
@@ -14,12 +14,10 @@ const QUESTION_CONFIG = [
     label: "Quel type d'enseignant préfères-tu ?",
     type: 'select',
     options: [
-      { value: 'methodical', label: 'Méthodique' },
-      { value: 'passionate', label: 'Passionné' },
-      { value: 'analogist', label: 'Analogiste' },
-      { value: 'pragmatic', label: 'Pragmatique' },
-      { value: 'benevolent', label: 'Bienveillant' },
-      { value: 'synthetic', label: 'Synthétique' }
+      { value: 'spark', label: '🔥 Prof Étincelle' },
+      { value: 'builder', label: '🏗️ Prof Lego' },
+      { value: 'storyteller', label: '🧙‍♂️ Prof Métaphore' },
+      { value: 'lightning', label: '⚡ Prof Flash' }
     ]
   },
   {

--- a/backend/src/utils/constants.js
+++ b/backend/src/utils/constants.js
@@ -25,12 +25,10 @@ const LEGACY_VULGARIZATION_LEVELS = {
 
 // Types d'enseignants
 const TEACHER_TYPES = {
-  METHODICAL: 'methodical',
-  PASSIONATE: 'passionate',
-  ANALOGIST: 'analogist',
-  PRAGMATIC: 'pragmatic',
-  BENEVOLENT: 'benevolent',
-  SYNTHETIC: 'synthetic'
+  SPARK: 'spark',
+  BUILDER: 'builder',
+  STORYTELLER: 'storyteller',
+  LIGHTNING: 'lightning'
 };
 
 // Durées estimées des cours

--- a/backend/src/utils/helpers.js
+++ b/backend/src/utils/helpers.js
@@ -72,7 +72,17 @@ const mapLegacyParams = ({
     [LEGACY_VULGARIZATION_LEVELS.EXPERT]: VULGARIZATION_LEVELS.EXPERT,
   };
 
-  const finalTeacherType = teacherType || TEACHER_TYPES.METHODICAL;
+  const legacyTeacherMap = {
+    methodical: TEACHER_TYPES.BUILDER,
+    pragmatic: TEACHER_TYPES.BUILDER,
+    analogist: TEACHER_TYPES.STORYTELLER,
+    benevolent: TEACHER_TYPES.STORYTELLER,
+    passionate: TEACHER_TYPES.SPARK,
+    synthetic: TEACHER_TYPES.LIGHTNING
+  };
+
+  const normalizedTeacherType = legacyTeacherMap[teacherType] || teacherType;
+  const finalTeacherType = normalizedTeacherType || TEACHER_TYPES.BUILDER;
   const finalDuration = duration || durationMap[detailLevel] || DURATIONS.MEDIUM;
   const finalVulgarization =
     vulgarization || vulgarizationMap[vulgarizationLevel] || VULGARIZATION_LEVELS.ENLIGHTENED;

--- a/backend/tests/controllers/courseController.test.js
+++ b/backend/tests/controllers/courseController.test.js
@@ -39,10 +39,15 @@ test('applies default duration, vulgarization and teacherType when none provided
   assert.strictEqual(result.duration, DURATIONS.MEDIUM);
   assert.strictEqual(result.vulgarization, VULGARIZATION_LEVELS.ENLIGHTENED);
   assert.strictEqual(result.vulgarizationLevel, LEGACY_VULGARIZATION_LEVELS.ENLIGHTENED);
-  assert.strictEqual(result.teacherType, TEACHER_TYPES.METHODICAL);
+  assert.strictEqual(result.teacherType, TEACHER_TYPES.BUILDER);
 });
 
 test('returns provided teacherType', () => {
-  const result = mapLegacyParams({ teacherType: TEACHER_TYPES.PASSIONATE });
-  assert.strictEqual(result.teacherType, TEACHER_TYPES.PASSIONATE);
+  const result = mapLegacyParams({ teacherType: TEACHER_TYPES.SPARK });
+  assert.strictEqual(result.teacherType, TEACHER_TYPES.SPARK);
+});
+
+test('maps legacy teacher types to new ones', () => {
+  const result = mapLegacyParams({ teacherType: 'pragmatic' });
+  assert.strictEqual(result.teacherType, TEACHER_TYPES.BUILDER);
 });

--- a/backend/tests/onboarding/onboarding.test.js
+++ b/backend/tests/onboarding/onboarding.test.js
@@ -7,11 +7,11 @@ test('calculateProfileConfidence computes fraction of answered questions', () =>
   const emptyProfile = {};
   assert.strictEqual(service.calculateProfileConfidence(emptyProfile), 0);
 
-  const partialProfile = { teacherType: 'methodical', vulgarization: 'general_public' };
+  const partialProfile = { teacherType: 'builder', vulgarization: 'general_public' };
   assert.strictEqual(service.calculateProfileConfidence(partialProfile), 2 / 3);
 
   const fullProfile = {
-    teacherType: 'methodical',
+    teacherType: 'builder',
     vulgarization: 'general_public',
     duration: 'short',
     interests: ['science', 'history']
@@ -21,14 +21,14 @@ test('calculateProfileConfidence computes fraction of answered questions', () =>
 
 test('needsOnboarding returns true when profile is missing fields', () => {
   const service = new OnboardingService();
-  const incompleteProfile = { teacherType: 'methodical', interests: ['science'] };
+  const incompleteProfile = { teacherType: 'builder', interests: ['science'] };
   assert.strictEqual(service.needsOnboarding(incompleteProfile), true);
 });
 
 test('needsOnboarding returns false when profile is complete', () => {
   const service = new OnboardingService();
   const fullProfile = {
-    teacherType: 'methodical',
+    teacherType: 'builder',
     vulgarization: 'general_public',
     duration: 'short',
     interests: ['science']
@@ -64,7 +64,7 @@ test('saveAnswers rejects when mandatory fields are missing', async () => {
   };
   const service = new OnboardingService(prismaMock);
   await assert.rejects(
-    service.saveAnswers('u1', { teacherType: 'methodical' }),
+    service.saveAnswers('u1', { teacherType: 'builder' }),
     /Champs obligatoires manquants/
   );
 });
@@ -94,7 +94,7 @@ test('saveAnswers stores optional fields including arrays', async () => {
 
   const service = new OnboardingService(prismaMock);
   const profile = await service.saveAnswers('u1', {
-    teacherType: 'methodical',
+    teacherType: 'builder',
     vulgarization: 'general_public',
     duration: 'short',
     interests: ['science', 'history'],

--- a/backend/tests/services/anthropicService.test.js
+++ b/backend/tests/services/anthropicService.test.js
@@ -24,7 +24,7 @@ test('createPrompt creates flexible educational content', () => {
   const prompt = anthropicService.createPrompt(
     'Sujet',
     INTENSITY_LEVELS.BALANCED,
-    TEACHER_TYPES.METHODICAL
+    TEACHER_TYPES.BUILDER
   );
 
   assert.match(prompt, /PROFIL PÉDAGOGIQUE/);
@@ -35,7 +35,7 @@ test('createPrompt allows pedagogical freedom', () => {
   const prompt = anthropicService.createPrompt(
     'Sujet',
     INTENSITY_LEVELS.BALANCED,
-    TEACHER_TYPES.METHODICAL
+    TEACHER_TYPES.BUILDER
   );
 
   assert.doesNotMatch(prompt, /STRUCTURE REQUISE/);
@@ -88,7 +88,7 @@ test('APIUserAbortError does not trigger offline mode', async () => {
   };
 
   try {
-    await anthropicService.generateCourse('Sujet', INTENSITY_LEVELS.RAPID_SIMPLE, TEACHER_TYPES.METHODICAL);
+    await anthropicService.generateCourse('Sujet', INTENSITY_LEVELS.RAPID_SIMPLE, TEACHER_TYPES.BUILDER);
     assert.fail('generateCourse should throw');
   } catch (err) {
     assert.strictEqual(err.code, ERROR_CODES.IA_TIMEOUT);

--- a/frontend/app/assets/js/course-manager.js
+++ b/frontend/app/assets/js/course-manager.js
@@ -18,13 +18,25 @@ export const DURATION_LABELS = {
 };
 
 export const TEACHER_TYPE_LABELS = {
-  methodical: 'Méthodique',
-  passionate: 'Passionné',
-  analogist: 'Analogiste',
-  pragmatic: 'Pragmatique',
-  benevolent: 'Bienveillant',
-  synthetic: 'Synthétique'
+  spark: '🔥 Prof Étincelle',
+  builder: '🏗️ Prof Lego',
+  storyteller: '🧙‍♂️ Prof Métaphore',
+  lightning: '⚡ Prof Flash'
 };
+
+const LEGACY_TEACHER_TYPE_MAP = {
+  methodical: 'builder',
+  pragmatic: 'builder',
+  analogist: 'storyteller',
+  benevolent: 'storyteller',
+  passionate: 'spark',
+  synthetic: 'lightning'
+};
+
+export function getTeacherTypeLabel(type) {
+  const normalized = LEGACY_TEACHER_TYPE_MAP[type] || type;
+  return TEACHER_TYPE_LABELS[normalized] || normalized;
+}
 
 // Rate limit between costly actions
 const REQUEST_COOLDOWN = 5000; // 5 seconds
@@ -343,7 +355,7 @@ class CourseManager {
         .map(course => {
           const vulgarizationLabel = VULGARIZATION_LABELS[course.vulgarization] || course.vulgarization;
           const durationLabel = DURATION_LABELS[course.duration] || course.duration;
-          const teacherTypeLabel = TEACHER_TYPE_LABELS[course.teacher_type] || course.teacher_type;
+          const teacherTypeLabel = getTeacherTypeLabel(course.teacher_type);
 
           return `
         <div class="history-item" onclick="courseManager.loadCourseFromHistory('${course.id}')">
@@ -409,7 +421,7 @@ class CourseManager {
       if (typeof displayCourseMetadata === 'function') {
         const vulgarizationLabel = VULGARIZATION_LABELS[course.vulgarization] || course.vulgarization;
         const durationLabel = DURATION_LABELS[course.duration] || course.duration;
-        const teacherTypeLabel = TEACHER_TYPE_LABELS[course.teacher_type] || course.teacher_type;
+        const teacherTypeLabel = getTeacherTypeLabel(course.teacher_type);
         displayCourseMetadata(vulgarizationLabel, durationLabel, teacherTypeLabel);
       }
       utils.showNotification('Cours chargé depuis l\'historique', 'success');

--- a/frontend/app/assets/js/main.js
+++ b/frontend/app/assets/js/main.js
@@ -2,7 +2,7 @@
 
 import { utils, API_BASE_URL } from './utils/utils.js';
 import { authManager } from './auth.js';
-import { courseManager, VULGARIZATION_LABELS, DURATION_LABELS, TEACHER_TYPE_LABELS } from './course-manager.js';
+import { courseManager, VULGARIZATION_LABELS, DURATION_LABELS, getTeacherTypeLabel } from './course-manager.js';
 
 // État global de l'application
 let currentCourse = null;
@@ -83,7 +83,7 @@ async function handleGenerateCourse() {
                 currentCourse = course;
                 const vulgarizationLabel = VULGARIZATION_LABELS[course.vulgarization] || course.vulgarization;
                 const durationLabel = DURATION_LABELS[course.duration] || course.duration;
-                const teacherTypeLabel = TEACHER_TYPE_LABELS[course.teacher_type] || course.teacher_type;
+                const teacherTypeLabel = getTeacherTypeLabel(course.teacher_type);
                 displayCourseMetadata(vulgarizationLabel, durationLabel, teacherTypeLabel);
                 if (typeof configManager !== 'undefined') {
                     configManager.enableQuizCard();
@@ -260,7 +260,7 @@ function initializeGauges() {
 }
 
 function collectFormParameters() {
-    const teacherType = document.querySelector('[data-type="teacher_type"].active')?.dataset.value || 'methodical';
+    const teacherType = document.querySelector('[data-type="teacher_type"].active')?.dataset.value || 'builder';
     const intensity = window.currentIntensity || intensityLevels[2];
 
     return {

--- a/frontend/app/assets/js/modular-config-manager.js
+++ b/frontend/app/assets/js/modular-config-manager.js
@@ -2,9 +2,9 @@ export class ModularConfigManager {
     constructor() {
         this.currentPreset = 'default';
         this.presets = {
-            default: { vulgarization: 'general_public', duration: 'short', teacher_type: 'methodical' },
-            balanced: { vulgarization: 'enlightened', duration: 'medium', teacher_type: 'pragmatic' },
-            expert: { vulgarization: 'expert', duration: 'long', teacher_type: 'synthetic' }
+            default: { vulgarization: 'general_public', duration: 'short', teacher_type: 'builder' },
+            balanced: { vulgarization: 'enlightened', duration: 'medium', teacher_type: 'storyteller' },
+            expert: { vulgarization: 'expert', duration: 'long', teacher_type: 'lightning' }
         };
         this.currentValues = { ...this.presets[this.currentPreset] };
     }

--- a/frontend/app/index.html
+++ b/frontend/app/index.html
@@ -79,12 +79,10 @@
                                     <div class="selector-group">
                                         <div class="selector-title">👨‍🏫 Type de prof</div>
                                         <div class="selector-buttons">
-                                            <button data-type="teacher_type" data-value="methodical" class="active">Méthodique</button>
-                                            <button data-type="teacher_type" data-value="passionate">Passionné</button>
-                                            <button data-type="teacher_type" data-value="analogist">Analogiste</button>
-                                            <button data-type="teacher_type" data-value="pragmatic">Pragmatique</button>
-                                            <button data-type="teacher_type" data-value="benevolent">Bienveillant</button>
-                                            <button data-type="teacher_type" data-value="synthetic">Synthétique</button>
+                                            <button data-type="teacher_type" data-value="spark" class="active">🔥 Prof Étincelle</button>
+                                            <button data-type="teacher_type" data-value="builder">🏗️ Prof Lego</button>
+                                            <button data-type="teacher_type" data-value="storyteller">🧙‍♂️ Prof Métaphore</button>
+                                            <button data-type="teacher_type" data-value="lightning">⚡ Prof Flash</button>
                                         </div>
                                     </div>
                                 </div>

--- a/frontend/marketing/assets/js/main.js
+++ b/frontend/marketing/assets/js/main.js
@@ -109,7 +109,7 @@ function initializeGauges() {
 }
 
 function collectFormParameters() {
-    const teacherType = document.querySelector('[data-type="teacher_type"].active')?.dataset.value || 'methodical';
+    const teacherType = document.querySelector('[data-type="teacher_type"].active')?.dataset.value || 'builder';
     const intensity = window.currentIntensity || intensityLevels[2];
 
     return {

--- a/frontend/tests/course-generation.integration.test.js
+++ b/frontend/tests/course-generation.integration.test.js
@@ -33,7 +33,7 @@ test('course generation triggered from decryptage controls', async () => {
   subjectInput.value = 'Quantum Mechanics';
 
   const generateBtn = createElement();
-  const teacherBtn = createElement({ dataset: { type: 'teacher_type', value: 'synthetic' }, className: 'active' });
+  const teacherBtn = createElement({ dataset: { type: 'teacher_type', value: 'lightning' }, className: 'active' });
 
   global.document = {
     getElementById(id) {
@@ -56,7 +56,7 @@ test('course generation triggered from decryptage controls', async () => {
   const { VULGARIZATION_LABELS, TEACHER_TYPE_LABELS } = await import('../app/assets/js/course-manager.js');
 
   function collectFormParameters() {
-    const teacherType = document.querySelector('[data-type="teacher_type"].active')?.dataset.value || 'methodical';
+    const teacherType = document.querySelector('[data-type="teacher_type"].active')?.dataset.value || 'builder';
     const intensity = window.currentIntensity || { level: 2, vulgarization: 'enlightened', duration: 'medium' };
     return {
       teacher_type: teacherType,
@@ -90,9 +90,9 @@ test('course generation triggered from decryptage controls', async () => {
     subject: 'Quantum Mechanics',
     vulgarization: 'expert',
     duration: 'long',
-    teacher_type: 'synthetic',
+    teacher_type: 'lightning',
     intensity: 'deep_expert'
   });
   assert.strictEqual(VULGARIZATION_LABELS[calledWith.vulgarization], 'Expert');
-  assert.strictEqual(TEACHER_TYPE_LABELS[calledWith.teacher_type], 'Synthétique');
+  assert.strictEqual(TEACHER_TYPE_LABELS[calledWith.teacher_type], '⚡ Prof Flash');
 });

--- a/frontend/tests/modular-config-manager.test.js
+++ b/frontend/tests/modular-config-manager.test.js
@@ -34,9 +34,9 @@ test('preset selection updates advanced controls', async () => {
   const vulgarizationExpert = createElement({ dataset: { type: 'vulgarization', value: 'expert' } });
   const durationShort = createElement({ dataset: { type: 'duration', value: 'short' } });
   const durationLong = createElement({ dataset: { type: 'duration', value: 'long' } });
-  const teacherMethodical = createElement({ dataset: { type: 'teacher_type', value: 'methodical' } });
-  const teacherSynthetic = createElement({ dataset: { type: 'teacher_type', value: 'synthetic' } });
-  const allButtons = [vulgarizationGeneral, vulgarizationExpert, durationShort, durationLong, teacherMethodical, teacherSynthetic];
+  const teacherBuilder = createElement({ dataset: { type: 'teacher_type', value: 'builder' } });
+  const teacherLightning = createElement({ dataset: { type: 'teacher_type', value: 'lightning' } });
+  const allButtons = [vulgarizationGeneral, vulgarizationExpert, durationShort, durationLong, teacherBuilder, teacherLightning];
 
   global.document = {
     querySelectorAll(selector) {
@@ -51,7 +51,7 @@ test('preset selection updates advanced controls', async () => {
       const sel = selector.replace(/^\.decryptage-controls\s*/, '');
       if (sel === '[data-type="vulgarization"][data-value="expert"]') return vulgarizationExpert;
       if (sel === '[data-type="duration"][data-value="long"]') return durationLong;
-      if (sel === '[data-type="teacher_type"][data-value="synthetic"]') return teacherSynthetic;
+      if (sel === '[data-type="teacher_type"][data-value="lightning"]') return teacherLightning;
       return null;
     },
     getElementById() { return null; },
@@ -72,12 +72,12 @@ test('preset selection updates advanced controls', async () => {
   const cfg = manager.getConfig();
   assert.strictEqual(cfg.vulgarization, 'expert');
   assert.strictEqual(cfg.duration, 'long');
-  assert.strictEqual(cfg.teacher_type, 'synthetic');
+  assert.strictEqual(cfg.teacher_type, 'lightning');
   assert.ok(vulgarizationExpert.classList.contains('active'));
   assert.ok(durationLong.classList.contains('active'));
-  assert.ok(teacherSynthetic.classList.contains('active'));
+  assert.ok(teacherLightning.classList.contains('active'));
   assert.strictEqual(VULGARIZATION_LABELS[cfg.vulgarization], 'Expert');
-  assert.strictEqual(TEACHER_TYPE_LABELS[cfg.teacher_type], 'Synthétique');
+  assert.strictEqual(TEACHER_TYPE_LABELS[cfg.teacher_type], '⚡ Prof Flash');
 });
 
 test('quiz button reflects quiz availability', async () => {


### PR DESCRIPTION
## Summary
- introduce four new teacher personas (spark, builder, storyteller, lightning) across backend and frontend
- update style instructions, validation, presets, and UI labels
- add legacy teacher type mapping for backward compatibility

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ade9f0a8b08325a41974e808b60b92