### PR TITLE
Remove marketing intensity selector from homepage

### DIFF
--- a/frontend/marketing/index.html
+++ b/frontend/marketing/index.html
@@ -41,33 +41,6 @@
                 <h2>Tarifs</h2>
                 <p>Choisissez le plan qui vous convient, de l'accès gratuit aux fonctionnalités avancées pour les apprenants passionnés.</p>
             </section>
-
-            <section class="marketing-section">
-                <div class="selector-group">
-                    <div class="selector-title">🎓 Intensité Pédagogique</div>
-                    <div class="intensity-slider-container">
-                        <div class="slider-wrapper">
-                            <input type="range"
-                                   id="intensitySlider"
-                                   min="1"
-                                   max="3"
-                                   value="2"
-                                   class="intensity-slider">
-                            <div class="slider-track">
-                                <div class="slider-fill" id="intensityTrack"></div>
-                            </div>
-                        </div>
-                        <div class="slider-labels">
-                            <span class="slider-label left">⚡ Rapide & Simple</span>
-                            <span class="slider-label center">⚖️ Équilibré</span>
-                            <span class="slider-label right">🎓 Approfondi & Expert</span>
-                        </div>
-                        <div class="intensity-description" id="intensityDescription">
-                            <strong>Équilibré :</strong> Cours complet avec bon équilibre accessibilité/profondeur
-                        </div>
-                    </div>
-                </div>
-            </section>
         </main>
     </div>
 


### PR DESCRIPTION
## Summary
- remove pedagogical intensity selector from marketing landing page

## Testing
- `npm test` *(hangs after tests pass; interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68c135bbf6a483258b2abc7cd6a05877