### PR TITLE
Expand teacher cards grid to full width

### DIFF
--- a/frontend/app/assets/css/app.css
+++ b/frontend/app/assets/css/app.css
@@ -460,7 +460,8 @@ body::before {
     grid-template-columns: repeat(3, 1fr);
     gap: 16px;
     margin-top: 12px;
-    max-width: 900px; /* Limite la largeur totale */
+    width: 100%;
+    max-width: none;
 }
 
 /* Carte individuelle de professeur */


### PR DESCRIPTION
## Summary
- Remove fixed max width from `.teacher-cards-grid`
- Ensure grid uses full width and no max-width restriction

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c13a5e2f688325b65420f289cb976a