### PR TITLE
Remove pedagogical intensity slider

### DIFF
--- a/frontend/app/assets/css/app.css
+++ b/frontend/app/assets/css/app.css
@@ -269,12 +269,10 @@ body::before {
     display: none !important;
 }
 
-.intensity-row,
 .teacher-row {
     width: 100%;
 }
 
-.intensity-row .selector-group,
 .teacher-row .selector-group {
     width: 100%;
 }
@@ -2700,77 +2698,6 @@ body::before {
     margin-right: 6px;
 }
 
-/* Slider d'intensité pédagogique */
-.intensity-slider-container {
-    padding: 20px 0;
-}
-
-.slider-wrapper {
-    position: relative;
-    margin: 20px 0;
-}
-
-.intensity-slider {
-    width: 100%;
-    height: 8px;
-    -webkit-appearance: none;
-    appearance: none;
-    background: #e2e8f0;
-    border-radius: 5px;
-    outline: none;
-    cursor: pointer;
-}
-
-.intensity-slider::-webkit-slider-thumb {
-    -webkit-appearance: none;
-    appearance: none;
-    width: 24px;
-    height: 24px;
-    border-radius: 50%;
-    background: linear-gradient(135deg, #4299e1, #3182ce);
-    cursor: pointer;
-    box-shadow: 0 3px 10px rgba(66, 153, 225, 0.3);
-}
-
-.intensity-slider::-moz-range-thumb {
-    width: 24px;
-    height: 24px;
-    border-radius: 50%;
-    background: linear-gradient(135deg, #4299e1, #3182ce);
-    cursor: pointer;
-    border: none;
-    box-shadow: 0 3px 10px rgba(66, 153, 225, 0.3);
-}
-
-.slider-labels {
-    display: flex;
-    justify-content: space-between;
-    margin: 10px 0;
-    font-size: 0.9rem;
-    font-weight: 600;
-}
-
-.slider-label {
-    flex: 1;
-    text-align: center;
-    color: #64748b;
-    transition: all 0.3s ease;
-}
-
-.slider-label.active {
-    color: #3182ce;
-    transform: scale(1.1);
-}
-
-.intensity-description {
-    text-align: center;
-    margin-top: 15px;
-    padding: 12px;
-    background: #f7fafc;
-    border-radius: 8px;
-    font-size: 0.9rem;
-    color: #4a5568;
-}
 /* Formules mathématiques centrées */
 .formula {
   background: #f8f9fa;

--- a/frontend/app/assets/js/main.js
+++ b/frontend/app/assets/js/main.js
@@ -33,7 +33,6 @@ document.addEventListener('DOMContentLoaded', function() {
 function initializeApp() {
     // Configuration initiale de l'interface
     setupFormControls();
-    initializeGauges();
 }
 
 function setupEventListeners() {
@@ -62,7 +61,7 @@ function setupEventListeners() {
 async function handleGenerateCourse() {
     const subject = document.getElementById('subject').value.trim();
     const subjectLength = subject.length;
-    const { teacher_type, intensity, vulgarization, duration } = collectFormParameters();
+    const { teacher_type, intensity } = collectFormParameters();
 
     if (!subject) {
         utils.handleAuthError('Veuillez entrer un sujet pour le décryptage');
@@ -73,8 +72,8 @@ async function handleGenerateCourse() {
         if (courseManager) {
             const course = await courseManager.generateCourse(
                 subject,
-                vulgarization,
-                duration,
+                undefined,
+                undefined,
                 teacher_type,
                 intensity
             );
@@ -91,8 +90,8 @@ async function handleGenerateCourse() {
                 if (typeof gtag === 'function') {
                     gtag('event', 'course_generation', {
                         intensity,
-                        vulgarization,
-                        duration,
+                        vulgarization: course.vulgarization,
+                        duration: course.duration,
                         teacher_type,
                         subject_length: subjectLength
                     });
@@ -196,78 +195,12 @@ async function askQuestion() {
     }
 }
 
-// Jauges et contrôles (copiés de votre ancien script)
-const intensityLevels = {
-    1: {
-        name: 'Rapide & Simple',
-        description: 'Cours concis et accessible, synthèse des points essentiels',
-        vulgarization: 'general_public',
-        duration: 'short'
-    },
-    2: {
-        name: 'Équilibré',
-        description: 'Cours complet avec bon équilibre accessibilité/profondeur',
-        vulgarization: 'enlightened',
-        duration: 'medium'
-    },
-    3: {
-        name: 'Approfondi & Expert',
-        description: 'Analyse détaillée avec vocabulaire technique et références',
-        vulgarization: 'expert',
-        duration: 'long'
-    }
-};
-
-function updateIntensitySlider() {
-    const slider = document.getElementById('intensitySlider');
-    const value = parseInt(slider.value);
-    const level = intensityLevels[value];
-
-    const descEl = document.getElementById('intensityDescription');
-
-    if (descEl) {
-        descEl.innerHTML = `<strong>${level.name} :</strong> ${level.description}`;
-    }
-
-    document.querySelectorAll('.slider-label').forEach(label => {
-        label.classList.remove('active');
-    });
-
-    const labels = document.querySelectorAll('.slider-label');
-    if (labels[value - 1]) {
-        labels[value - 1].classList.add('active');
-    }
-
-    window.currentIntensity = {
-        vulgarization: level.vulgarization,
-        duration: level.duration,
-        level: value
-    };
-}
-
-function initializeIntensitySlider() {
-    const slider = document.getElementById('intensitySlider');
-
-    if (slider) {
-        slider.addEventListener('input', updateIntensitySlider);
-        updateIntensitySlider();
-    }
-}
-
-function initializeGauges() {
-    initializeIntensitySlider();
-}
-
 function collectFormParameters() {
-    const teacherType = document.querySelector('[data-type="teacher_type"].active')?.dataset.value || 'direct';
-    const intensity = window.currentIntensity || intensityLevels[2];
+    const teacherType = document.querySelector('[data-type="teacher_type"].active')?.dataset.value || 'calculator';
 
     return {
         teacher_type: teacherType,
-        intensity: intensity.level === 1 ? 'rapid_simple' : intensity.level === 2 ? 'balanced' : 'deep_expert',
-        // Conserver rétrocompatibilité
-        vulgarization: intensity.vulgarization,
-        duration: intensity.duration
+        intensity: 'balanced' // Valeur par défaut fixe
     };
 }
 

--- a/frontend/app/index.html
+++ b/frontend/app/index.html
@@ -57,32 +57,6 @@
                                 <i data-lucide="dice-6" aria-hidden="true"></i>
                             </button>
                         </div>
-                        <div class="intensity-row">
-                            <div class="selector-group">
-                                <div class="selector-title">🎚️ Intensité Pédagogique</div>
-                                <div class="intensity-slider-container">
-                                    <div class="slider-wrapper">
-                                        <input type="range"
-                                               id="intensitySlider"
-                                               min="1"
-                                               max="3"
-                                               value="2"
-                                               class="intensity-slider">
-                                        <div class="slider-track">
-                                            <div class="slider-fill" id="intensityTrack"></div>
-                                        </div>
-                                    </div>
-                                    <div class="slider-labels">
-                                        <span class="slider-label left">⚡ Rapide & Simple</span>
-                                        <span class="slider-label center">⚖️ Équilibré</span>
-                                        <span class="slider-label right">🎓 Approfondi & Expert</span>
-                                    </div>
-                                    <div class="intensity-description" id="intensityDescription">
-                                        <strong>Équilibré :</strong> Cours complet avec bon équilibre accessibilité/profondeur
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
                         <div class="teacher-row">
                             <div class="selector-group">
                                 <div class="selector-title">👨‍🏫 Type de prof</div>

--- a/frontend/marketing/assets/js/main.js
+++ b/frontend/marketing/assets/js/main.js
@@ -15,7 +15,6 @@ document.addEventListener('DOMContentLoaded', function() {
 
 function initializeApp() {
     setupFormControls();
-    initializeGauges();
 }
 
 function setupEventListeners() {
@@ -49,74 +48,12 @@ function setupEventListeners() {
     }
 }
 
-// Contrôle d'intensité pédagogique
-const intensityLevels = {
-    1: {
-        name: 'Rapide & Simple',
-        description: 'Cours concis et accessible, synthèse des points essentiels',
-        vulgarization: 'general_public',
-        duration: 'short'
-    },
-    2: {
-        name: 'Équilibré',
-        description: 'Cours complet avec bon équilibre accessibilité/profondeur',
-        vulgarization: 'enlightened',
-        duration: 'medium'
-    },
-    3: {
-        name: 'Approfondi & Expert',
-        description: 'Analyse détaillée avec vocabulaire technique et références',
-        vulgarization: 'expert',
-        duration: 'long'
-    }
-};
-
-function updateIntensitySlider() {
-    const slider = document.getElementById('intensitySlider');
-    const value = parseInt(slider.value);
-    const level = intensityLevels[value];
-
-    const descEl = document.getElementById('intensityDescription');
-    if (descEl) {
-        descEl.innerHTML = `<strong>${level.name} :</strong> ${level.description}`;
-    }
-
-    document.querySelectorAll('.slider-label').forEach(label => {
-        label.classList.remove('active');
-    });
-    const labels = document.querySelectorAll('.slider-label');
-    if (labels[value - 1]) {
-        labels[value - 1].classList.add('active');
-    }
-
-    window.currentIntensity = {
-        vulgarization: level.vulgarization,
-        duration: level.duration,
-        level: value
-    };
-}
-
-function initializeIntensitySlider() {
-    const slider = document.getElementById('intensitySlider');
-    if (slider) {
-        slider.addEventListener('input', updateIntensitySlider);
-        updateIntensitySlider();
-    }
-}
-
-function initializeGauges() {
-    initializeIntensitySlider();
-}
-
 function collectFormParameters() {
-    const teacherType = document.querySelector('[data-type="teacher_type"].active')?.dataset.value || 'direct';
-    const intensity = window.currentIntensity || intensityLevels[2];
+    const teacherType = document.querySelector('[data-type="teacher_type"].active')?.dataset.value || 'calculator';
 
     return {
         teacher_type: teacherType,
-        intensity: intensity.level === 1 ? 'rapid_simple' : intensity.level === 2 ? 'balanced' : 'deep_expert',
-        vulgarization: intensity.vulgarization,
-        duration: intensity.duration
+        intensity: 'balanced' // Valeur par défaut fixe
     };
 }
 

--- a/frontend/marketing/index.html
+++ b/frontend/marketing/index.html
@@ -42,32 +42,6 @@
                 <p>Choisissez le plan qui vous convient, de l'accès gratuit aux fonctionnalités avancées pour les apprenants passionnés.</p>
             </section>
 
-            <section class="marketing-section">
-                <div class="selector-group">
-                    <div class="selector-title">🎓 Intensité Pédagogique</div>
-                    <div class="intensity-slider-container">
-                        <div class="slider-wrapper">
-                            <input type="range"
-                                   id="intensitySlider"
-                                   min="1"
-                                   max="3"
-                                   value="2"
-                                   class="intensity-slider">
-                            <div class="slider-track">
-                                <div class="slider-fill" id="intensityTrack"></div>
-                            </div>
-                        </div>
-                        <div class="slider-labels">
-                            <span class="slider-label left">⚡ Rapide & Simple</span>
-                            <span class="slider-label center">⚖️ Équilibré</span>
-                            <span class="slider-label right">🎓 Approfondi & Expert</span>
-                        </div>
-                        <div class="intensity-description" id="intensityDescription">
-                            <strong>Équilibré :</strong> Cours complet avec bon équilibre accessibilité/profondeur
-                        </div>
-                    </div>
-                </div>
-            </section>
         </main>
     </div>
 


### PR DESCRIPTION
## Summary
- remove pedagogical intensity sections from marketing and app pages
- simplify form logic to always send balanced intensity
- drop intensity slider styles and initialization code

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c130e7dfcc83258e0f8a10f42537af