### PR TITLE
refactor: update teacher personas

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The `POST /api/courses` endpoint now supports the following parameters:
 - `subject` (string, required): topic to generate a course about.
 - `vulgarization` (string, required): target audience. Accepted values: `general_public`, `enlightened`, `knowledgeable`, `expert`.
 - `duration` (string, required): estimated course length. Accepted values: `short`, `medium`, `long`.
-- `teacher_type` (string, required): teaching persona. Accepted values: `spark`, `builder`, `storyteller`, `lightning`.
+  - `teacher_type` (string, required): teaching persona. Accepted values: `calculator`, `experimenter`, `memorizer`.
 - `detailLevel` (number, deprecated): legacy field mapped to `duration`.
 - `vulgarizationLevel` (number, deprecated): legacy field mapped to `vulgarization`.
 - `style` (string, deprecated): maps to `vulgarization`.
@@ -20,7 +20,7 @@ The `POST /api/courses` endpoint now supports the following parameters:
   "subject": "Introduction to Algebra",
   "vulgarization": "enlightened",
   "duration": "medium",
-  "teacher_type": "builder"
+    "teacher_type": "calculator"
 }
 ```
 
@@ -36,7 +36,7 @@ The `POST /api/courses` endpoint now supports the following parameters:
     "vulgarizationLevel": 2,
     "vulgarization": "enlightened",
     "duration": "medium",
-    "teacherType": "builder",
+      "teacherType": "calculator",
     "createdAt": "2024-01-01T00:00:00.000Z"
   }
 }

--- a/backend/src/middleware/validation.js
+++ b/backend/src/middleware/validation.js
@@ -54,7 +54,7 @@ const courseValidation = [
     .withMessage("Niveau d'intensité invalide"),
   body('teacher_type')
     .optional()
-    .isIn(['spark', 'builder', 'storyteller', 'lightning'])
+    .isIn(['calculator', 'experimenter', 'memorizer', 'spark', 'builder', 'storyteller', 'lightning'])
     .withMessage("Type d'enseignant invalide"),
   body('vulgarization')
     .optional()
@@ -68,7 +68,7 @@ const courseValidation = [
   // Alias de compatibilité
   body('teacherType')
     .optional()
-    .isIn(['spark', 'builder', 'storyteller', 'lightning'])
+    .isIn(['calculator', 'experimenter', 'memorizer', 'spark', 'builder', 'storyteller', 'lightning'])
     .withMessage("Type d'enseignant invalide"),
   body('vulgarizationLevel')
     .optional()

--- a/backend/src/services/anthropicService.js
+++ b/backend/src/services/anthropicService.js
@@ -27,29 +27,23 @@ const DURATION_TO_WORDS = {
 
 // Instructions détaillées selon le type de prof
 const TEACHER_STYLE_INSTRUCTIONS = {
-  [TEACHER_TYPES.SPARK]: {
-    approach: "Transmets l'information avec passion explosive et enthousiasme contagieux.",
-    structure: "Commence par captiver avec une anecdote épique, transforme chaque point en découverte fascinante.",
-    language: "Emploie un ton dynamique avec exclamations, vocabulaire vivant et métaphores enflammées.",
-    examples: "Raconte des histoires inspirantes, utilise des découvertes révolutionnaires comme exemples."
+  [TEACHER_TYPES.CALCULATOR]: {
+    approach: "Résoudre les mystères mathématiques étape par étape avec logique rigoureuse.",
+    structure: "Organise comme un calcul : données → méthode → résolution → vérification.",
+    language: "Utilise un vocabulaire mathématique précis : 'calculons', 'résolvons', 'démontrons'.",
+    examples: "Donne des exemples concrets avec chiffres, formules et calculs détaillés."
   },
-  [TEACHER_TYPES.BUILDER]: {
-    approach: "Décompose la connaissance étape par étape comme un guide de construction.",
-    structure: "Organise en phases claires : fondations → construction → assemblage final.",
-    language: "Utilise un vocabulaire de construction : 'construisons', 'assemblons', 'posons les bases'.",
-    examples: "Donne des analogies de construction, compare aux projets DIY, explique l'utilité pratique."
+  [TEACHER_TYPES.EXPERIMENTER]: {
+    approach: "Découvrir les secrets scientifiques par l'observation et l'expérimentation.",
+    structure: "Structure comme une expérience : hypothèse → protocole → résultats → conclusion.",
+    language: "Adopte un ton de chercheur : 'observons', 'testons', 'analysons', 'découvrons'.",
+    examples: "Utilise des expériences, des observations, des phénomènes scientifiques concrets."
   },
-  [TEACHER_TYPES.STORYTELLER]: {
-    approach: "Transforme chaque concept en conte merveilleux avec des analogies magiques.",
-    structure: "Structure comme un récit : situation initiale → transformation → résolution.",
-    language: "Adopte un ton bienveillant de conteur : 'Il était une fois...', 'Imagine un royaume où...'",
-    examples: "Utilise des métaphores fantastiques, des personnages, des univers imaginaires."
-  },
-  [TEACHER_TYPES.LIGHTNING]: {
-    approach: "Synthétise avec une efficacité redoutable, va à l'essentiel avec impact.",
-    structure: "Structure ultra-claire : points clés → schémas → synthèse percutante.",
-    language: "Style direct et percutant, phrases courtes et mémorables.",
-    examples: "Résumés en bullet points, comparaisons synthétiques, tableaux visuels."
+  [TEACHER_TYPES.MEMORIZER]: {
+    approach: "Graver durablement les connaissances essentielles avec techniques de mémorisation.",
+    structure: "Organise pour la rétention : points clés → répétition → synthèse → ancrage.",
+    language: "Style mnémotechnique et répétitif : 'retenons', 'mémorisons', 'fixons', 'ancrons'.",
+    examples: "Utilise des moyens mnémotechniques, acronymes, répétitions structurées."
   }
 };
 
@@ -153,7 +147,7 @@ class AnthropicService {
   getAdaptiveInstructions(teacherType, intensity = 'balanced') {
     const teacher =
       TEACHER_STYLE_INSTRUCTIONS[teacherType] ||
-      TEACHER_STYLE_INSTRUCTIONS[TEACHER_TYPES.BUILDER];
+      TEACHER_STYLE_INSTRUCTIONS[TEACHER_TYPES.CALCULATOR];
     const intensityConfig =
       INTENSITY_INSTRUCTIONS[intensity] || INTENSITY_INSTRUCTIONS['balanced'];
 
@@ -259,7 +253,7 @@ Sujet à traiter : "${subject}"`;
       return this.getOfflineMessage();
     }
 
-    teacherType = teacherType || TEACHER_TYPES.BUILDER;
+    teacherType = teacherType || TEACHER_TYPES.CALCULATOR;
 
     try {
       const prompt = this.createPrompt(subject, intensity, teacherType);

--- a/backend/src/services/onboardingService.js
+++ b/backend/src/services/onboardingService.js
@@ -14,10 +14,9 @@ const QUESTION_CONFIG = [
     label: "Quel type d'enseignant préfères-tu ?",
     type: 'select',
     options: [
-      { value: 'spark', label: '🔥 Pour vibrer' },
-      { value: 'builder', label: '🏗️ Pour comprendre' },
-      { value: 'storyteller', label: '🧙‍♂️ Pour imaginer' },
-      { value: 'lightning', label: '⚡ Pour retenir' }
+      { value: 'calculator', label: '📐 Pour calculer' },
+      { value: 'experimenter', label: '🔬 Pour expérimenter' },
+      { value: 'memorizer', label: '📖 Pour mémoriser' }
     ]
   },
   {

--- a/backend/src/utils/constants.js
+++ b/backend/src/utils/constants.js
@@ -25,10 +25,9 @@ const LEGACY_VULGARIZATION_LEVELS = {
 
 // Types d'enseignants
 const TEACHER_TYPES = {
-  SPARK: 'spark',
-  BUILDER: 'builder',
-  STORYTELLER: 'storyteller',
-  LIGHTNING: 'lightning'
+  CALCULATOR: 'calculator',
+  EXPERIMENTER: 'experimenter',
+  MEMORIZER: 'memorizer'
 };
 
 // Durées estimées des cours

--- a/backend/src/utils/helpers.js
+++ b/backend/src/utils/helpers.js
@@ -73,16 +73,20 @@ const mapLegacyParams = ({
   };
 
   const legacyTeacherMap = {
-    methodical: TEACHER_TYPES.BUILDER,
-    pragmatic: TEACHER_TYPES.BUILDER,
-    analogist: TEACHER_TYPES.STORYTELLER,
-    benevolent: TEACHER_TYPES.STORYTELLER,
-    passionate: TEACHER_TYPES.SPARK,
-    synthetic: TEACHER_TYPES.LIGHTNING
+    spark: TEACHER_TYPES.EXPERIMENTER,
+    builder: TEACHER_TYPES.CALCULATOR,
+    storyteller: TEACHER_TYPES.MEMORIZER,
+    lightning: TEACHER_TYPES.MEMORIZER,
+    methodical: TEACHER_TYPES.CALCULATOR,
+    pragmatic: TEACHER_TYPES.CALCULATOR,
+    analogist: TEACHER_TYPES.MEMORIZER,
+    benevolent: TEACHER_TYPES.MEMORIZER,
+    passionate: TEACHER_TYPES.EXPERIMENTER,
+    synthetic: TEACHER_TYPES.MEMORIZER
   };
 
   const normalizedTeacherType = legacyTeacherMap[teacherType] || teacherType;
-  const finalTeacherType = normalizedTeacherType || TEACHER_TYPES.BUILDER;
+  const finalTeacherType = normalizedTeacherType || TEACHER_TYPES.CALCULATOR;
   const finalDuration = duration || durationMap[detailLevel] || DURATIONS.MEDIUM;
   const finalVulgarization =
     vulgarization || vulgarizationMap[vulgarizationLevel] || VULGARIZATION_LEVELS.ENLIGHTENED;

--- a/backend/tests/controllers/courseController.test.js
+++ b/backend/tests/controllers/courseController.test.js
@@ -39,15 +39,15 @@ test('applies default duration, vulgarization and teacherType when none provided
   assert.strictEqual(result.duration, DURATIONS.MEDIUM);
   assert.strictEqual(result.vulgarization, VULGARIZATION_LEVELS.ENLIGHTENED);
   assert.strictEqual(result.vulgarizationLevel, LEGACY_VULGARIZATION_LEVELS.ENLIGHTENED);
-  assert.strictEqual(result.teacherType, TEACHER_TYPES.BUILDER);
+  assert.strictEqual(result.teacherType, TEACHER_TYPES.CALCULATOR);
 });
 
 test('returns provided teacherType', () => {
-  const result = mapLegacyParams({ teacherType: TEACHER_TYPES.SPARK });
-  assert.strictEqual(result.teacherType, TEACHER_TYPES.SPARK);
+  const result = mapLegacyParams({ teacherType: TEACHER_TYPES.EXPERIMENTER });
+  assert.strictEqual(result.teacherType, TEACHER_TYPES.EXPERIMENTER);
 });
 
 test('maps legacy teacher types to new ones', () => {
   const result = mapLegacyParams({ teacherType: 'pragmatic' });
-  assert.strictEqual(result.teacherType, TEACHER_TYPES.BUILDER);
+  assert.strictEqual(result.teacherType, TEACHER_TYPES.CALCULATOR);
 });

--- a/backend/tests/onboarding/onboarding.test.js
+++ b/backend/tests/onboarding/onboarding.test.js
@@ -7,11 +7,11 @@ test('calculateProfileConfidence computes fraction of answered questions', () =>
   const emptyProfile = {};
   assert.strictEqual(service.calculateProfileConfidence(emptyProfile), 0);
 
-  const partialProfile = { teacherType: 'builder', vulgarization: 'general_public' };
+  const partialProfile = { teacherType: 'calculator', vulgarization: 'general_public' };
   assert.strictEqual(service.calculateProfileConfidence(partialProfile), 2 / 3);
 
   const fullProfile = {
-    teacherType: 'builder',
+    teacherType: 'calculator',
     vulgarization: 'general_public',
     duration: 'short',
     interests: ['science', 'history']
@@ -21,14 +21,14 @@ test('calculateProfileConfidence computes fraction of answered questions', () =>
 
 test('needsOnboarding returns true when profile is missing fields', () => {
   const service = new OnboardingService();
-  const incompleteProfile = { teacherType: 'builder', interests: ['science'] };
+  const incompleteProfile = { teacherType: 'calculator', interests: ['science'] };
   assert.strictEqual(service.needsOnboarding(incompleteProfile), true);
 });
 
 test('needsOnboarding returns false when profile is complete', () => {
   const service = new OnboardingService();
   const fullProfile = {
-    teacherType: 'builder',
+    teacherType: 'calculator',
     vulgarization: 'general_public',
     duration: 'short',
     interests: ['science']
@@ -64,7 +64,7 @@ test('saveAnswers rejects when mandatory fields are missing', async () => {
   };
   const service = new OnboardingService(prismaMock);
   await assert.rejects(
-    service.saveAnswers('u1', { teacherType: 'builder' }),
+    service.saveAnswers('u1', { teacherType: 'calculator' }),
     /Champs obligatoires manquants/
   );
 });
@@ -94,7 +94,7 @@ test('saveAnswers stores optional fields including arrays', async () => {
 
   const service = new OnboardingService(prismaMock);
   const profile = await service.saveAnswers('u1', {
-    teacherType: 'builder',
+    teacherType: 'calculator',
     vulgarization: 'general_public',
     duration: 'short',
     interests: ['science', 'history'],

--- a/backend/tests/services/anthropicService.test.js
+++ b/backend/tests/services/anthropicService.test.js
@@ -24,7 +24,7 @@ test('createPrompt creates flexible educational content', () => {
   const prompt = anthropicService.createPrompt(
     'Sujet',
     INTENSITY_LEVELS.BALANCED,
-    TEACHER_TYPES.BUILDER
+    TEACHER_TYPES.CALCULATOR
   );
 
   assert.match(prompt, /PROFIL PÉDAGOGIQUE/);
@@ -35,7 +35,7 @@ test('createPrompt allows pedagogical freedom', () => {
   const prompt = anthropicService.createPrompt(
     'Sujet',
     INTENSITY_LEVELS.BALANCED,
-    TEACHER_TYPES.BUILDER
+    TEACHER_TYPES.CALCULATOR
   );
 
   assert.doesNotMatch(prompt, /STRUCTURE REQUISE/);
@@ -88,7 +88,7 @@ test('APIUserAbortError does not trigger offline mode', async () => {
   };
 
   try {
-    await anthropicService.generateCourse('Sujet', INTENSITY_LEVELS.RAPID_SIMPLE, TEACHER_TYPES.BUILDER);
+    await anthropicService.generateCourse('Sujet', INTENSITY_LEVELS.RAPID_SIMPLE, TEACHER_TYPES.CALCULATOR);
     assert.fail('generateCourse should throw');
   } catch (err) {
     assert.strictEqual(err.code, ERROR_CODES.IA_TIMEOUT);

--- a/frontend/app/assets/css/app.css
+++ b/frontend/app/assets/css/app.css
@@ -453,11 +453,14 @@ body::before {
 
 
 /* Grille des cartes professeurs */
+
+/* Grille des cartes professeurs */
 .teacher-cards-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    grid-template-columns: repeat(3, 1fr);
     gap: 16px;
     margin-top: 12px;
+    max-width: 900px; /* Limite la largeur totale */
 }
 
 /* Carte individuelle de professeur */
@@ -515,6 +518,7 @@ body::before {
 }
 
 /* Responsive */
+/* Responsive pour mobile : 1 colonne */
 @media (max-width: 768px) {
     .teacher-cards-grid {
         grid-template-columns: 1fr;
@@ -538,11 +542,10 @@ body::before {
     }
 }
 
-/* Pour écrans très larges, limiter à 2 colonnes */
-@media (min-width: 1200px) {
+/* Responsive pour tablette : 2 colonnes */
+@media (max-width: 1024px) and (min-width: 769px) {
     .teacher-cards-grid {
         grid-template-columns: repeat(2, 1fr);
-        max-width: 800px;
     }
 }
 

--- a/frontend/app/assets/js/course-manager.js
+++ b/frontend/app/assets/js/course-manager.js
@@ -18,19 +18,22 @@ export const DURATION_LABELS = {
 };
 
 export const TEACHER_TYPE_LABELS = {
-  spark: '🔥 Pour vibrer',
-  builder: '🏗️ Pour comprendre',
-  storyteller: '🧙‍♂️ Pour imaginer',
-  lightning: '⚡ Pour retenir'
+  calculator: '📐 Pour calculer',
+  experimenter: '🔬 Pour expérimenter',
+  memorizer: '📖 Pour mémoriser'
 };
 
 const LEGACY_TEACHER_TYPE_MAP = {
-  methodical: 'builder',
-  pragmatic: 'builder',
-  analogist: 'storyteller',
-  benevolent: 'storyteller',
-  passionate: 'spark',
-  synthetic: 'lightning'
+  spark: 'experimenter',
+  builder: 'calculator',
+  storyteller: 'memorizer',
+  lightning: 'memorizer',
+  methodical: 'calculator',
+  pragmatic: 'calculator',
+  analogist: 'memorizer',
+  benevolent: 'memorizer',
+  passionate: 'experimenter',
+  synthetic: 'memorizer'
 };
 
 export function getTeacherTypeLabel(type) {

--- a/frontend/app/assets/js/main.js
+++ b/frontend/app/assets/js/main.js
@@ -259,7 +259,7 @@ function initializeGauges() {
 }
 
 function collectFormParameters() {
-    const teacherType = document.querySelector('[data-type="teacher_type"].active')?.dataset.value || 'builder';
+    const teacherType = document.querySelector('[data-type="teacher_type"].active')?.dataset.value || 'calculator';
     const intensity = window.currentIntensity || intensityLevels[2];
 
     return {

--- a/frontend/app/assets/js/modular-config-manager.js
+++ b/frontend/app/assets/js/modular-config-manager.js
@@ -2,9 +2,9 @@ export class ModularConfigManager {
     constructor() {
         this.currentPreset = 'default';
         this.presets = {
-            default: { vulgarization: 'general_public', duration: 'short', teacher_type: 'builder' },
-            balanced: { vulgarization: 'enlightened', duration: 'medium', teacher_type: 'storyteller' },
-            expert: { vulgarization: 'expert', duration: 'long', teacher_type: 'lightning' }
+            default: { vulgarization: 'general_public', duration: 'short', teacher_type: 'calculator' },
+            balanced: { vulgarization: 'enlightened', duration: 'medium', teacher_type: 'experimenter' },
+            expert: { vulgarization: 'expert', duration: 'long', teacher_type: 'memorizer' }
         };
         this.currentValues = { ...this.presets[this.currentPreset] };
     }

--- a/frontend/app/index.html
+++ b/frontend/app/index.html
@@ -87,35 +87,27 @@
                             <div class="selector-group">
                                 <div class="selector-title">👨‍🏫 Type de prof</div>
                                 <div class="teacher-cards-grid">
-                                    <div class="teacher-card active" data-type="teacher_type" data-value="spark">
-                                        <div class="teacher-icon">🔥</div>
+                                    <div class="teacher-card active" data-type="teacher_type" data-value="calculator">
+                                        <div class="teacher-icon">📐</div>
                                         <div class="teacher-info">
-                                            <h3 class="teacher-name">Pour vibrer</h3>
-                                            <p class="teacher-subtitle">Cours dynamiques et passionnants qui réveillent votre curiosité</p>
+                                            <h3 class="teacher-name">Pour calculer</h3>
+                                            <p class="teacher-subtitle">Transforme les chiffres en amis, les formules en outils magiques</p>
                                         </div>
                                     </div>
 
-                                    <div class="teacher-card" data-type="teacher_type" data-value="builder">
-                                        <div class="teacher-icon">🏗️</div>
+                                    <div class="teacher-card" data-type="teacher_type" data-value="experimenter">
+                                        <div class="teacher-icon">🔬</div>
                                         <div class="teacher-info">
-                                            <h3 class="teacher-name">Pour comprendre</h3>
-                                            <p class="teacher-subtitle">Explications progressives et claires qui construisent votre savoir solide</p>
+                                            <h3 class="teacher-name">Pour expérimenter</h3>
+                                            <p class="teacher-subtitle">Chaque théorie devient une aventure, chaque concept une découverte</p>
                                         </div>
                                     </div>
 
-                                    <div class="teacher-card" data-type="teacher_type" data-value="storyteller">
-                                        <div class="teacher-icon">🧙‍♂️</div>
+                                    <div class="teacher-card" data-type="teacher_type" data-value="memorizer">
+                                        <div class="teacher-icon">📖</div>
                                         <div class="teacher-info">
-                                            <h3 class="teacher-name">Pour imaginer</h3>
-                                            <p class="teacher-subtitle">Apprentissage créatif avec des histoires et métaphores qui marquent</p>
-                                        </div>
-                                    </div>
-
-                                    <div class="teacher-card" data-type="teacher_type" data-value="lightning">
-                                        <div class="teacher-icon">⚡</div>
-                                        <div class="teacher-info">
-                                            <h3 class="teacher-name">Pour retenir</h3>
-                                            <p class="teacher-subtitle">Synthèses percutantes qui vont à l'essentiel de manière mémorable</p>
+                                            <h3 class="teacher-name">Pour mémoriser</h3>
+                                            <p class="teacher-subtitle">L'art de retenir l'important, techniques de mémorisation incluses</p>
                                         </div>
                                     </div>
                                 </div>

--- a/frontend/marketing/assets/js/main.js
+++ b/frontend/marketing/assets/js/main.js
@@ -109,7 +109,7 @@ function initializeGauges() {
 }
 
 function collectFormParameters() {
-    const teacherType = document.querySelector('[data-type="teacher_type"].active')?.dataset.value || 'builder';
+    const teacherType = document.querySelector('[data-type="teacher_type"].active')?.dataset.value || 'calculator';
     const intensity = window.currentIntensity || intensityLevels[2];
 
     return {

--- a/frontend/tests/course-generation.integration.test.js
+++ b/frontend/tests/course-generation.integration.test.js
@@ -33,7 +33,7 @@ test('course generation triggered from decryptage controls', async () => {
   subjectInput.value = 'Quantum Mechanics';
 
   const generateBtn = createElement();
-  const teacherBtn = createElement({ dataset: { type: 'teacher_type', value: 'lightning' }, className: 'active' });
+  const teacherBtn = createElement({ dataset: { type: 'teacher_type', value: 'memorizer' }, className: 'active' });
 
   global.document = {
     getElementById(id) {
@@ -56,7 +56,7 @@ test('course generation triggered from decryptage controls', async () => {
   const { VULGARIZATION_LABELS, TEACHER_TYPE_LABELS } = await import('../app/assets/js/course-manager.js');
 
   function collectFormParameters() {
-    const teacherType = document.querySelector('[data-type="teacher_type"].active')?.dataset.value || 'builder';
+    const teacherType = document.querySelector('[data-type="teacher_type"].active')?.dataset.value || 'calculator';
     const intensity = window.currentIntensity || { level: 2, vulgarization: 'enlightened', duration: 'medium' };
     return {
       teacher_type: teacherType,
@@ -90,9 +90,9 @@ test('course generation triggered from decryptage controls', async () => {
     subject: 'Quantum Mechanics',
     vulgarization: 'expert',
     duration: 'long',
-    teacher_type: 'lightning',
+    teacher_type: 'memorizer',
     intensity: 'deep_expert'
   });
   assert.strictEqual(VULGARIZATION_LABELS[calledWith.vulgarization], 'Expert');
-  assert.strictEqual(TEACHER_TYPE_LABELS[calledWith.teacher_type], '⚡ Prof Flash');
+  assert.strictEqual(TEACHER_TYPE_LABELS[calledWith.teacher_type], '📖 Pour mémoriser');
 });

--- a/frontend/tests/modular-config-manager.test.js
+++ b/frontend/tests/modular-config-manager.test.js
@@ -34,9 +34,9 @@ test('preset selection updates advanced controls', async () => {
   const vulgarizationExpert = createElement({ dataset: { type: 'vulgarization', value: 'expert' } });
   const durationShort = createElement({ dataset: { type: 'duration', value: 'short' } });
   const durationLong = createElement({ dataset: { type: 'duration', value: 'long' } });
-  const teacherBuilder = createElement({ dataset: { type: 'teacher_type', value: 'builder' } });
-  const teacherLightning = createElement({ dataset: { type: 'teacher_type', value: 'lightning' } });
-  const allButtons = [vulgarizationGeneral, vulgarizationExpert, durationShort, durationLong, teacherBuilder, teacherLightning];
+  const teacherCalculator = createElement({ dataset: { type: 'teacher_type', value: 'calculator' } });
+  const teacherMemorizer = createElement({ dataset: { type: 'teacher_type', value: 'memorizer' } });
+  const allButtons = [vulgarizationGeneral, vulgarizationExpert, durationShort, durationLong, teacherCalculator, teacherMemorizer];
 
   global.document = {
     querySelectorAll(selector) {
@@ -51,7 +51,7 @@ test('preset selection updates advanced controls', async () => {
       const sel = selector.replace(/^\.decryptage-controls\s*/, '');
       if (sel === '[data-type="vulgarization"][data-value="expert"]') return vulgarizationExpert;
       if (sel === '[data-type="duration"][data-value="long"]') return durationLong;
-      if (sel === '[data-type="teacher_type"][data-value="lightning"]') return teacherLightning;
+      if (sel === '[data-type="teacher_type"][data-value="memorizer"]') return teacherMemorizer;
       return null;
     },
     getElementById() { return null; },
@@ -72,12 +72,12 @@ test('preset selection updates advanced controls', async () => {
   const cfg = manager.getConfig();
   assert.strictEqual(cfg.vulgarization, 'expert');
   assert.strictEqual(cfg.duration, 'long');
-  assert.strictEqual(cfg.teacher_type, 'lightning');
+  assert.strictEqual(cfg.teacher_type, 'memorizer');
   assert.ok(vulgarizationExpert.classList.contains('active'));
   assert.ok(durationLong.classList.contains('active'));
-  assert.ok(teacherLightning.classList.contains('active'));
+  assert.ok(teacherMemorizer.classList.contains('active'));
   assert.strictEqual(VULGARIZATION_LABELS[cfg.vulgarization], 'Expert');
-  assert.strictEqual(TEACHER_TYPE_LABELS[cfg.teacher_type], '⚡ Prof Flash');
+  assert.strictEqual(TEACHER_TYPE_LABELS[cfg.teacher_type], '📖 Pour mémoriser');
 });
 
 test('quiz button reflects quiz availability', async () => {


### PR DESCRIPTION
## Summary
- replace spark/builder/storyteller/lightning with calculator/experimenter/memorizer across backend and frontend
- map legacy teacher types and set calculator as default
- refresh teacher cards grid, labels, and styles

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b02f5898f88325b84115c546f5da71