### PR TITLE
feat: relocate random subject generator

### DIFF
--- a/frontend/app/assets/css/app.css
+++ b/frontend/app/assets/css/app.css
@@ -166,12 +166,6 @@ body::before {
     margin: 0 auto;
 }
 
-/* Container du sujet */
-.subject-container {
-    flex: 1;
-    min-width: 0;
-}
-
 /* === NOUVEAUX BOUTONS HORIZONTAUX === */
 .action-buttons-horizontal {
     display: flex;
@@ -421,66 +415,6 @@ body::before {
     line-height: 1.5;
 }
 
-.subject-container textarea {
-    min-height: 100px;
-    resize: vertical;
-}
-
-/* --- Subject Input with Random Button (Version 3 - NOUVEAU) --- */
-.subject-input-container {
-    display: flex;
-    flex-direction: column;
-    gap: 12px;
-}
-
-.subject-input-container textarea {
-    width: 100%;
-}
-
-.random-subject-btn {
-    padding: 12px 20px;
-    border: 2px dashed #9f7aea;
-    border-radius: 12px;
-    background: linear-gradient(135deg, rgba(159, 122, 234, 0.1), rgba(128, 90, 213, 0.1));
-    color: #805ad5;
-    cursor: pointer;
-    transition: all 0.3s ease;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 10px;
-    font-weight: 600;
-    font-size: 0.95rem;
-}
-
-.random-subject-btn:hover {
-    background: linear-gradient(135deg, #9f7aea, #805ad5);
-    color: white;
-    border-style: solid;
-    transform: translateY(-2px);
-    box-shadow: 0 5px 15px rgba(159, 122, 234, 0.3);
-}
-
-.random-subject-btn:active {
-    transform: translateY(-1px) scale(0.98);
-}
-
-.random-subject-btn:disabled {
-    background: #e2e8f0;
-    color: #a0aec0;
-    cursor: not-allowed;
-    transform: none;
-    border-style: solid;
-}
-
-.random-subject-btn i {
-    transition: transform 0.3s ease;
-    font-size: 1.1rem;
-}
-
-.random-subject-btn.spinning i {
-    animation: spin 0.8s ease-in-out;
-}
 
 .selector-group {
     display: flex;

--- a/frontend/app/assets/js/main.js
+++ b/frontend/app/assets/js/main.js
@@ -41,18 +41,13 @@ function setupEventListeners() {
     const generateBtn = document.getElementById('generateBtn');
     const generateQuiz = document.getElementById('generateQuiz');
     const copyContent = document.getElementById('copyContent');
-    const randomSubjectBtn = document.getElementById('randomSubjectBtn');
     const randomQuizSubjectBtn = document.getElementById('randomQuizSubjectBtn');
-    const randomSubjectBtnNew = document.getElementById('randomSubjectBtnNew');
 
     if (generateBtn) generateBtn.addEventListener('click', handleGenerateCourse);
     if (generateQuiz) generateQuiz.addEventListener('click', handleGenerateQuiz);
     if (copyContent) copyContent.addEventListener('click', () => courseManager && courseManager.copyContent());
-    if (randomSubjectBtn) randomSubjectBtn.addEventListener('click', generateRandomSubject);
+    document.getElementById('randomSubjectBtn')?.addEventListener('click', generateRandomSubject);
     if (randomQuizSubjectBtn) randomQuizSubjectBtn.addEventListener('click', generateRandomQuizSubject);
-    if (randomSubjectBtnNew) {
-        randomSubjectBtnNew.addEventListener('click', handleRandomSubjectFromButtons);
-    }
     const generateOnDemandQuiz = document.getElementById('generateOnDemandQuiz');
     if (generateOnDemandQuiz) {
         generateOnDemandQuiz.addEventListener('click', handleGenerateOnDemandQuiz);
@@ -425,7 +420,7 @@ async function generateRandomSubject() {
     // Désactiver le bouton et ajouter l'animation
     randomBtn.disabled = true;
     randomBtn.classList.add('spinning');
-    randomBtn.innerHTML = '<i data-lucide="sparkles"></i>Génération... <i data-lucide="dice-6"></i>';
+    randomBtn.innerHTML = '<i data-lucide="sparkles"></i> Génération... <i data-lucide="dice-6"></i>';
     
     try {
         const response = await fetch(`${API_BASE_URL}/ai/random-subject`, {
@@ -440,7 +435,7 @@ async function generateRandomSubject() {
                 // Réactiver le bouton
                 randomBtn.disabled = false;
                 randomBtn.classList.remove('spinning');
-                randomBtn.innerHTML = '<i data-lucide="sparkles"></i>Générer un sujet aléatoire <i data-lucide="dice-6"></i>';
+                randomBtn.innerHTML = '<i data-lucide="sparkles"></i> Générer un sujet aléatoire <i data-lucide="dice-6"></i>';
                 
                 // Afficher une notification avec la catégorie
                 utils.showNotification(`Sujet aléatoire généré (${data.category})`, 'success');
@@ -456,7 +451,7 @@ async function generateRandomSubject() {
         // Réactiver le bouton en cas d'erreur
         randomBtn.disabled = false;
         randomBtn.classList.remove('spinning');
-        randomBtn.innerHTML = '<i data-lucide="sparkles"></i>Générer un sujet aléatoire <i data-lucide="dice-6"></i>';
+        randomBtn.innerHTML = '<i data-lucide="sparkles"></i> Générer un sujet aléatoire <i data-lucide="dice-6"></i>';
         utils.initializeLucide();
     }
 }
@@ -499,60 +494,6 @@ async function generateRandomQuizSubject() {
         randomBtn.classList.remove('spinning');
         randomBtn.innerHTML = '<i data-lucide="sparkles"></i>Générer un sujet aléatoire <i data-lucide="dice-6"></i>';
         utils.initializeLucide();
-    }
-}
-
-async function generateRandomSubjectContent() {
-    const response = await fetch(`${API_BASE_URL}/ai/random-subject`, {
-        headers: authManager.getAuthHeaders()
-    });
-
-    const data = await response.json();
-
-    if (data.success) {
-        return data.subject;
-    } else {
-        throw new Error(data.error || 'Erreur lors de la génération');
-    }
-}
-
-// Fonction pour gérer le nouveau bouton sujet aléatoire
-async function handleRandomSubjectFromButtons() {
-    const subjectTextarea = document.getElementById('subject');
-    const button = document.getElementById('randomSubjectBtnNew');
-
-    if (!subjectTextarea || !button) return;
-
-    // Animation de chargement
-    button.classList.add('loading');
-    button.innerHTML = `<i data-lucide="loader-2" class="animate-spin"></i> Génération...`;
-    button.disabled = true;
-    utils.initializeLucide();
-
-    try {
-        const randomSubject = await generateRandomSubjectContent();
-        subjectTextarea.value = randomSubject;
-
-        // Animation de succès
-        button.innerHTML = `<i data-lucide="check"></i> Généré !`;
-        utils.initializeLucide();
-        setTimeout(() => {
-            button.innerHTML = `<i data-lucide="shuffle"></i> Sujet aléatoire`;
-            button.disabled = false;
-            button.classList.remove('loading');
-            utils.initializeLucide();
-        }, 1500);
-
-    } catch (error) {
-        console.error('Erreur génération sujet aléatoire:', error);
-        button.innerHTML = `<i data-lucide="x"></i> Erreur`;
-        utils.initializeLucide();
-        setTimeout(() => {
-            button.innerHTML = `<i data-lucide="shuffle"></i> Sujet aléatoire`;
-            button.disabled = false;
-            button.classList.remove('loading');
-            utils.initializeLucide();
-        }, 2000);
     }
 }
 

--- a/frontend/app/index.html
+++ b/frontend/app/index.html
@@ -36,18 +36,9 @@
             <div class="tab-content" id="courseTab">
                 <div class="config-card primary-card">
                     <div class="decryptage-controls-new">
-                        <div class="subject-action-row-new">
-                            <div class="subject-container">
-                                <div class="form-group">
-                                    <label for="subject">Sujet à décrypter</label>
-                                    <textarea id="subject" placeholder="Ex: La théorie de la dérive des continents" rows="4"></textarea>
-                                    <button type="button" class="random-subject-btn" id="randomSubjectBtn">
-                                        <i data-lucide="sparkles" aria-hidden="true"></i>
-                                        Générer un sujet aléatoire
-                                        <i data-lucide="dice-6" aria-hidden="true"></i>
-                                    </button>
-                                </div>
-                            </div>
+                        <div class="form-group">
+                            <label for="subject">Sujet à décrypter</label>
+                            <textarea id="subject" placeholder="Ex: La théorie de la dérive des continents" rows="4"></textarea>
                         </div>
 
                         <!-- NOUVEAUX BOUTONS HORIZONTAUX -->
@@ -60,9 +51,10 @@
                                 <i data-lucide="help-circle" aria-hidden="true"></i>
                                 Quiz
                             </button>
-                            <button class="action-btn tertiary-action" id="randomSubjectBtnNew">
-                                <i data-lucide="shuffle" aria-hidden="true"></i>
-                                Sujet aléatoire
+                            <button class="action-btn tertiary-action" id="randomSubjectBtn">
+                                <i data-lucide="sparkles" aria-hidden="true"></i>
+                                Générer un sujet aléatoire
+                                <i data-lucide="dice-6" aria-hidden="true"></i>
                             </button>
                         </div>
                         <div class="intensity-row">


### PR DESCRIPTION
## Summary
- remove embedded random subject button and replace action bar button
- clean up styling and unused handlers for random subject generation
- wire new random subject button to generator function

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af668713b0832585c6bace69e5c027