### PR TITLE
Fix table regex to capture all columns

### DIFF
--- a/frontend/app/assets/js/course-manager.js
+++ b/frontend/app/assets/js/course-manager.js
@@ -346,7 +346,7 @@ class CourseManager {
       .replace(/`([^`]+)`/g, '<code>$1</code>')
       
       // Convertir les tableaux markdown en HTML stylé
-      .replace(/\|(.+)\|\n\|[\s\-:|]+\|\n((?:\|[^|\n]+\|\n?)*)/gm, function(match, header, rows) {
+      .replace(/\|(.+)\|\n\|[\s\-:|]+\|\n((?:\|.*\|\n?)*)/gm, function(match, header, rows) {
         // Parser l'en-tête
         const headerCells = header.split('|')
           .filter(cell => cell.trim() && !cell.trim().match(/^[\-]+$/))


### PR DESCRIPTION
## Summary
- adjust markdown table regex to capture all column content when converting to HTML

## Testing
- `node - <<'NODE' ...` (sample table conversion)
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c182fa56e4832593e26b344c15c806