### PR TITLE
refactor: rename teacher types and update labels

### DIFF
--- a/backend/src/services/onboardingService.js
+++ b/backend/src/services/onboardingService.js
@@ -14,10 +14,10 @@ const QUESTION_CONFIG = [
     label: "Quel type d'enseignant préfères-tu ?",
     type: 'select',
     options: [
-      { value: 'spark', label: '🔥 Prof Étincelle' },
-      { value: 'builder', label: '🏗️ Prof Lego' },
-      { value: 'storyteller', label: '🧙‍♂️ Prof Métaphore' },
-      { value: 'lightning', label: '⚡ Prof Flash' }
+      { value: 'spark', label: '🔥 Pour vibrer' },
+      { value: 'builder', label: '🏗️ Pour comprendre' },
+      { value: 'storyteller', label: '🧙‍♂️ Pour imaginer' },
+      { value: 'lightning', label: '⚡ Pour retenir' }
     ]
   },
   {

--- a/frontend/app/assets/css/app.css
+++ b/frontend/app/assets/css/app.css
@@ -447,7 +447,7 @@ body::before {
     flex-direction: column;
     align-items: center;
     text-align: center;
-    min-height: 200px;
+    min-height: 140px;
 }
 
 .teacher-card:hover {
@@ -475,41 +475,18 @@ body::before {
 }
 
 .teacher-name {
-    font-size: 1.25rem;
-    font-weight: 600;
+    font-size: 1.3rem;
+    font-weight: 700;
     color: #1f2937;
-    margin: 0 0 6px 0;
+    margin: 0 0 8px 0;
 }
 
 .teacher-subtitle {
-    font-size: 0.9rem;
+    font-size: 0.95rem;
     color: #6b7280;
     font-style: italic;
-    margin: 0 0 12px 0;
-}
-
-/* Liste des caractéristiques */
-.teacher-features {
-    list-style: none;
-    padding: 0;
+    line-height: 1.4;
     margin: 0;
-    text-align: left;
-}
-
-.teacher-features li {
-    font-size: 0.85rem;
-    color: #4b5563;
-    margin-bottom: 6px;
-    padding-left: 16px;
-    position: relative;
-}
-
-.teacher-features li::before {
-    content: "•";
-    color: #3b82f6;
-    font-weight: bold;
-    position: absolute;
-    left: 0;
 }
 
 /* Responsive */
@@ -519,7 +496,7 @@ body::before {
     }
 
     .teacher-card {
-        min-height: auto;
+        min-height: 120px;
         padding: 16px;
     }
 
@@ -528,7 +505,11 @@ body::before {
     }
 
     .teacher-name {
-        font-size: 1.1rem;
+        font-size: 1.2rem;
+    }
+
+    .teacher-subtitle {
+        font-size: 0.9rem;
     }
 }
 

--- a/frontend/app/assets/js/course-manager.js
+++ b/frontend/app/assets/js/course-manager.js
@@ -18,10 +18,10 @@ export const DURATION_LABELS = {
 };
 
 export const TEACHER_TYPE_LABELS = {
-  spark: '🔥 Prof Étincelle',
-  builder: '🏗️ Prof Lego',
-  storyteller: '🧙‍♂️ Prof Métaphore',
-  lightning: '⚡ Prof Flash'
+  spark: '🔥 Pour vibrer',
+  builder: '🏗️ Pour comprendre',
+  storyteller: '🧙‍♂️ Pour imaginer',
+  lightning: '⚡ Pour retenir'
 };
 
 const LEGACY_TEACHER_TYPE_MAP = {

--- a/frontend/app/index.html
+++ b/frontend/app/index.html
@@ -82,52 +82,32 @@
                                             <div class="teacher-card active" data-type="teacher_type" data-value="spark">
                                                 <div class="teacher-icon">🔥</div>
                                                 <div class="teacher-info">
-                                                    <h3 class="teacher-name">Prof Étincelle</h3>
-                                                    <p class="teacher-subtitle">Le passionné contagieux</p>
-                                                    <ul class="teacher-features">
-                                                        <li>Transmet avec enthousiasme explosif</li>
-                                                        <li>Captive par des anecdotes épiques</li>
-                                                        <li>Transforme chaque point en découverte</li>
-                                                    </ul>
+                                                    <h3 class="teacher-name">Pour vibrer</h3>
+                                                    <p class="teacher-subtitle">Cours dynamiques et passionnants qui réveillent votre curiosité</p>
                                                 </div>
                                             </div>
 
                                             <div class="teacher-card" data-type="teacher_type" data-value="builder">
                                                 <div class="teacher-icon">🏗️</div>
                                                 <div class="teacher-info">
-                                                    <h3 class="teacher-name">Prof Lego</h3>
-                                                    <p class="teacher-subtitle">Le constructeur méthodique</p>
-                                                    <ul class="teacher-features">
-                                                        <li>Décompose étape par étape</li>
-                                                        <li>Structure progressive et claire</li>
-                                                        <li>Approche pratique et concrète</li>
-                                                    </ul>
+                                                    <h3 class="teacher-name">Pour comprendre</h3>
+                                                    <p class="teacher-subtitle">Explications progressives et claires qui construisent votre savoir solide</p>
                                                 </div>
                                             </div>
 
                                             <div class="teacher-card" data-type="teacher_type" data-value="storyteller">
                                                 <div class="teacher-icon">🧙‍♂️</div>
                                                 <div class="teacher-info">
-                                                    <h3 class="teacher-name">Prof Métaphore</h3>
-                                                    <p class="teacher-subtitle">Le conteur bienveillant</p>
-                                                    <ul class="teacher-features">
-                                                        <li>Transforme les concepts en contes</li>
-                                                        <li>Utilise des analogies magiques</li>
-                                                        <li>Ton bienveillant et rassurant</li>
-                                                    </ul>
+                                                    <h3 class="teacher-name">Pour imaginer</h3>
+                                                    <p class="teacher-subtitle">Apprentissage créatif avec des histoires et métaphores qui marquent</p>
                                                 </div>
                                             </div>
 
                                             <div class="teacher-card" data-type="teacher_type" data-value="lightning">
                                                 <div class="teacher-icon">⚡</div>
                                                 <div class="teacher-info">
-                                                    <h3 class="teacher-name">Prof Flash</h3>
-                                                    <p class="teacher-subtitle">L'efficace synthétique</p>
-                                                    <ul class="teacher-features">
-                                                        <li>Va à l'essentiel avec impact</li>
-                                                        <li>Synthèse percutante et directe</li>
-                                                        <li>Points clés mémorables</li>
-                                                    </ul>
+                                                    <h3 class="teacher-name">Pour retenir</h3>
+                                                    <p class="teacher-subtitle">Synthèses percutantes qui vont à l'essentiel de manière mémorable</p>
                                                 </div>
                                             </div>
                                         </div>


### PR DESCRIPTION
## Summary
- rebrand teacher card titles and descriptions to user-benefit names
- update course manager and onboarding service with new teacher type labels
- simplify teacher card styling and remove feature lists

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae18db667c8325a979bfbaae10b411