### PR TITLE
feat: reorganize decryptage controls layout

### DIFF
--- a/frontend/app/assets/css/app.css
+++ b/frontend/app/assets/css/app.css
@@ -161,16 +161,28 @@ body::before {
     width: 100%;
     margin: 20px 0;
     display: flex;
-    flex-direction: row;
+    flex-direction: column;
     gap: 20px;
 }
 
-.decryptage-left {
-    flex: 0 0 65%;
+.decryptage-row-1 {
+    width: 70%;
+    margin: 0 auto;
 }
 
-.decryptage-right {
-    flex: 0 0 35%;
+.subject-container {
+    width: 100%;
+}
+
+.decryptage-row-2 {
+    display: flex;
+    width: 100%;
+    gap: 20px;
+}
+
+.intensity-container,
+.teacher-container {
+    flex: 1;
 }
 
 .config-card {
@@ -369,14 +381,6 @@ body::before {
     animation: spin 0.8s ease-in-out;
 }
 
-/* --- Nouveaux sélecteurs de configuration --- */
-.new-selector-container {
-    display: flex;
-    flex-direction: row;
-    gap: 25px;
-    justify-content: space-between;
-}
-
 .selector-group {
     display: flex;
     flex-direction: column;
@@ -413,17 +417,17 @@ body::before {
 }
 
 @media (max-width: 768px) {
-    .decryptage-controls {
+    .decryptage-row-1 {
+        width: 100%;
+    }
+
+    .decryptage-row-2 {
         flex-direction: column;
     }
 
-    .decryptage-left,
-    .decryptage-right {
-        flex: 0 0 100%;
-    }
-
-    .new-selector-container {
-        flex-direction: column;
+    .intensity-container,
+    .teacher-container {
+        width: 100%;
     }
 }
 

--- a/frontend/app/index.html
+++ b/frontend/app/index.html
@@ -36,22 +36,24 @@
             <div class="tab-content" id="courseTab">
                 <div class="config-card primary-card">
                     <div class="decryptage-controls">
-                        <div class="decryptage-left">
-                            <div class="form-group">
-                                <label for="subject">Sujet à décrypter</label>
-                                <div class="subject-input-container">
-                                    <textarea id="subject" placeholder="Ex: Le fonctionnement de la mémoire humaine"></textarea>
-                                    <button type="button" class="random-subject-btn" id="randomSubjectBtn">
-                                        <i data-lucide="sparkles" aria-hidden="true"></i>
-                                        Générer un sujet aléatoire
-                                        <i data-lucide="dice-6" aria-hidden="true"></i>
-                                    </button>
+                        <div class="decryptage-row-1">
+                            <div class="subject-container">
+                                <div class="form-group">
+                                    <label for="subject">Sujet à décrypter</label>
+                                    <div class="subject-input-container">
+                                        <textarea id="subject" placeholder="Ex: Le fonctionnement de la mémoire humaine"></textarea>
+                                        <button type="button" class="random-subject-btn" id="randomSubjectBtn">
+                                            <i data-lucide="sparkles" aria-hidden="true"></i>
+                                            Générer un sujet aléatoire
+                                            <i data-lucide="dice-6" aria-hidden="true"></i>
+                                        </button>
+                                    </div>
                                 </div>
                             </div>
                         </div>
-                        <div class="decryptage-right">
-                            <div id="advancedSettings" class="advanced-settings">
-                                <div class="new-selector-container">
+                        <div id="advancedSettings" class="advanced-settings">
+                            <div class="decryptage-row-2">
+                                <div class="intensity-container">
                                     <div class="selector-group">
                                         <div class="selector-title">🎓 Intensité Pédagogique</div>
                                         <div class="intensity-slider-container">
@@ -76,6 +78,8 @@
                                             </div>
                                         </div>
                                     </div>
+                                </div>
+                                <div class="teacher-container">
                                     <div class="selector-group">
                                         <div class="selector-title">👨‍🏫 Type de prof</div>
                                         <div class="teacher-cards-grid">


### PR DESCRIPTION
## Summary
- restructure decryptage controls in inverted L layout with subject row and intensity/teacher row
- update styles for new layout and responsive behavior

## Testing
- `npm test` *(hangs after tests complete; last subtests pass)*

------
https://chatgpt.com/codex/tasks/task_e_68af33f656b08325aa1ae2b1a70a9f37