### PR TITLE
feat: add horizontal action buttons

### DIFF
--- a/frontend/app/assets/css/app.css
+++ b/frontend/app/assets/css/app.css
@@ -166,75 +166,113 @@ body::before {
     margin: 0 auto;
 }
 
-.subject-action-row {
-    display: flex;
-    gap: 20px;
-    align-items: flex-start;
-}
-
+/* Container du sujet */
 .subject-container {
     flex: 1;
     min-width: 0;
 }
 
-.action-buttons-vertical {
+/* === NOUVEAUX BOUTONS HORIZONTAUX === */
+.action-buttons-horizontal {
     display: flex;
-    flex-direction: column;
-    gap: 12px;
-    flex-shrink: 0;
-    width: 180px;
+    gap: 15px;
+    width: 100%;
+    margin-top: 20px;
 }
 
-.action-buttons-vertical .generate-btn,
-.action-buttons-vertical .generate-quiz-btn {
-    width: 100%;
-    padding: 14px 16px;
-    font-size: 0.95rem;
-    font-weight: 600;
+.action-btn {
+    flex: 1;
+    padding: 16px 20px;
     border: none;
     border-radius: 12px;
+    font-size: 1rem;
+    font-weight: 600;
     cursor: pointer;
     transition: all 0.3s ease;
     display: flex;
     align-items: center;
     justify-content: center;
     gap: 8px;
-    min-height: 50px;
+    min-height: 55px;
     text-align: center;
     line-height: 1.2;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
 }
 
-.action-buttons-vertical .generate-btn {
+/* Bouton principal - Décrypter le sujet */
+.action-btn.primary-action {
     background: linear-gradient(135deg, #4299e1, #3182ce);
     color: white;
     box-shadow: 0 4px 12px rgba(66, 153, 225, 0.3);
 }
 
-.action-buttons-vertical .generate-btn:hover {
+.action-btn.primary-action:hover {
     background: linear-gradient(135deg, #3182ce, #2c5282);
     transform: translateY(-2px);
     box-shadow: 0 6px 20px rgba(66, 153, 225, 0.4);
 }
 
-.action-buttons-vertical .generate-quiz-btn {
+/* Bouton secondaire - Quiz */
+.action-btn.secondary-action {
     background: linear-gradient(135deg, #48bb78, #38a169);
     color: white;
     box-shadow: 0 4px 12px rgba(72, 187, 120, 0.3);
 }
 
-.action-buttons-vertical .generate-quiz-btn:hover {
+.action-btn.secondary-action:hover {
     background: linear-gradient(135deg, #38a169, #2f855a);
     transform: translateY(-2px);
     box-shadow: 0 6px 20px rgba(72, 187, 120, 0.4);
 }
 
-.action-buttons-vertical .generate-btn:disabled,
-.action-buttons-vertical .generate-quiz-btn:disabled {
-    background: #a0aec0;
+/* Bouton tertiaire - Sujet aléatoire */
+.action-btn.tertiary-action {
+    background: linear-gradient(135deg, #9f7aea, #805ad5);
+    color: white;
+    box-shadow: 0 4px 12px rgba(159, 122, 234, 0.3);
+}
+
+.action-btn.tertiary-action:hover {
+    background: linear-gradient(135deg, #805ad5, #6b46c1);
+    transform: translateY(-2px);
+    box-shadow: 0 6px 20px rgba(159, 122, 234, 0.4);
+}
+
+/* États désactivés */
+.action-btn:disabled {
+    background: #a0aec0 !important;
+    color: #718096 !important;
     cursor: not-allowed;
-    transform: none;
-    box-shadow: none;
-    opacity: 0.7;
+    transform: none !important;
+    box-shadow: none !important;
+    opacity: 0.6;
+}
+
+/* Responsive design */
+@media (max-width: 768px) {
+    .action-buttons-horizontal {
+        flex-direction: column;
+        gap: 12px;
+    }
+    
+    .action-btn {
+        min-height: 50px;
+        font-size: 0.95rem;
+        padding: 14px 16px;
+    }
+}
+
+@media (max-width: 480px) {
+    .action-btn {
+        min-height: 48px;
+        font-size: 0.9rem;
+        padding: 12px 14px;
+    }
+}
+
+/* Suppression de la structure verticale ancienne */
+.action-buttons-vertical {
+    display: none !important;
 }
 
 .intensity-row,
@@ -245,35 +283,6 @@ body::before {
 .intensity-row .selector-group,
 .teacher-row .selector-group {
     width: 100%;
-}
-
-
-@media (max-width: 768px) {
-    .subject-action-row {
-        flex-direction: column;
-        gap: 15px;
-    }
-
-    .action-buttons-vertical {
-        flex-direction: row;
-        width: 100%;
-        justify-content: space-between;
-    }
-
-    .action-buttons-vertical .generate-btn,
-    .action-buttons-vertical .generate-quiz-btn {
-        flex: 1;
-        min-height: 45px;
-        font-size: 0.9rem;
-        padding: 12px 14px;
-    }
-}
-
-@media (max-width: 480px) {
-    .action-buttons-vertical {
-        flex-direction: column;
-        gap: 10px;
-    }
 }
 
 .config-card {

--- a/frontend/app/assets/js/main.js
+++ b/frontend/app/assets/js/main.js
@@ -43,12 +43,16 @@ function setupEventListeners() {
     const copyContent = document.getElementById('copyContent');
     const randomSubjectBtn = document.getElementById('randomSubjectBtn');
     const randomQuizSubjectBtn = document.getElementById('randomQuizSubjectBtn');
+    const randomSubjectBtnNew = document.getElementById('randomSubjectBtnNew');
 
     if (generateBtn) generateBtn.addEventListener('click', handleGenerateCourse);
     if (generateQuiz) generateQuiz.addEventListener('click', handleGenerateQuiz);
     if (copyContent) copyContent.addEventListener('click', () => courseManager && courseManager.copyContent());
     if (randomSubjectBtn) randomSubjectBtn.addEventListener('click', generateRandomSubject);
     if (randomQuizSubjectBtn) randomQuizSubjectBtn.addEventListener('click', generateRandomQuizSubject);
+    if (randomSubjectBtnNew) {
+        randomSubjectBtnNew.addEventListener('click', handleRandomSubjectFromButtons);
+    }
     const generateOnDemandQuiz = document.getElementById('generateOnDemandQuiz');
     if (generateOnDemandQuiz) {
         generateOnDemandQuiz.addEventListener('click', handleGenerateOnDemandQuiz);
@@ -495,6 +499,60 @@ async function generateRandomQuizSubject() {
         randomBtn.classList.remove('spinning');
         randomBtn.innerHTML = '<i data-lucide="sparkles"></i>Générer un sujet aléatoire <i data-lucide="dice-6"></i>';
         utils.initializeLucide();
+    }
+}
+
+async function generateRandomSubjectContent() {
+    const response = await fetch(`${API_BASE_URL}/ai/random-subject`, {
+        headers: authManager.getAuthHeaders()
+    });
+
+    const data = await response.json();
+
+    if (data.success) {
+        return data.subject;
+    } else {
+        throw new Error(data.error || 'Erreur lors de la génération');
+    }
+}
+
+// Fonction pour gérer le nouveau bouton sujet aléatoire
+async function handleRandomSubjectFromButtons() {
+    const subjectTextarea = document.getElementById('subject');
+    const button = document.getElementById('randomSubjectBtnNew');
+
+    if (!subjectTextarea || !button) return;
+
+    // Animation de chargement
+    button.classList.add('loading');
+    button.innerHTML = `<i data-lucide="loader-2" class="animate-spin"></i> Génération...`;
+    button.disabled = true;
+    utils.initializeLucide();
+
+    try {
+        const randomSubject = await generateRandomSubjectContent();
+        subjectTextarea.value = randomSubject;
+
+        // Animation de succès
+        button.innerHTML = `<i data-lucide="check"></i> Généré !`;
+        utils.initializeLucide();
+        setTimeout(() => {
+            button.innerHTML = `<i data-lucide="shuffle"></i> Sujet aléatoire`;
+            button.disabled = false;
+            button.classList.remove('loading');
+            utils.initializeLucide();
+        }, 1500);
+
+    } catch (error) {
+        console.error('Erreur génération sujet aléatoire:', error);
+        button.innerHTML = `<i data-lucide="x"></i> Erreur`;
+        utils.initializeLucide();
+        setTimeout(() => {
+            button.innerHTML = `<i data-lucide="shuffle"></i> Sujet aléatoire`;
+            button.disabled = false;
+            button.classList.remove('loading');
+            utils.initializeLucide();
+        }, 2000);
     }
 }
 

--- a/frontend/app/index.html
+++ b/frontend/app/index.html
@@ -36,7 +36,7 @@
             <div class="tab-content" id="courseTab">
                 <div class="config-card primary-card">
                     <div class="decryptage-controls-new">
-                        <div class="subject-action-row">
+                        <div class="subject-action-row-new">
                             <div class="subject-container">
                                 <div class="form-group">
                                     <label for="subject">Sujet à décrypter</label>
@@ -48,16 +48,22 @@
                                     </button>
                                 </div>
                             </div>
-                            <div class="action-buttons-vertical">
-                                <button class="generate-btn" id="generateBtn">
-                                    <i data-lucide="zap" aria-hidden="true"></i>
-                                    Décrypter le sujet
-                                </button>
-                                <button class="generate-quiz-btn" id="generateQuiz" disabled>
-                                    <i data-lucide="help-circle" aria-hidden="true"></i>
-                                    Quiz du cours
-                                </button>
-                            </div>
+                        </div>
+
+                        <!-- NOUVEAUX BOUTONS HORIZONTAUX -->
+                        <div class="action-buttons-horizontal">
+                            <button class="action-btn primary-action" id="generateBtn">
+                                <i data-lucide="zap" aria-hidden="true"></i>
+                                Décrypter le sujet
+                            </button>
+                            <button class="action-btn secondary-action" id="generateQuiz" disabled>
+                                <i data-lucide="help-circle" aria-hidden="true"></i>
+                                Quiz
+                            </button>
+                            <button class="action-btn tertiary-action" id="randomSubjectBtnNew">
+                                <i data-lucide="shuffle" aria-hidden="true"></i>
+                                Sujet aléatoire
+                            </button>
                         </div>
                         <div class="intensity-row">
                             <div class="selector-group">


### PR DESCRIPTION
## Summary
- switch vertical action buttons to a three-button horizontal layout
- style new horizontal action buttons and hide legacy vertical layout
- add random subject generator button handler

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68af5f7c0250832595079358df583834