### PR TITLE
refactor: migrate teacher types to new profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The `POST /api/courses` endpoint now supports the following parameters:
 - `subject` (string, required): topic to generate a course about.
 - `vulgarization` (string, required): target audience. Accepted values: `general_public`, `enlightened`, `knowledgeable`, `expert`.
 - `duration` (string, required): estimated course length. Accepted values: `short`, `medium`, `long`.
-  - `teacher_type` (string, required): teaching persona. Accepted values: `calculator`, `experimenter`, `memorizer`.
+- `teacher_type` (string, required): teaching persona. Accepted values: `direct`, `structure`, `immersif`.
 - `detailLevel` (number, deprecated): legacy field mapped to `duration`.
 - `vulgarizationLevel` (number, deprecated): legacy field mapped to `vulgarization`.
 - `style` (string, deprecated): maps to `vulgarization`.
@@ -20,7 +20,7 @@ The `POST /api/courses` endpoint now supports the following parameters:
   "subject": "Introduction to Algebra",
   "vulgarization": "enlightened",
   "duration": "medium",
-    "teacher_type": "calculator"
+    "teacher_type": "direct"
 }
 ```
 
@@ -36,7 +36,7 @@ The `POST /api/courses` endpoint now supports the following parameters:
     "vulgarizationLevel": 2,
     "vulgarization": "enlightened",
     "duration": "medium",
-      "teacherType": "calculator",
+      "teacherType": "direct",
     "createdAt": "2024-01-01T00:00:00.000Z"
   }
 }

--- a/backend/migrations/update_teacher_types.js
+++ b/backend/migrations/update_teacher_types.js
@@ -1,0 +1,46 @@
+const { Pool } = require('pg');
+require('dotenv').config();
+
+const pool = new Pool({
+  connectionString: process.env.DATABASE_URL,
+});
+
+async function migrateTeacherTypes() {
+  const client = await pool.connect();
+  
+  try {
+    await client.query('BEGIN');
+    
+    // Mapping des anciens types vers les nouveaux
+    const mappings = [
+      { old: 'calculator', new: 'direct' },
+      { old: 'experimenter', new: 'immersif' },
+      { old: 'memorizer', new: 'structure' }
+    ];
+    
+    for (const { old, new: newType } of mappings) {
+      await client.query(
+        'UPDATE courses SET teacher_type = $1 WHERE teacher_type = $2',
+        [newType, old]
+      );
+    }
+    
+    // Mettre tous les types invalides vers le type par défaut
+    await client.query(
+      'UPDATE courses SET teacher_type = $1 WHERE teacher_type NOT IN ($1, $2, $3)',
+      ['direct', 'structure', 'immersif']
+    );
+    
+    await client.query('COMMIT');
+    console.log('Migration terminée avec succès');
+  } catch (error) {
+    await client.query('ROLLBACK');
+    console.error('Erreur migration:', error);
+    throw error;
+  } finally {
+    client.release();
+    pool.end();
+  }
+}
+
+migrateTeacherTypes();

--- a/backend/src/controllers/courseController.js
+++ b/backend/src/controllers/courseController.js
@@ -1,7 +1,7 @@
 // backend/src/controllers/courseController.js
 const { prisma } = require('../config/database');
 const { createResponse, validateCourseParams, sanitizeInput, logger, mapLegacyParams } = require('../utils/helpers');
-const { HTTP_STATUS, ERROR_MESSAGES, LIMITS, ERROR_CODES, INTENSITY_LEVELS, INTENSITY_TO_CONFIG } = require('../utils/constants');
+const { HTTP_STATUS, ERROR_MESSAGES, LIMITS, ERROR_CODES, INTENSITY_LEVELS, INTENSITY_TO_CONFIG, DEFAULT_TEACHER_TYPE } = require('../utils/constants');
 const anthropicService = require('../services/anthropicService');
 const crypto = require('crypto');
 
@@ -99,12 +99,12 @@ class CourseController {
           subject,
           detailLevel,
           vulgarizationLevel,
-          teacherType,
-          teacher_type,
           duration,
           vulgarization,
           intensity
         } = req.body;
+        const rawTeacherType = req.body.teacher_type;
+        const teacher_type = rawTeacherType || DEFAULT_TEACHER_TYPE;
 
       const deprecatedFields = [];
       if (detailLevel != null) deprecatedFields.push('detailLevel');
@@ -117,8 +117,7 @@ class CourseController {
 
         const isLegacyPayload =
           intensity == null &&
-          teacherType == null &&
-          teacher_type == null &&
+          rawTeacherType == null &&
           duration == null &&
           vulgarization == null &&
           hasDeprecatedParams;
@@ -127,7 +126,7 @@ class CourseController {
         const params = mapLegacyParams({
           detailLevel,
           vulgarizationLevel,
-          teacherType: teacher_type ?? teacherType,
+          teacherType: teacher_type,
           duration,
           vulgarization,
         });

--- a/backend/src/middleware/validation.js
+++ b/backend/src/middleware/validation.js
@@ -54,7 +54,7 @@ const courseValidation = [
     .withMessage("Niveau d'intensité invalide"),
   body('teacher_type')
     .optional()
-    .isIn(['calculator', 'experimenter', 'memorizer', 'spark', 'builder', 'storyteller', 'lightning'])
+    .isIn(['direct', 'structure', 'immersif'])
     .withMessage("Type d'enseignant invalide"),
   body('vulgarization')
     .optional()
@@ -65,11 +65,6 @@ const courseValidation = [
     .isIn(Object.values(DURATIONS))
     .withMessage('Durée invalide'),
 
-  // Alias de compatibilité
-  body('teacherType')
-    .optional()
-    .isIn(['calculator', 'experimenter', 'memorizer', 'spark', 'builder', 'storyteller', 'lightning'])
-    .withMessage("Type d'enseignant invalide"),
   body('vulgarizationLevel')
     .optional()
     .isInt({ min: 1, max: 4 })

--- a/backend/src/routes/courses.js
+++ b/backend/src/routes/courses.js
@@ -23,18 +23,7 @@ router.get(
   asyncHandler(courseController.getAllCourses)
 );
 router.get('/:id', asyncHandler(courseController.getCourse));
-router.post(
-  '/',
-  courseValidation,
-  (req, res, next) => {
-    // Compatibilité : accepter encore teacherType (camelCase)
-    if (req.body.teacherType && !req.body.teacher_type) {
-      req.body.teacher_type = req.body.teacherType;
-    }
-    next();
-  },
-  asyncHandler(courseController.generateCourse)
-);
+router.post('/', courseValidation, asyncHandler(courseController.generateCourse));
 router.delete('/:id', asyncHandler(courseController.deleteCourse));
 
 module.exports = router;

--- a/backend/src/services/onboardingService.js
+++ b/backend/src/services/onboardingService.js
@@ -14,9 +14,9 @@ const QUESTION_CONFIG = [
     label: "Quel type d'enseignant préfères-tu ?",
     type: 'select',
     options: [
-      { value: 'calculator', label: '📐 Pour calculer' },
-      { value: 'experimenter', label: '🔬 Pour expérimenter' },
-      { value: 'memorizer', label: '📖 Pour mémoriser' }
+      { value: 'direct', label: '💡 Direct' },
+      { value: 'structure', label: '🏗️ Structuré' },
+      { value: 'immersif', label: '🎭 Immersif' }
     ]
   },
   {

--- a/backend/src/utils/constants.js
+++ b/backend/src/utils/constants.js
@@ -23,12 +23,15 @@ const LEGACY_VULGARIZATION_LEVELS = {
   EXPERT: 4
 };
 
-// Types d'enseignants
+// Types de professeurs
 const TEACHER_TYPES = {
-  CALCULATOR: 'calculator',
-  EXPERIMENTER: 'experimenter',
-  MEMORIZER: 'memorizer'
+  DIRECT: 'direct',
+  STRUCTURE: 'structure',
+  IMMERSIF: 'immersif'
 };
+
+// Type par défaut
+const DEFAULT_TEACHER_TYPE = TEACHER_TYPES.DIRECT;
 
 // Durées estimées des cours
 const DURATIONS = {
@@ -139,6 +142,7 @@ module.exports = {
   VULGARIZATION_LEVELS,
   LEGACY_VULGARIZATION_LEVELS,
   TEACHER_TYPES,
+  DEFAULT_TEACHER_TYPE,
   QUESTION_TYPES,
   LIMITS,
   RATE_LIMITS,

--- a/backend/src/utils/helpers.js
+++ b/backend/src/utils/helpers.js
@@ -4,6 +4,7 @@ const {
   HTTP_STATUS,
   DURATIONS,
   TEACHER_TYPES,
+  DEFAULT_TEACHER_TYPE,
   VULGARIZATION_LEVELS,
   LEGACY_VULGARIZATION_LEVELS,
 } = require('./constants');
@@ -72,21 +73,7 @@ const mapLegacyParams = ({
     [LEGACY_VULGARIZATION_LEVELS.EXPERT]: VULGARIZATION_LEVELS.EXPERT,
   };
 
-  const legacyTeacherMap = {
-    spark: TEACHER_TYPES.EXPERIMENTER,
-    builder: TEACHER_TYPES.CALCULATOR,
-    storyteller: TEACHER_TYPES.MEMORIZER,
-    lightning: TEACHER_TYPES.MEMORIZER,
-    methodical: TEACHER_TYPES.CALCULATOR,
-    pragmatic: TEACHER_TYPES.CALCULATOR,
-    analogist: TEACHER_TYPES.MEMORIZER,
-    benevolent: TEACHER_TYPES.MEMORIZER,
-    passionate: TEACHER_TYPES.EXPERIMENTER,
-    synthetic: TEACHER_TYPES.MEMORIZER
-  };
-
-  const normalizedTeacherType = legacyTeacherMap[teacherType] || teacherType;
-  const finalTeacherType = normalizedTeacherType || TEACHER_TYPES.CALCULATOR;
+  const finalTeacherType = teacherType || DEFAULT_TEACHER_TYPE;
   const finalDuration = duration || durationMap[detailLevel] || DURATIONS.MEDIUM;
   const finalVulgarization =
     vulgarization || vulgarizationMap[vulgarizationLevel] || VULGARIZATION_LEVELS.ENLIGHTENED;

--- a/backend/tests/controllers/courseController.test.js
+++ b/backend/tests/controllers/courseController.test.js
@@ -39,15 +39,10 @@ test('applies default duration, vulgarization and teacherType when none provided
   assert.strictEqual(result.duration, DURATIONS.MEDIUM);
   assert.strictEqual(result.vulgarization, VULGARIZATION_LEVELS.ENLIGHTENED);
   assert.strictEqual(result.vulgarizationLevel, LEGACY_VULGARIZATION_LEVELS.ENLIGHTENED);
-  assert.strictEqual(result.teacherType, TEACHER_TYPES.CALCULATOR);
+  assert.strictEqual(result.teacherType, TEACHER_TYPES.DIRECT);
 });
 
 test('returns provided teacherType', () => {
-  const result = mapLegacyParams({ teacherType: TEACHER_TYPES.EXPERIMENTER });
-  assert.strictEqual(result.teacherType, TEACHER_TYPES.EXPERIMENTER);
-});
-
-test('maps legacy teacher types to new ones', () => {
-  const result = mapLegacyParams({ teacherType: 'pragmatic' });
-  assert.strictEqual(result.teacherType, TEACHER_TYPES.CALCULATOR);
+  const result = mapLegacyParams({ teacherType: TEACHER_TYPES.IMMERSIF });
+  assert.strictEqual(result.teacherType, TEACHER_TYPES.IMMERSIF);
 });

--- a/backend/tests/onboarding/onboarding.test.js
+++ b/backend/tests/onboarding/onboarding.test.js
@@ -7,11 +7,11 @@ test('calculateProfileConfidence computes fraction of answered questions', () =>
   const emptyProfile = {};
   assert.strictEqual(service.calculateProfileConfidence(emptyProfile), 0);
 
-  const partialProfile = { teacherType: 'calculator', vulgarization: 'general_public' };
+  const partialProfile = { teacherType: 'direct', vulgarization: 'general_public' };
   assert.strictEqual(service.calculateProfileConfidence(partialProfile), 2 / 3);
 
   const fullProfile = {
-    teacherType: 'calculator',
+    teacherType: 'direct',
     vulgarization: 'general_public',
     duration: 'short',
     interests: ['science', 'history']
@@ -21,14 +21,14 @@ test('calculateProfileConfidence computes fraction of answered questions', () =>
 
 test('needsOnboarding returns true when profile is missing fields', () => {
   const service = new OnboardingService();
-  const incompleteProfile = { teacherType: 'calculator', interests: ['science'] };
+  const incompleteProfile = { teacherType: 'direct', interests: ['science'] };
   assert.strictEqual(service.needsOnboarding(incompleteProfile), true);
 });
 
 test('needsOnboarding returns false when profile is complete', () => {
   const service = new OnboardingService();
   const fullProfile = {
-    teacherType: 'calculator',
+    teacherType: 'direct',
     vulgarization: 'general_public',
     duration: 'short',
     interests: ['science']
@@ -64,7 +64,7 @@ test('saveAnswers rejects when mandatory fields are missing', async () => {
   };
   const service = new OnboardingService(prismaMock);
   await assert.rejects(
-    service.saveAnswers('u1', { teacherType: 'calculator' }),
+    service.saveAnswers('u1', { teacherType: 'direct' }),
     /Champs obligatoires manquants/
   );
 });
@@ -94,7 +94,7 @@ test('saveAnswers stores optional fields including arrays', async () => {
 
   const service = new OnboardingService(prismaMock);
   const profile = await service.saveAnswers('u1', {
-    teacherType: 'calculator',
+    teacherType: 'direct',
     vulgarization: 'general_public',
     duration: 'short',
     interests: ['science', 'history'],

--- a/frontend/app/assets/js/course-manager.js
+++ b/frontend/app/assets/js/course-manager.js
@@ -17,28 +17,28 @@ export const DURATION_LABELS = {
   long: 'Longue'
 };
 
-export const TEACHER_TYPE_LABELS = {
-  calculator: '📐 Pour calculer',
-  experimenter: '🔬 Pour expérimenter',
-  memorizer: '📖 Pour mémoriser'
+export const TEACHER_TYPES = {
+  DIRECT: 'direct',
+  STRUCTURE: 'structure',
+  IMMERSIF: 'immersif'
 };
 
-const LEGACY_TEACHER_TYPE_MAP = {
-  spark: 'experimenter',
-  builder: 'calculator',
-  storyteller: 'memorizer',
-  lightning: 'memorizer',
-  methodical: 'calculator',
-  pragmatic: 'calculator',
-  analogist: 'memorizer',
-  benevolent: 'memorizer',
-  passionate: 'experimenter',
-  synthetic: 'memorizer'
+export const TEACHER_TYPE_LABELS = {
+  direct: '💡 Direct',
+  structure: '🏗️ Structuré',
+  immersif: '🎭 Immersif'
 };
+
+export const TEACHER_TYPE_DESCRIPTIONS = {
+  direct: 'Je vais droit au but, sans détours',
+  structure: 'Je bâtis ta compréhension bloc par bloc',
+  immersif: "Je te plonge dans l'univers du sujet"
+};
+
+export const DEFAULT_TEACHER_TYPE = 'direct';
 
 export function getTeacherTypeLabel(type) {
-  const normalized = LEGACY_TEACHER_TYPE_MAP[type] || type;
-  return TEACHER_TYPE_LABELS[normalized] || normalized;
+  return TEACHER_TYPE_LABELS[type] || type;
 }
 
 // Rate limit between costly actions
@@ -140,9 +140,10 @@ class CourseManager {
       if (duration && DURATION_LABELS[duration]) {
         payload.duration = utils.sanitizeInput(duration);
       }
-      if (teacher_type && TEACHER_TYPE_LABELS[teacher_type]) {
-        payload.teacher_type = utils.sanitizeInput(teacher_type);
-      }
+      const teacherType = Object.values(TEACHER_TYPES).includes(teacher_type)
+        ? teacher_type
+        : DEFAULT_TEACHER_TYPE;
+      payload.teacher_type = utils.sanitizeInput(teacherType);
       if (intensity) {
         payload.intensity = utils.sanitizeInput(intensity);
       }

--- a/frontend/app/assets/js/main.js
+++ b/frontend/app/assets/js/main.js
@@ -259,7 +259,7 @@ function initializeGauges() {
 }
 
 function collectFormParameters() {
-    const teacherType = document.querySelector('[data-type="teacher_type"].active')?.dataset.value || 'calculator';
+    const teacherType = document.querySelector('[data-type="teacher_type"].active')?.dataset.value || 'direct';
     const intensity = window.currentIntensity || intensityLevels[2];
 
     return {

--- a/frontend/app/assets/js/modular-config-manager.js
+++ b/frontend/app/assets/js/modular-config-manager.js
@@ -2,9 +2,9 @@ export class ModularConfigManager {
     constructor() {
         this.currentPreset = 'default';
         this.presets = {
-            default: { vulgarization: 'general_public', duration: 'short', teacher_type: 'calculator' },
-            balanced: { vulgarization: 'enlightened', duration: 'medium', teacher_type: 'experimenter' },
-            expert: { vulgarization: 'expert', duration: 'long', teacher_type: 'memorizer' }
+            default: { vulgarization: 'general_public', duration: 'short', teacher_type: 'direct' },
+            balanced: { vulgarization: 'enlightened', duration: 'medium', teacher_type: 'immersif' },
+            expert: { vulgarization: 'expert', duration: 'long', teacher_type: 'structure' }
         };
         this.currentValues = { ...this.presets[this.currentPreset] };
     }

--- a/frontend/app/index.html
+++ b/frontend/app/index.html
@@ -87,27 +87,27 @@
                             <div class="selector-group">
                                 <div class="selector-title">👨‍🏫 Type de prof</div>
                                 <div class="teacher-cards-grid">
-                                    <div class="teacher-card active" data-type="teacher_type" data-value="calculator">
-                                        <div class="teacher-icon">📐</div>
+                                    <div class="teacher-card active" data-type="teacher_type" data-value="direct">
+                                        <div class="teacher-icon">💡</div>
                                         <div class="teacher-info">
-                                            <h3 class="teacher-name">Pour calculer</h3>
-                                            <p class="teacher-subtitle">Transforme les chiffres en amis, les formules en outils magiques</p>
+                                            <h3 class="teacher-name">Direct</h3>
+                                            <p class="teacher-subtitle">Je vais droit au but, sans détours</p>
                                         </div>
                                     </div>
 
-                                    <div class="teacher-card" data-type="teacher_type" data-value="experimenter">
-                                        <div class="teacher-icon">🔬</div>
+                                    <div class="teacher-card" data-type="teacher_type" data-value="structure">
+                                        <div class="teacher-icon">🏗️</div>
                                         <div class="teacher-info">
-                                            <h3 class="teacher-name">Pour expérimenter</h3>
-                                            <p class="teacher-subtitle">Chaque théorie devient une aventure, chaque concept une découverte</p>
+                                            <h3 class="teacher-name">Structuré</h3>
+                                            <p class="teacher-subtitle">Je bâtis ta compréhension bloc par bloc</p>
                                         </div>
                                     </div>
 
-                                    <div class="teacher-card" data-type="teacher_type" data-value="memorizer">
-                                        <div class="teacher-icon">📖</div>
+                                    <div class="teacher-card" data-type="teacher_type" data-value="immersif">
+                                        <div class="teacher-icon">🎭</div>
                                         <div class="teacher-info">
-                                            <h3 class="teacher-name">Pour mémoriser</h3>
-                                            <p class="teacher-subtitle">L'art de retenir l'important, techniques de mémorisation incluses</p>
+                                            <h3 class="teacher-name">Immersif</h3>
+                                            <p class="teacher-subtitle">Je te plonge dans l'univers du sujet</p>
                                         </div>
                                     </div>
                                 </div>

--- a/frontend/marketing/assets/js/main.js
+++ b/frontend/marketing/assets/js/main.js
@@ -109,7 +109,7 @@ function initializeGauges() {
 }
 
 function collectFormParameters() {
-    const teacherType = document.querySelector('[data-type="teacher_type"].active')?.dataset.value || 'calculator';
+    const teacherType = document.querySelector('[data-type="teacher_type"].active')?.dataset.value || 'direct';
     const intensity = window.currentIntensity || intensityLevels[2];
 
     return {

--- a/frontend/tests/course-generation.integration.test.js
+++ b/frontend/tests/course-generation.integration.test.js
@@ -33,7 +33,7 @@ test('course generation triggered from decryptage controls', async () => {
   subjectInput.value = 'Quantum Mechanics';
 
   const generateBtn = createElement();
-  const teacherBtn = createElement({ dataset: { type: 'teacher_type', value: 'memorizer' }, className: 'active' });
+  const teacherBtn = createElement({ dataset: { type: 'teacher_type', value: 'immersif' }, className: 'active' });
 
   global.document = {
     getElementById(id) {
@@ -56,7 +56,7 @@ test('course generation triggered from decryptage controls', async () => {
   const { VULGARIZATION_LABELS, TEACHER_TYPE_LABELS } = await import('../app/assets/js/course-manager.js');
 
   function collectFormParameters() {
-    const teacherType = document.querySelector('[data-type="teacher_type"].active')?.dataset.value || 'calculator';
+    const teacherType = document.querySelector('[data-type="teacher_type"].active')?.dataset.value || 'direct';
     const intensity = window.currentIntensity || { level: 2, vulgarization: 'enlightened', duration: 'medium' };
     return {
       teacher_type: teacherType,
@@ -90,9 +90,9 @@ test('course generation triggered from decryptage controls', async () => {
     subject: 'Quantum Mechanics',
     vulgarization: 'expert',
     duration: 'long',
-    teacher_type: 'memorizer',
+    teacher_type: 'immersif',
     intensity: 'deep_expert'
   });
   assert.strictEqual(VULGARIZATION_LABELS[calledWith.vulgarization], 'Expert');
-  assert.strictEqual(TEACHER_TYPE_LABELS[calledWith.teacher_type], '📖 Pour mémoriser');
+  assert.strictEqual(TEACHER_TYPE_LABELS[calledWith.teacher_type], '🎭 Immersif');
 });

--- a/frontend/tests/modular-config-manager.test.js
+++ b/frontend/tests/modular-config-manager.test.js
@@ -34,16 +34,16 @@ test('preset selection updates advanced controls', async () => {
   const vulgarizationExpert = createElement({ dataset: { type: 'vulgarization', value: 'expert' } });
   const durationShort = createElement({ dataset: { type: 'duration', value: 'short' } });
   const durationLong = createElement({ dataset: { type: 'duration', value: 'long' } });
-  const teacherCalculator = createElement({ dataset: { type: 'teacher_type', value: 'calculator' } });
-  const teacherMemorizer = createElement({ dataset: { type: 'teacher_type', value: 'memorizer' } });
-  const allButtons = [vulgarizationGeneral, vulgarizationExpert, durationShort, durationLong, teacherCalculator, teacherMemorizer];
+  const teacherDirect = createElement({ dataset: { type: 'teacher_type', value: 'direct' } });
+  const teacherStructure = createElement({ dataset: { type: 'teacher_type', value: 'structure' } });
+  const allButtons = [vulgarizationGeneral, vulgarizationExpert, durationShort, durationLong, teacherDirect, teacherStructure];
 
   global.document = {
     querySelectorAll(selector) {
       const sel = selector.replace(/^\.decryptage-controls\s*/, '');
       if (sel === '.quick-config [data-preset]') return [presetDefault, presetExpert];
-      if (sel === '.selector-group button') return allButtons;
-      const typeMatch = sel.match(/\.selector-group button\[data-type="([^"]+)"\]/);
+      if (sel === '.selector-group [data-type][data-value]') return allButtons;
+      const typeMatch = sel.match(/\.selector-group \[data-type="([^"]+)"\]/);
       if (typeMatch) return allButtons.filter(b => b.dataset.type === typeMatch[1]);
       return [];
     },
@@ -51,7 +51,7 @@ test('preset selection updates advanced controls', async () => {
       const sel = selector.replace(/^\.decryptage-controls\s*/, '');
       if (sel === '[data-type="vulgarization"][data-value="expert"]') return vulgarizationExpert;
       if (sel === '[data-type="duration"][data-value="long"]') return durationLong;
-      if (sel === '[data-type="teacher_type"][data-value="memorizer"]') return teacherMemorizer;
+      if (sel === '[data-type="teacher_type"][data-value="structure"]') return teacherStructure;
       return null;
     },
     getElementById() { return null; },
@@ -72,12 +72,12 @@ test('preset selection updates advanced controls', async () => {
   const cfg = manager.getConfig();
   assert.strictEqual(cfg.vulgarization, 'expert');
   assert.strictEqual(cfg.duration, 'long');
-  assert.strictEqual(cfg.teacher_type, 'memorizer');
+  assert.strictEqual(cfg.teacher_type, 'structure');
   assert.ok(vulgarizationExpert.classList.contains('active'));
   assert.ok(durationLong.classList.contains('active'));
-  assert.ok(teacherMemorizer.classList.contains('active'));
+  assert.ok(teacherStructure.classList.contains('active'));
   assert.strictEqual(VULGARIZATION_LABELS[cfg.vulgarization], 'Expert');
-  assert.strictEqual(TEACHER_TYPE_LABELS[cfg.teacher_type], '📖 Pour mémoriser');
+  assert.strictEqual(TEACHER_TYPE_LABELS[cfg.teacher_type], '🏗️ Structuré');
 });
 
 test('quiz button reflects quiz availability', async () => {


### PR DESCRIPTION
## Summary
- replace legacy teacher personas with direct, structure, and immersif
- validate new teacher type inputs across API and UI
- add migration script to update existing courses

## Testing
- `node --test frontend/tests/*.js`
- `npm test` *(fails: process hang? but tail shows tests passing? hmm)*

------
https://chatgpt.com/codex/tasks/task_e_68c0846c5acc83258368f116d5271304